### PR TITLE
Better way to test edge cases with tile collisions

### DIFF
--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -14,17 +14,17 @@ namespace MegaManLofi
    public:
       Arena( const std::shared_ptr<ArenaConfig> config );
 
-      double GetWidth() const override { return _width; }
-      double GetHeight() const override { return _height; }
+      long long GetWidth() const override { return _width; }
+      long long GetHeight() const override { return _height; }
 
-      double GetPlayerPositionX() const override { return _playerPositionX; }
-      double GetPlayerPositionY() const override { return _playerPositionY; }
+      long long GetPlayerPositionX() const override { return _playerPositionX; }
+      long long GetPlayerPositionY() const override { return _playerPositionY; }
 
-      void SetPlayerPositionX( double positionX ) override { _playerPositionX = positionX; }
-      void SetPlayerPositionY( double positionY ) override { _playerPositionY = positionY; }
+      void SetPlayerPositionX( long long positionX ) override { _playerPositionX = positionX; }
+      void SetPlayerPositionY( long long positionY ) override { _playerPositionY = positionY; }
 
-      double GetTileWidth() const override { return _tileWidth; }
-      double GetTileHeight() const override { return _tileHeight; }
+      long long GetTileWidth() const override { return _tileWidth; }
+      long long GetTileHeight() const override { return _tileHeight; }
 
       int GetHorizontalTiles() const override { return _horizontalTiles; }
       int GetVerticalTiles() const override { return _verticalTiles; }
@@ -34,14 +34,14 @@ namespace MegaManLofi
    private:
       std::vector<ArenaTile> _tiles;
 
-      double _width;
-      double _height;
+      long long _width;
+      long long _height;
 
-      double _playerPositionX;
-      double _playerPositionY;
+      long long _playerPositionX;
+      long long _playerPositionY;
 
-      double _tileWidth;
-      double _tileHeight;
+      long long _tileWidth;
+      long long _tileHeight;
 
       int _horizontalTiles;
       int _verticalTiles;

--- a/MegaManLofi/ArenaConfig.h
+++ b/MegaManLofi/ArenaConfig.h
@@ -9,15 +9,15 @@ namespace MegaManLofi
    class ArenaConfig
    {
    public:
-      double DefaultTileWidth = 0.;
-      double DefaultTileHeight = 0.;
+      long long DefaultTileWidth = 0;
+      long long DefaultTileHeight = 0;
 
       int DefaultHorizontalTiles = 0;
       int DefaultVerticalTiles = 0;
 
       std::vector<ArenaTile> DefaultTiles;
 
-      double DefaultPlayerPositionX = 0.;
-      double DefaultPlayerPositionY = 0.;
+      long long DefaultPlayerPositionX = 0;
+      long long DefaultPlayerPositionY = 0;
    };
 }

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -23,12 +23,12 @@ void ArenaPhysics::MovePlayer()
 {
    UpdatePlayerOccupyingTileIndices();
 
-   if ( _player->GetVelocityX() != 0. )
+   if ( _player->GetVelocityX() != 0 )
    {
       MovePlayerX();
    }
 
-   if ( _player->GetVelocityY() != 0. )
+   if ( _player->GetVelocityY() != 0 )
    {
       MovePlayerY();
    }
@@ -40,15 +40,17 @@ void ArenaPhysics::UpdatePlayerOccupyingTileIndices()
    auto playerPositionX = _arena->GetPlayerPositionX();
    auto playerPositionY = _arena->GetPlayerPositionY();
 
-   _playerOccupyingTileIndices.Left = (long long)( ( playerPositionX + hitBox.Left ) / _arena->GetTileWidth() );
-   _playerOccupyingTileIndices.Top = (long long)( ( playerPositionY + hitBox.Top ) / _arena->GetTileHeight() );
+   _playerOccupyingTileIndices.Left = ( playerPositionX + hitBox.Left ) / _arena->GetTileWidth();
+   _playerOccupyingTileIndices.Top = ( playerPositionY + hitBox.Top ) / _arena->GetTileHeight();
 
    // if the hit box is exactly on a right or bottom tile edge, these will be incorrect,
    // so a quick and dirty solution is to trim a tiny bit off the hit box width and height
-   // TODO: there must be a better way to do this, because this can still mess up in rare cases...
-   // how can we (quickly & easily) tell if the right/bottom edge perfectly matches a tile boundary?
-   _playerOccupyingTileIndices.Right = (long long)( ( playerPositionX + hitBox.Left + ( hitBox.Width - 0.001 ) ) / _arena->GetTileWidth() );
-   _playerOccupyingTileIndices.Bottom = (long long)( ( playerPositionY + hitBox.Top + hitBox.Height - 0.001 ) / _arena->GetTileHeight() );
+   // TODO: after switching away from doubles in favor of long longs, we can do this:
+   // ( playerPositionX + hitBox.Left + hitBox.Width ) % _arena->GetTileWidth();
+   // this will tell us if the right edge aligns perfectly with a tile, in which case
+   // we would decrement the index by one. Same with the bottom edge.
+   _playerOccupyingTileIndices.Right = (long long)( ( playerPositionX + hitBox.Left + ( hitBox.Width - 1 ) ) / _arena->GetTileWidth() );
+   _playerOccupyingTileIndices.Bottom = (long long)( ( playerPositionY + hitBox.Top + ( hitBox.Height - 1 ) ) / _arena->GetTileHeight() );
 }
 
 void ArenaPhysics::MovePlayerX()
@@ -77,7 +79,7 @@ void ArenaPhysics::MovePlayerY()
    }
 }
 
-void ArenaPhysics::DetectPlayerTileCollisionX( double& newPositionX )
+void ArenaPhysics::DetectPlayerTileCollisionX( long long& newPositionX )
 {
    const auto& hitBox = _player->GetHitBox();
    auto currentPositionX = _arena->GetPlayerPositionX();
@@ -89,10 +91,10 @@ void ArenaPhysics::DetectPlayerTileCollisionX( double& newPositionX )
       {
          auto leftOccupyingTileLeftEdge = _playerOccupyingTileIndices.Left * _arena->GetTileWidth();
 
-         if ( newPositionX < 0. )
+         if ( newPositionX < 0 )
          {
             // we've collided with the left edge of the arena
-            newPositionX = 0.;
+            newPositionX = 0;
             _player->StopX();
             break;
          }
@@ -134,7 +136,7 @@ void ArenaPhysics::DetectPlayerTileCollisionX( double& newPositionX )
    }
 }
 
-void ArenaPhysics::DetectPlayerTileCollisionY( double& newPositionY )
+void ArenaPhysics::DetectPlayerTileCollisionY( long long& newPositionY )
 {
    const auto& hitBox = _player->GetHitBox();
    auto currentPositionY = _arena->GetPlayerPositionY();
@@ -146,10 +148,10 @@ void ArenaPhysics::DetectPlayerTileCollisionY( double& newPositionY )
       {
          auto topOccupyingTileTopEdge = _playerOccupyingTileIndices.Top * _arena->GetTileHeight();
 
-         if ( newPositionY < 0. )
+         if ( newPositionY < 0 )
          {
             // we've collided with the top edge of the arena
-            newPositionY = 0.;
+            newPositionY = 0;
             _player->StopY();
             break;
          }

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -42,15 +42,19 @@ void ArenaPhysics::UpdatePlayerOccupyingTileIndices()
 
    _playerOccupyingTileIndices.Left = ( playerPositionX + hitBox.Left ) / _arena->GetTileWidth();
    _playerOccupyingTileIndices.Top = ( playerPositionY + hitBox.Top ) / _arena->GetTileHeight();
+   _playerOccupyingTileIndices.Right = (long long)( ( playerPositionX + hitBox.Left + hitBox.Width ) / _arena->GetTileWidth() );
+   _playerOccupyingTileIndices.Bottom = (long long)( ( playerPositionY + hitBox.Top + hitBox.Height ) / _arena->GetTileHeight() );
 
-   // if the hit box is exactly on a right or bottom tile edge, these will be incorrect,
-   // so a quick and dirty solution is to trim a tiny bit off the hit box width and height
-   // TODO: after switching away from doubles in favor of long longs, we can do this:
-   // ( playerPositionX + hitBox.Left + hitBox.Width ) % _arena->GetTileWidth();
-   // this will tell us if the right edge aligns perfectly with a tile, in which case
-   // we would decrement the index by one. Same with the bottom edge.
-   _playerOccupyingTileIndices.Right = (long long)( ( playerPositionX + hitBox.Left + ( hitBox.Width - 1 ) ) / _arena->GetTileWidth() );
-   _playerOccupyingTileIndices.Bottom = (long long)( ( playerPositionY + hitBox.Top + ( hitBox.Height - 1 ) ) / _arena->GetTileHeight() );
+   // when the player is positioned exactly at the edge of the right or bottom tile,
+   // these indices will be incorrect, and need to be decremented.
+   if ( ( ( playerPositionX + hitBox.Left + hitBox.Width ) % _arena->GetTileWidth() ) == 0 )
+   {
+      _playerOccupyingTileIndices.Right--;
+   }
+   if ( ( ( playerPositionY + hitBox.Top + hitBox.Height ) % _arena->GetTileHeight() ) == 0 )
+   {
+      _playerOccupyingTileIndices.Bottom--;
+   }
 }
 
 void ArenaPhysics::MovePlayerX()

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -26,8 +26,8 @@ namespace MegaManLofi
       void UpdatePlayerOccupyingTileIndices();
       void MovePlayerX();
       void MovePlayerY();
-      void DetectPlayerTileCollisionX( double& newPositionX );
-      void DetectPlayerTileCollisionY( double& newPositionY );
+      void DetectPlayerTileCollisionX( long long& newPositionX );
+      void DetectPlayerTileCollisionY( long long& newPositionY );
 
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;

--- a/MegaManLofi/ConsoleBuffer.cpp
+++ b/MegaManLofi/ConsoleBuffer.cpp
@@ -45,7 +45,7 @@ ConsoleBuffer::ConsoleBuffer() :
    _bufferInfo = shared_ptr<ConsoleBufferInfo>( new ConsoleBufferInfo( GetStdHandle( STD_OUTPUT_HANDLE ),
                                                                        { _originalWidth, _originalHeight },
                                                                        _originalWidth * _originalHeight,
-                                                                       new CHAR_INFO[(__int64)_originalWidth * (__int64)_originalHeight],
+                                                                       new CHAR_INFO[(long long)_originalWidth * (long long)_originalHeight],
                                                                        { 0, 0, _originalWidth, _originalHeight } ) );
 
    CONSOLE_SCREEN_BUFFER_INFO screenBufferInfo;
@@ -128,17 +128,17 @@ void ConsoleBuffer::Clear()
    }
 }
 
-void ConsoleBuffer::Draw( int left, int top, char buffer )
+void ConsoleBuffer::Draw( short left, short top, char buffer )
 {
    Draw( left, top, buffer, _defaultForegroundColor );
 }
 
-void ConsoleBuffer::Draw( int left, int top, char buffer, ConsoleColor foregroundColor )
+void ConsoleBuffer::Draw( short left, short top, char buffer, ConsoleColor foregroundColor )
 {
    Draw( left, top, buffer, foregroundColor, _defaultBackgroundColor );
 }
 
-void ConsoleBuffer::Draw( int left, int top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor )
+void ConsoleBuffer::Draw( short left, short top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor )
 {
    if ( left < 0 || left >= _bufferInfo->ConsoleSize.X || top < 0 || top >= _bufferInfo->ConsoleSize.Y )
    {
@@ -150,17 +150,17 @@ void ConsoleBuffer::Draw( int left, int top, char buffer, ConsoleColor foregroun
    _bufferInfo->DrawBuffer[bufferLocation].Char.AsciiChar = buffer;
 }
 
-void ConsoleBuffer::Draw( int left, int top, const string& buffer )
+void ConsoleBuffer::Draw( short left, short top, const string& buffer )
 {
    Draw( left, top, buffer, _defaultForegroundColor );
 }
 
-void ConsoleBuffer::Draw( int left, int top, const string& buffer, ConsoleColor foregroundColor )
+void ConsoleBuffer::Draw( short left, short top, const string& buffer, ConsoleColor foregroundColor )
 {
    Draw( left, top, buffer, foregroundColor, _defaultBackgroundColor );
 }
 
-void ConsoleBuffer::Draw( int left, int top, const string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor )
+void ConsoleBuffer::Draw( short left, short top, const string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor )
 {
    for ( int i = 0; i < (int)buffer.length(); i++ )
    {
@@ -168,7 +168,7 @@ void ConsoleBuffer::Draw( int left, int top, const string& buffer, ConsoleColor 
    }
 }
 
-void ConsoleBuffer::Draw( int left, int top, const ConsoleSprite& sprite )
+void ConsoleBuffer::Draw( short left, short top, const ConsoleSprite& sprite )
 {
    int i = 0, j = 0;
 

--- a/MegaManLofi/ConsoleBuffer.h
+++ b/MegaManLofi/ConsoleBuffer.h
@@ -21,13 +21,13 @@ namespace MegaManLofi
       void SetDefaultBackgroundColor( ConsoleColor color ) override;
       void Clear() override;
 
-      void Draw( int left, int top, char buffer ) override;
-      void Draw( int left, int top, char buffer, ConsoleColor foregroundColor ) override;
-      void Draw( int left, int top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
-      void Draw( int left, int top, const std::string& buffer ) override;
-      void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) override;
-      void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
-      void Draw( int left, int top, const ConsoleSprite& sprite ) override;
+      void Draw( short left, short top, char buffer ) override;
+      void Draw( short left, short top, char buffer, ConsoleColor foregroundColor ) override;
+      void Draw( short left, short top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
+      void Draw( short left, short top, const std::string& buffer ) override;
+      void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor ) override;
+      void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
+      void Draw( short left, short top, const ConsoleSprite& sprite ) override;
 
       void Flip() override;
 

--- a/MegaManLofi/ConsoleSprite.h
+++ b/MegaManLofi/ConsoleSprite.h
@@ -8,8 +8,8 @@ namespace MegaManLofi
 {
    struct ConsoleSprite
    {
-      int Width = 0;
-      int Height = 0;
+      short Width = 0;
+      short Height = 0;
 
       std::vector<ConsolePixel> Pixels;
    };

--- a/MegaManLofi/GameClock.cpp
+++ b/MegaManLofi/GameClock.cpp
@@ -30,11 +30,11 @@ void GameClock::WaitForNextFrame()
    auto elapsedFrameTimeNano = frameEndTimeNano - _frameStartTimeNano;
    auto remainingFrameTimeNano = _nanoSecondsPerFrame - elapsedFrameTimeNano;
 
-   if ( remainingFrameTimeNano > 0ll )
+   if ( remainingFrameTimeNano > 0 )
    {
       _sleeper->Sleep( remainingFrameTimeNano );
    }
-   else if ( remainingFrameTimeNano < 0ll )
+   else if ( remainingFrameTimeNano < 0 )
    {
       _lagFrameCount++;
    }

--- a/MegaManLofi/IArena.h
+++ b/MegaManLofi/IArena.h
@@ -7,7 +7,7 @@ namespace MegaManLofi
    class __declspec( novtable ) IArena : public IArenaInfoProvider
    {
    public:
-      virtual void SetPlayerPositionX( double positionX ) = 0;
-      virtual void SetPlayerPositionY( double positionY ) = 0;
+      virtual void SetPlayerPositionX( long long positionX ) = 0;
+      virtual void SetPlayerPositionY( long long positionY ) = 0;
    };
 }

--- a/MegaManLofi/IArenaInfoProvider.h
+++ b/MegaManLofi/IArenaInfoProvider.h
@@ -7,14 +7,14 @@ namespace MegaManLofi
    class __declspec( novtable ) IArenaInfoProvider
    {
    public:
-      virtual double GetWidth() const = 0;
-      virtual double GetHeight() const = 0;
+      virtual long long GetWidth() const = 0;
+      virtual long long GetHeight() const = 0;
 
-      virtual double GetPlayerPositionX() const = 0;
-      virtual double GetPlayerPositionY() const = 0;
+      virtual long long GetPlayerPositionX() const = 0;
+      virtual long long GetPlayerPositionY() const = 0;
 
-      virtual double GetTileWidth() const = 0;
-      virtual double GetTileHeight() const = 0;
+      virtual long long GetTileWidth() const = 0;
+      virtual long long GetTileHeight() const = 0;
 
       virtual int GetHorizontalTiles() const = 0;
       virtual int GetVerticalTiles() const = 0;

--- a/MegaManLofi/IConsoleBuffer.h
+++ b/MegaManLofi/IConsoleBuffer.h
@@ -19,13 +19,13 @@ namespace MegaManLofi
       virtual void SetDefaultBackgroundColor( ConsoleColor color ) = 0;
       virtual void Clear() override = 0;
 
-      virtual void Draw( int left, int top, char buffer ) = 0;
-      virtual void Draw( int left, int top, char buffer, ConsoleColor foregroundColor ) = 0;
-      virtual void Draw( int left, int top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
-      virtual void Draw( int left, int top, const std::string& buffer ) = 0;
-      virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) = 0;
-      virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
-      virtual void Draw( int left, int top, const ConsoleSprite& sprite ) = 0;
+      virtual void Draw( short left, short top, char buffer ) = 0;
+      virtual void Draw( short left, short top, char buffer, ConsoleColor foregroundColor ) = 0;
+      virtual void Draw( short left, short top, char buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
+      virtual void Draw( short left, short top, const std::string& buffer ) = 0;
+      virtual void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor ) = 0;
+      virtual void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
+      virtual void Draw( short left, short top, const ConsoleSprite& sprite ) = 0;
 
       virtual void Flip() override = 0;
    };

--- a/MegaManLofi/IPlayer.h
+++ b/MegaManLofi/IPlayer.h
@@ -14,11 +14,11 @@ namespace MegaManLofi
 
       virtual void SetDirection( Direction direction ) = 0;
 
-      virtual double GetVelocityX() const = 0;
-      virtual double GetVelocityY() const = 0;
+      virtual long long GetVelocityX() const = 0;
+      virtual long long GetVelocityY() const = 0;
 
-      virtual void SetVelocityX( double velocityX ) = 0;
-      virtual void SetVelocityY( double velocityY ) = 0;
+      virtual void SetVelocityX( long long velocityX ) = 0;
+      virtual void SetVelocityY( long long velocityY ) = 0;
 
       virtual void StopX() = 0;
       virtual void StopY() = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -252,10 +252,10 @@ shared_ptr<PlayerConfig> BuildPlayerConfig()
 
    // one character is 38 x 78 units, and our player sprites are 4 x 3 characters,
    // so this hit box should match the player's sprite size
-   playerConfig->DefaultHitBox = { 0., 0., 38. * 4., 78. * 3. };
+   playerConfig->DefaultHitBox = { 0, 0, 38 * 4, 78 * 3 };
 
-   playerConfig->DefaultVelocityX = 0.;
-   playerConfig->DefaultVelocityY = 0.;
+   playerConfig->DefaultVelocityX = 0;
+   playerConfig->DefaultVelocityY = 0;
 
    playerConfig->DefaultDirection = Direction::Right;
 
@@ -267,8 +267,8 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
    auto arenaConfig = make_shared<ArenaConfig>();
 
    // this results in a 4332 x 1872 arena, which translates super well to a 120 x 30 console
-   arenaConfig->DefaultTileWidth = 38.;
-   arenaConfig->DefaultTileHeight = 78.;
+   arenaConfig->DefaultTileWidth = 38;
+   arenaConfig->DefaultTileHeight = 78;
 
    arenaConfig->DefaultHorizontalTiles = 114;
    arenaConfig->DefaultVerticalTiles = 24;
@@ -291,8 +291,8 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
       arenaConfig->DefaultTiles[i] = { true, true, true, false }; // passable in all ways except down
    }
 
-   arenaConfig->DefaultPlayerPositionX = ( arenaConfig->DefaultTileWidth * arenaConfig->DefaultHorizontalTiles ) / 2.;
-   arenaConfig->DefaultPlayerPositionY = ( arenaConfig->DefaultTileHeight * arenaConfig->DefaultVerticalTiles ) / 2.;
+   arenaConfig->DefaultPlayerPositionX = ( arenaConfig->DefaultTileWidth * arenaConfig->DefaultHorizontalTiles ) / 2;
+   arenaConfig->DefaultPlayerPositionY = ( arenaConfig->DefaultTileHeight * arenaConfig->DefaultVerticalTiles ) / 2;
 
    return arenaConfig;
 }
@@ -301,12 +301,12 @@ shared_ptr<PlayerPhysicsConfig> BuildPlayerPhysicsConfig()
 {
    auto playerPhysicsConfig = make_shared<PlayerPhysicsConfig>();
 
-   playerPhysicsConfig->MaxPushVelocity = 1'000.;
-   playerPhysicsConfig->MaxGravityVelocity = 4'000.;
+   playerPhysicsConfig->MaxPushVelocity = 1'000;
+   playerPhysicsConfig->MaxGravityVelocity = 4'000;
 
-   playerPhysicsConfig->PushAccelerationPerSecond = 8'000.;
+   playerPhysicsConfig->PushAccelerationPerSecond = 8'000;
    playerPhysicsConfig->FrictionDecelerationPerSecond = 10'000;
-   playerPhysicsConfig->GravityAccelerationPerSecond = 10'000.;
+   playerPhysicsConfig->GravityAccelerationPerSecond = 10'000;
 
    return playerPhysicsConfig;
 }

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -24,5 +24,5 @@ Player::Player( const shared_ptr<PlayerConfig> config,
 
 bool Player::IsMoving() const
 {
-   return _velocityX != 0. || _velocityY != 0.;
+   return _velocityX != 0 || _velocityY != 0;
 }

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -26,11 +26,11 @@ namespace MegaManLofi
 
       const Rectangle& GetHitBox() const override { return _hitBox; }
 
-      double GetVelocityX() const override { return _velocityX; }
-      double GetVelocityY() const override { return _velocityY; }
+      long long GetVelocityX() const override { return _velocityX; }
+      long long GetVelocityY() const override { return _velocityY; }
 
-      void SetVelocityX( double velocityX ) override { _velocityX = velocityX; }
-      void SetVelocityY( double velocityY ) override { _velocityY = velocityY; }
+      void SetVelocityX( long long velocityX ) override { _velocityX = velocityX; }
+      void SetVelocityY( long long velocityY ) override { _velocityY = velocityY; }
 
       void StopX() override { _velocityX = 0; }
       void StopY() override { _velocityY = 0; }
@@ -41,8 +41,8 @@ namespace MegaManLofi
 
       Rectangle _hitBox;
 
-      double _velocityX;
-      double _velocityY;
+      long long _velocityX;
+      long long _velocityY;
 
       Direction _direction;
    };

--- a/MegaManLofi/PlayerConfig.h
+++ b/MegaManLofi/PlayerConfig.h
@@ -8,10 +8,10 @@ namespace MegaManLofi
    class PlayerConfig
    {
    public:
-      Rectangle DefaultHitBox = { 0., 0., 0., 0. };
+      Rectangle DefaultHitBox = { 0, 0, 0, 0 };
 
-      double DefaultVelocityX = 0.;
-      double DefaultVelocityY = 0.;
+      long long DefaultVelocityX = 0;
+      long long DefaultVelocityY = 0;
 
       Direction DefaultDirection = (Direction)0;
    };

--- a/MegaManLofi/PlayerPhysics.cpp
+++ b/MegaManLofi/PlayerPhysics.cpp
@@ -31,15 +31,15 @@ void PlayerPhysics::ApplyFriction() const
 
    auto velocityDelta = ( _config->FrictionDecelerationPerSecond / _frameRateProvider->GetFramesPerSecond() );
    auto currentVelocityX = _player->GetVelocityX();
-   auto newVelocityX = 0.;
+   auto newVelocityX = 0ll;
 
-   if ( currentVelocityX < 0. )
+   if ( currentVelocityX < 0 )
    {
-      newVelocityX = min( currentVelocityX + velocityDelta, 0. );
+      newVelocityX = min( currentVelocityX + velocityDelta, 0ll );
    }
-   else if ( currentVelocityX > 0. )
+   else if ( currentVelocityX > 0 )
    {
-      newVelocityX = max( currentVelocityX - velocityDelta, 0. );
+      newVelocityX = max( currentVelocityX - velocityDelta, 0ll );
    }
 
    _player->SetVelocityX( newVelocityX );
@@ -62,7 +62,7 @@ void PlayerPhysics::Point( Direction direction ) const
 
 void PlayerPhysics::Push( Direction direction ) const
 {
-   auto velocityDelta = 0.;
+   auto velocityDelta = 0ll;
 
    switch ( direction )
    {

--- a/MegaManLofi/PlayerPhysicsConfig.h
+++ b/MegaManLofi/PlayerPhysicsConfig.h
@@ -5,11 +5,11 @@ namespace MegaManLofi
    class PlayerPhysicsConfig
    {
    public:
-      double MaxPushVelocity = 0.;
-      double MaxGravityVelocity = 0.;
+      long long MaxPushVelocity = 0;
+      long long MaxGravityVelocity = 0;
 
-      double PushAccelerationPerSecond = 0.;
-      double FrictionDecelerationPerSecond = 0.;
-      double GravityAccelerationPerSecond = 0.;
+      long long PushAccelerationPerSecond = 0;
+      long long FrictionDecelerationPerSecond = 0;
+      long long GravityAccelerationPerSecond = 0;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -19,8 +19,8 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _renderConfig( renderConfig ),
    _playerInfoProvider( playerInfoProvider ),
    _arenaInfoProvider( arenaInfoProvider ),
-   _arenaCoordConverterX( renderConfig->ArenaCharWidth / arenaInfoProvider->GetWidth() ),
-   _arenaCoordConverterY( renderConfig->ArenaCharHeight / arenaInfoProvider->GetHeight() )
+   _arenaCoordConverterX( renderConfig->ArenaCharWidth / (double)arenaInfoProvider->GetWidth() ),
+   _arenaCoordConverterY( renderConfig->ArenaCharHeight / (double)arenaInfoProvider->GetHeight() )
 {
 }
 

--- a/MegaManLofi/Rectangle.h
+++ b/MegaManLofi/Rectangle.h
@@ -4,9 +4,9 @@ namespace MegaManLofi
 {
    struct Rectangle
    {
-      double Left = 0.;
-      double Top = 0.;
-      double Width = 0.;
-      double Height = 0.;
+      long long Left = 0;
+      long long Top = 0;
+      long long Width = 0;
+      long long Height = 0;
    };
 }

--- a/MegaManLofi/RectangleUtilities.cpp
+++ b/MegaManLofi/RectangleUtilities.cpp
@@ -6,10 +6,10 @@ using namespace MegaManLofi;
 
 bool RectangleUtilities::RectanglesIntersect( const Rectangle& rect1, const Rectangle& rect2 )
 {
-   double rect1Right = rect1.Left + rect1.Width;
-   double rect2Right = rect2.Left + rect2.Width;
-   double rect1Bottom = rect1.Top + rect1.Height;
-   double rect2Bottom = rect2.Top + rect2.Height;
+   auto rect1Right = rect1.Left + rect1.Width;
+   auto rect2Right = rect2.Left + rect2.Width;
+   auto rect1Bottom = rect1.Top + rect1.Height;
+   auto rect2Bottom = rect2.Top + rect2.Height;
 
    bool leftInBounds = rect1.Left > rect2.Left && rect1Right < rect2Right;
    bool rightInBounds = rect1Right > rect2.Left && rect1Right < rect2Right;
@@ -22,8 +22,8 @@ bool RectangleUtilities::RectanglesIntersect( const Rectangle& rect1, const Rect
 
 void RectangleUtilities::UnclipHorizontal( Rectangle& clippingRect, const Rectangle& clippedRect )
 {
-   auto clippingRectMiddle = clippingRect.Left + ( clippingRect.Width / 2. );
-   auto clippedRectMiddle = clippedRect.Left + ( clippedRect.Width / 2. );
+   auto clippingRectMiddle = clippingRect.Left + ( clippingRect.Width / 2 );
+   auto clippedRectMiddle = clippedRect.Left + ( clippedRect.Width / 2 );
 
    if ( clippingRectMiddle < clippedRectMiddle )
    {

--- a/MegaManLofi/StartupStateConsoleRenderer.cpp
+++ b/MegaManLofi/StartupStateConsoleRenderer.cpp
@@ -33,16 +33,16 @@ void StartupStateConsoleRenderer::Render()
    _consoleBuffer->Draw( middleX - 30, 6, "They sky's the limit! Er, the console is the limit, I guess." );
    _consoleBuffer->Draw( middleX - 40, 7, "Just to get you started, here's a list of which keys are bound to which buttons:" );
 
-   int top = 9;
+   short top = 9;
 
    DrawKeyBindings( middleX, top );
 
-   top += (int)_inputConfig->KeyMap.size() + 1;
+   top += (short)_inputConfig->KeyMap.size() + 1;
    _consoleBuffer->Draw( middleX - 17, top, "Press any button to play the game!" );
    _consoleBuffer->Draw( middleX - 25, top + 1, "(remember, not every key is bound to a button....)" );
 }
 
-void StartupStateConsoleRenderer::DrawKeyBindings( int middleX, int top ) const
+void StartupStateConsoleRenderer::DrawKeyBindings( short middleX, short top ) const
 {
    auto leftOfMiddleX = middleX - 2;
 

--- a/MegaManLofi/StartupStateConsoleRenderer.h
+++ b/MegaManLofi/StartupStateConsoleRenderer.h
@@ -20,7 +20,7 @@ namespace MegaManLofi
       void Render() override;
 
    private:
-      void DrawKeyBindings( int middleX, int top ) const;
+      void DrawKeyBindings( short middleX, short top ) const;
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -26,20 +26,20 @@ public:
       _playerMock.reset( new NiceMock<mock_Player> );
       _defaultTile = { true, true, true, true };
 
-      ON_CALL( *_arenaMock, GetWidth() ).WillByDefault( Return( 20. ) );
-      ON_CALL( *_arenaMock, GetHeight() ).WillByDefault( Return( 16. ) );
-      ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 10. ) );
-      ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 8. ) );
-      ON_CALL( *_arenaMock, GetTileWidth() ).WillByDefault( Return( 2. ) );
-      ON_CALL( *_arenaMock, GetTileHeight() ).WillByDefault( Return( 2. ) );
+      ON_CALL( *_arenaMock, GetWidth() ).WillByDefault( Return( 20 ) );
+      ON_CALL( *_arenaMock, GetHeight() ).WillByDefault( Return( 16 ) );
+      ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 10 ) );
+      ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 8 ) );
+      ON_CALL( *_arenaMock, GetTileWidth() ).WillByDefault( Return( 2 ) );
+      ON_CALL( *_arenaMock, GetTileHeight() ).WillByDefault( Return( 2 ) );
       ON_CALL( *_arenaMock, GetHorizontalTiles() ).WillByDefault( Return( 10 ) );
       ON_CALL( *_arenaMock, GetVerticalTiles() ).WillByDefault( Return( 8 ) );
       ON_CALL( *_arenaMock, GetTile( _ ) ).WillByDefault( ReturnRef( _defaultTile ) );
 
-      _playerHitBox = { 0., 0., 4., 6. };
+      _playerHitBox = { 0, 0, 4, 6 };
       ON_CALL( *_playerMock, GetHitBox() ).WillByDefault( ReturnRef( _playerHitBox ) );
-      ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 0. ) );
-      ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 0. ) );
+      ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 0 ) );
+      ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 0 ) );
 
       ON_CALL( *_frameRateProviderMock, GetFramesPerSecond() ).WillByDefault( Return( 1 ) );
    }
@@ -73,11 +73,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_PlayerDidNotMove_DoesNotFlagMoveActions )
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithNoLeftTileCollisions_MovesPlayerAndFlagsMoveAction )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 12. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 12 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10 ) );
    EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedHorizontal ) );
 
    _arenaPhysics->MovePlayer();
@@ -85,11 +85,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithNoLeftTileCollisions_MovesPlayerAn
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpWithNoUpTileCollisions_MovesPlayerAndFlagsMoveAction )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 10. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 10 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8 ) );
    EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedVertical ) );
 
    _arenaPhysics->MovePlayer();
@@ -97,11 +97,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpWithNoUpTileCollisions_MovesPlayerAndFla
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightWithNoRightTileCollisions_MovesPlayerAndFlagsMoveAction )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 8. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 8 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10 ) );
    EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedHorizontal ) );
 
    _arenaPhysics->MovePlayer();
@@ -109,11 +109,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightWithNoRightTileCollisions_MovesPlayer
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownWithNoDownTileCollisions_MovesPlayerAndFlagsMoveAction )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 6. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 6 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8 ) );
    EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedVertical ) );
 
    _arenaPhysics->MovePlayer();
@@ -121,25 +121,25 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownWithNoDownTileCollisions_MovesPlayerAn
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingPassableUpperLeftTile_MovesPlayer )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 9. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 9 ) );
 
    _arenaPhysics->MovePlayer();
 }
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableUpperLeftTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { false, true, true, true };
    ON_CALL( *_arenaMock, GetTile( 34 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -147,14 +147,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableUpperLeftTile_
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableMiddleLeftTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { false, true, true, true };
    ON_CALL( *_arenaMock, GetTile( 44 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -162,14 +162,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableMiddleLeftTile
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableLowerLeftTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { false, true, true, true };
    ON_CALL( *_arenaMock, GetTile( 54 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 10 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -177,11 +177,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftWithCollidingNonPassableLowerLeftTile_
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftCloseToArenaBoundary_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 1. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 1 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 0. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 0 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -189,8 +189,8 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftCloseToArenaBoundary_StopsPlayerX )
 
 TEST_F( ArenaPhysicsTests, MovePlayer_LeftAtArenaBoundary_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 0. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 0 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionX( _ ) ).Times( 0 );
@@ -203,7 +203,7 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftAtTileBoundaryAndTileIsNotPassable_Sto
 {
    ArenaTile tile = { false, true, true, true };
    ON_CALL( *_arenaMock, GetTile( 44 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionX( _ ) ).Times( 0 );
@@ -214,14 +214,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_LeftAtTileBoundaryAndTileIsNotPassable_Sto
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableUpperRightTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, false, true };
    ON_CALL( *_arenaMock, GetTile( 38 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -229,14 +229,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableUpperRightTil
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableMiddleRightTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, false, true };
    ON_CALL( *_arenaMock, GetTile( 48 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -244,14 +244,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableMiddleRightTi
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableLowerRightTile_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, false, true };
    ON_CALL( *_arenaMock, GetTile( 58 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 12 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -259,11 +259,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightWithCollidingNonPassableLowerRightTil
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightCloseToArenaBoundary_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 15. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 15 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 16. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionX( 16 ) );
    EXPECT_CALL( *_playerMock, StopX() );
 
    _arenaPhysics->MovePlayer();
@@ -271,8 +271,8 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightCloseToArenaBoundary_StopsPlayerX )
 
 TEST_F( ArenaPhysicsTests, MovePlayer_RightAtArenaBoundary_StopsPlayerX )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 16. ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 16 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionX( _ ) ).Times( 0 );
@@ -285,7 +285,7 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightAtTileBoundaryAndTileIsNotPassable_St
 {
    ArenaTile tile = { true, true, false, true };
    ON_CALL( *_arenaMock, GetTile( 47 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionX( _ ) ).Times( 0 );
@@ -296,14 +296,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_RightAtTileBoundaryAndTileIsNotPassable_St
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperLeftTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, false, true, true };
    ON_CALL( *_arenaMock, GetTile( 25 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -311,14 +311,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperLeftTile_St
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperMiddleTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, false, true, true };
    ON_CALL( *_arenaMock, GetTile( 26 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -326,14 +326,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperMiddleTile_
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperRightTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, false, true, true };
    ON_CALL( *_arenaMock, GetTile( 27 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 6 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -341,11 +341,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpWithCollidingNonPassableUpperRightTile_S
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpCloseToArenaBoundary_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 1. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 1 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 0. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 0 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -353,8 +353,8 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpCloseToArenaBoundary_StopsPlayerY )
 
 TEST_F( ArenaPhysicsTests, MovePlayer_UpAtArenaBoundary_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 0. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 0 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionY( _ ) ).Times( 0 );
@@ -367,7 +367,7 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpAtTileBoundaryAndTileIsNotPassable_Stops
 {
    ArenaTile tile = { true, false, true, true };
    ON_CALL( *_arenaMock, GetTile( 35 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionY( _ ) ).Times( 0 );
@@ -378,14 +378,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_UpAtTileBoundaryAndTileIsNotPassable_Stops
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerLeftTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, true, false };
    ON_CALL( *_arenaMock, GetTile( 75 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -393,14 +393,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerLeftTile_
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerMiddleTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, true, false };
    ON_CALL( *_arenaMock, GetTile( 76 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -408,14 +408,14 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerMiddleTil
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerRightTile_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11. ) );
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionX() ).WillByDefault( Return( 11 ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 7 ) );
    ArenaTile tile = { true, true, true, false };
    ON_CALL( *_arenaMock, GetTile( 77 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 8 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -423,11 +423,11 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownWithCollidingNonPassableLowerRightTile
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownCloseToArenaBoundary_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 9. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 9 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
-   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 10. ) );
+   EXPECT_CALL( *_arenaMock, SetPlayerPositionY( 10 ) );
    EXPECT_CALL( *_playerMock, StopY() );
 
    _arenaPhysics->MovePlayer();
@@ -435,8 +435,8 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownCloseToArenaBoundary_StopsPlayerY )
 
 TEST_F( ArenaPhysicsTests, MovePlayer_DownAtArenaBoundary_StopsPlayerY )
 {
-   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 10. ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_arenaMock, GetPlayerPositionY() ).WillByDefault( Return( 10 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionY( _ ) ).Times( 0 );
@@ -449,7 +449,7 @@ TEST_F( ArenaPhysicsTests, MovePlayer_DownAtTileBoundaryAndTileIsNotPassable_Sto
 {
    ArenaTile tile = { true, true, true, false };
    ON_CALL( *_arenaMock, GetTile( 75 ) ).WillByDefault( ReturnRef( tile ) );
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
    BuildArenaPhysics();
 
    EXPECT_CALL( *_arenaMock, SetPlayerPositionY( _ ) ).Times( 0 );

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -22,12 +22,12 @@ public:
    {
       _config.reset( new ArenaConfig );
 
-      _config->DefaultTileWidth = 2.;
-      _config->DefaultTileHeight = 2.;
+      _config->DefaultTileWidth = 2;
+      _config->DefaultTileHeight = 2;
       _config->DefaultHorizontalTiles = 10;
       _config->DefaultVerticalTiles = 8;
-      _config->DefaultPlayerPositionX = 10.;
-      _config->DefaultPlayerPositionY = 8.;
+      _config->DefaultPlayerPositionX = 10;
+      _config->DefaultPlayerPositionY = 8;
 
       for ( int i = 0; i < _config->DefaultHorizontalTiles * _config->DefaultVerticalTiles; i++ )
       {
@@ -51,14 +51,14 @@ TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnConfig )
    _config->DefaultTiles[5] = { false, true, false, true };
    BuildArena();
 
-   EXPECT_EQ( _arena->GetWidth(), 20. );
-   EXPECT_EQ( _arena->GetHeight(), 16. );
-   EXPECT_EQ( _arena->GetPlayerPositionX(), 10. );
-   EXPECT_EQ( _arena->GetPlayerPositionY(), 8. );
-   EXPECT_EQ( _arena->GetTileWidth(), 2. );
-   EXPECT_EQ( _arena->GetTileHeight(), 2. );
+   EXPECT_EQ( _arena->GetWidth(), 20 );
+   EXPECT_EQ( _arena->GetHeight(), 16 );
+   EXPECT_EQ( _arena->GetPlayerPositionX(), 10 );
+   EXPECT_EQ( _arena->GetPlayerPositionY(), 8 );
+   EXPECT_EQ( _arena->GetTileWidth(), 2 );
+   EXPECT_EQ( _arena->GetTileHeight(), 2 );
    EXPECT_EQ( _arena->GetHorizontalTiles(), 10 );
-   EXPECT_EQ( _arena->GetVerticalTiles(), 8. );
+   EXPECT_EQ( _arena->GetVerticalTiles(), 8 );
 
    EXPECT_FALSE( _arena->GetTile( 5 ).LeftPassable );
    EXPECT_TRUE( _arena->GetTile( 5 ).UpPassable );

--- a/MegaManLofiTests/PlayerPhysicsTests.cpp
+++ b/MegaManLofiTests/PlayerPhysicsTests.cpp
@@ -23,11 +23,11 @@ public:
       _playerMock.reset( new NiceMock<mock_Player> );
       _config.reset( new PlayerPhysicsConfig );
 
-      _config->MaxPushVelocity = 10.;
-      _config->MaxGravityVelocity = 20.;
-      _config->PushAccelerationPerSecond = 2.;
-      _config->FrictionDecelerationPerSecond = 2.;
-      _config->GravityAccelerationPerSecond = 4.;
+      _config->MaxPushVelocity = 10;
+      _config->MaxGravityVelocity = 20;
+      _config->PushAccelerationPerSecond = 2;
+      _config->FrictionDecelerationPerSecond = 2;
+      _config->GravityAccelerationPerSecond = 4;
 
       ON_CALL( *_frameRateProviderMock, GetFramesPerSecond() ).WillByDefault( Return( 1 ) );
       ON_CALL( *_frameActionRegistryMock, ActionFlagged( FrameAction::PlayerPushed ) ).WillByDefault( Return( false ) );
@@ -54,18 +54,18 @@ TEST_F( PlayerPhysicsTests, ApplyFriction_PlayerWasPushed_DoesNotApplyFriction )
 
 TEST_F( PlayerPhysicsTests, ApplyFriction_PlayerIsMovingLeft_SlowsDownCorrectly )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -4. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -4 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( -2. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( -2 ) );
 
    _physics->ApplyFriction();
 }
 
 TEST_F( PlayerPhysicsTests, ApplyFriction_PlayerIsMovingRight_SlowsDownCorrectly )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 4. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 4 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( 2. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( 2 ) );
 
    _physics->ApplyFriction();
 }
@@ -81,34 +81,34 @@ TEST_F( PlayerPhysicsTests, ApplyGravity_PlayerIsJumping_DoesNotApplyGravity )
 
 TEST_F( PlayerPhysicsTests, ApplyGravity_PlayerIsMovingUp_DecreasesYVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -10. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -10 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityY( -6. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityY( -6 ) );
 
    _physics->ApplyGravity();
 }
 
 TEST_F( PlayerPhysicsTests, ApplyGravity_PlayerIsMovingDown_DecreasesYVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 10. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 10 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityY( 14. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityY( 14 ) );
 
    _physics->ApplyGravity();
 }
 
 TEST_F( PlayerPhysicsTests, ApplyGravity_PlayerIsNearTerminalVelocity_ClampsToTerminalVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 19. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 19 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityY( 20. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityY( 20 ) );
 
    _physics->ApplyGravity();
 }
 
 TEST_F( PlayerPhysicsTests, ApplyGravity_PlayerIsAtTerminalVelocity_DoesNotChangeYVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 20. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 20 ) );
 
    EXPECT_CALL( *_playerMock, SetVelocityY( _ ) ).Times( 0 );
 
@@ -138,25 +138,25 @@ TEST_F( PlayerPhysicsTests, Push_Right_FlagsAction )
 
 TEST_F( PlayerPhysicsTests, Push_Left_ChangesXVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -6. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -6 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( -8. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( -8 ) );
 
    _physics->Push( Direction::Left );
 }
 
 TEST_F( PlayerPhysicsTests, Push_LeftAndPushVelocityHasAlmostMaxedOut_ClampsToMaxPushVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -9. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -9 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( -10. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( -10 ) );
 
    _physics->Push( Direction::Left );
 }
 
 TEST_F( PlayerPhysicsTests, Push_LeftAndPushVelocityHasMaxedOut_DoesNotChangeXVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -10. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -10 ) );
 
    EXPECT_CALL( *_playerMock, SetVelocityX( _ ) ).Times( 0 );
 
@@ -165,25 +165,25 @@ TEST_F( PlayerPhysicsTests, Push_LeftAndPushVelocityHasMaxedOut_DoesNotChangeXVe
 
 TEST_F( PlayerPhysicsTests, Push_Right_ChangesXVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 6. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 6 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( 8. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( 8 ) );
 
    _physics->Push( Direction::Right );
 }
 
 TEST_F( PlayerPhysicsTests, Push_RightAndPushVelocityHasAlmostMaxedOut_ClampsToMaxPushVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 9. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 9 ) );
 
-   EXPECT_CALL( *_playerMock, SetVelocityX( 10. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityX( 10 ) );
 
    _physics->Push( Direction::Right );
 }
 
 TEST_F( PlayerPhysicsTests, Push_RightAndPushVelocityHasMaxedOut_DoesNotChangeXVelocity )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 10. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 10 ) );
 
    EXPECT_CALL( *_playerMock, SetVelocityX( _ ) ).Times( 0 );
 
@@ -192,7 +192,7 @@ TEST_F( PlayerPhysicsTests, Push_RightAndPushVelocityHasMaxedOut_DoesNotChangeXV
 
 TEST_F( PlayerPhysicsTests, Jump_Always_SetsVelocityToUpwardGravityMaximum )
 {
-   EXPECT_CALL( *_playerMock, SetVelocityY( -20. ) );
+   EXPECT_CALL( *_playerMock, SetVelocityY( -20 ) );
 
    _physics->Jump();
 }

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -23,9 +23,9 @@ public:
       _frameActionRegistryMock.reset( new NiceMock<mock_FrameActionRegistry> );
       _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
 
-      _config->DefaultHitBox = { 0., 0., 4., 4. };
-      _config->DefaultVelocityX = 0.;
-      _config->DefaultVelocityY = 0.;
+      _config->DefaultHitBox = { 0, 0, 4, 4 };
+      _config->DefaultVelocityX = 0;
+      _config->DefaultVelocityY = 0;
       _config->DefaultDirection = Direction::Left;
 
       ON_CALL( *_frameRateProviderMock, GetFramesPerSecond() ).WillByDefault( Return( 100 ) );
@@ -48,13 +48,13 @@ protected:
 
 TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
 {
-   _config->DefaultVelocityX = 100.;
-   _config->DefaultVelocityY = 200.;
+   _config->DefaultVelocityX = 100;
+   _config->DefaultVelocityY = 200;
    _config->DefaultDirection = Direction::Right;
    BuildPlayer();
 
-   EXPECT_EQ( _player->GetVelocityX(), 100. );
-   EXPECT_EQ( _player->GetVelocityY(), 200. );
+   EXPECT_EQ( _player->GetVelocityX(), 100 );
+   EXPECT_EQ( _player->GetVelocityY(), 200 );
    EXPECT_EQ( _player->GetDirection(), Direction::Right );
 }
 
@@ -70,8 +70,8 @@ TEST_F( PlayerTests, IsMoving_NotMoving_ReturnsFalse )
 {
    BuildPlayer();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0. );
-   EXPECT_EQ( _player->GetVelocityY(), 0. );
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
    EXPECT_FALSE( _player->IsMoving() );
 }
 
@@ -79,7 +79,7 @@ TEST_F( PlayerTests, IsMoving_MovingHorizontally_ReturnsTrue )
 {
    BuildPlayer();
 
-   _player->SetVelocityX( -2. );
+   _player->SetVelocityX( -2 );
 
    EXPECT_TRUE( _player->IsMoving() );
 }
@@ -88,7 +88,7 @@ TEST_F( PlayerTests, IsMoving_MovingVertically_ReturnsTrue )
 {
    BuildPlayer();
 
-   _player->SetVelocityY( 2. );
+   _player->SetVelocityY( 2 );
 
    EXPECT_TRUE( _player->IsMoving() );
 }
@@ -97,46 +97,46 @@ TEST_F( PlayerTests, GetHitBox_Always_ReturnsHitBox )
 {
    BuildPlayer();
 
-   EXPECT_EQ( _player->GetHitBox().Left, 0. );
-   EXPECT_EQ( _player->GetHitBox().Top, 0. );
-   EXPECT_EQ( _player->GetHitBox().Width, 4. );
-   EXPECT_EQ( _player->GetHitBox().Height, 4. );
+   EXPECT_EQ( _player->GetHitBox().Left, 0 );
+   EXPECT_EQ( _player->GetHitBox().Top, 0 );
+   EXPECT_EQ( _player->GetHitBox().Width, 4 );
+   EXPECT_EQ( _player->GetHitBox().Height, 4 );
 }
 
 TEST_F( PlayerTests, GetVelocityX_Always_ReturnsVelocityX )
 {
    BuildPlayer();
 
-   _player->SetVelocityX( 2. );
+   _player->SetVelocityX( 2 );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2. );
+   EXPECT_EQ( _player->GetVelocityX(), 2 );
 }
 
 TEST_F( PlayerTests, GetVelocityY_Always_ReturnsVelocityY )
 {
    BuildPlayer();
 
-   _player->SetVelocityY( 5. );
+   _player->SetVelocityY( 5 );
 
-   EXPECT_EQ( _player->GetVelocityY(), 5. );
+   EXPECT_EQ( _player->GetVelocityY(), 5 );
 }
 
 TEST_F( PlayerTests, StopX_Always_SetsXVelocityToZero )
 {
    BuildPlayer();
 
-   _player->SetVelocityX( 2. );
+   _player->SetVelocityX( 2 );
    _player->StopX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0. );
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
 }
 
 TEST_F( PlayerTests, StopY_Always_SetsYVelocityToZero )
 {
    BuildPlayer();
 
-   _player->SetVelocityY( -2. );
+   _player->SetVelocityY( -2 );
    _player->StopY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0. );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
 }

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -7,14 +7,14 @@
 class mock_Arena : public MegaManLofi::IArena
 {
 public:
-   MOCK_METHOD( double, GetWidth, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetHeight, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetPlayerPositionX, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetPlayerPositionY, ( ), ( const, override ) );
-   MOCK_METHOD( void, SetPlayerPositionX, ( double ), ( override ) );
-   MOCK_METHOD( void, SetPlayerPositionY, ( double ), ( override ) );
-   MOCK_METHOD( double, GetTileWidth, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetTileHeight, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetWidth, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetHeight, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetPlayerPositionX, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetPlayerPositionY, ( ), ( const, override ) );
+   MOCK_METHOD( void, SetPlayerPositionX, ( long long ), ( override ) );
+   MOCK_METHOD( void, SetPlayerPositionY, ( long long ), ( override ) );
+   MOCK_METHOD( long long, GetTileWidth, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetTileHeight, ( ), ( const, override ) );
    MOCK_METHOD( int, GetHorizontalTiles, ( ), ( const, override ) );
    MOCK_METHOD( int, GetVerticalTiles, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::ArenaTile&, GetTile, ( long long ), ( const, override ) );

--- a/MegaManLofiTests/mock_ConsoleBuffer.h
+++ b/MegaManLofiTests/mock_ConsoleBuffer.h
@@ -7,20 +7,20 @@
 class mock_ConsoleBuffer : public MegaManLofi::IConsoleBuffer
 {
 public:
-   MOCK_METHOD( void, Initialize, ( ), ( override ) );
+   MOCK_METHOD( void, LoadRenderConfig, ( std::shared_ptr<MegaManLofi::IGameRenderConfig> ), ( override ) );
    MOCK_METHOD( void, CleanUp, ( ), ( override ) );
 
    MOCK_METHOD( void, SetDefaultForegroundColor, ( MegaManLofi::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, SetDefaultBackgroundColor, ( MegaManLofi::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, Clear, ( ), ( override ) );
 
-   MOCK_METHOD( void, Draw, ( int, int, char ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, char, MegaManLofi::ConsoleColor ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, char, MegaManLofi::ConsoleColor, MegaManLofi::ConsoleColor ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, const std::string& ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, const std::string&, MegaManLofi::ConsoleColor ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, const std::string&, MegaManLofi::ConsoleColor, MegaManLofi::ConsoleColor ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, const MegaManLofi::ConsoleSprite& ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, char ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, char, MegaManLofi::ConsoleColor ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, char, MegaManLofi::ConsoleColor, MegaManLofi::ConsoleColor ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, const std::string& ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, const std::string&, MegaManLofi::ConsoleColor ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, const std::string&, MegaManLofi::ConsoleColor, MegaManLofi::ConsoleColor ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, const MegaManLofi::ConsoleSprite& ), ( override ) );
 
    MOCK_METHOD( void, Flip, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -11,10 +11,10 @@ public:
    MOCK_METHOD( bool, IsMoving, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::Rectangle&, GetHitBox, ( ), ( const, override ) );
    MOCK_METHOD( void, SetDirection, ( MegaManLofi::Direction ), ( override ) );
-   MOCK_METHOD( double, GetVelocityX, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetVelocityY, ( ), ( const, override ) );
-   MOCK_METHOD( void, SetVelocityX, ( double ), ( override ) );
-   MOCK_METHOD( void, SetVelocityY, ( double ), ( override ) );
+   MOCK_METHOD( long long, GetVelocityX, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetVelocityY, ( ), ( const, override ) );
+   MOCK_METHOD( void, SetVelocityX, ( long long ), ( override ) );
+   MOCK_METHOD( void, SetVelocityY, ( long long ), ( override ) );
    MOCK_METHOD( void, StopX, ( ), ( override ) );
    MOCK_METHOD( void, StopY, ( ), ( override ) );
 };


### PR DESCRIPTION
I guess I should've been doing this all along, using `long long` instead of `double` for arena distance measurement. It allows us to use the `%` operator to check for tile boundaries.