### PR TITLE
Use Assign() functions for physics objects

### DIFF
--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -9,14 +9,20 @@ using namespace std;
 using namespace MegaManLofi;
 
 ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
-                            const shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                            const shared_ptr<IArena> arena,
-                            const shared_ptr<IPlayer> player ) :
+                            const shared_ptr<IFrameActionRegistry> frameActionRegistry ) :
    _frameRateProvider( frameRateProvider ),
    _frameActionRegistry( frameActionRegistry ),
-   _arena( arena ),
-   _player( player )
+   _arena( nullptr ),
+   _player( nullptr )
 {
+}
+
+void ArenaPhysics::AssignTo( const shared_ptr<IArena> arena,
+                             const shared_ptr<IPlayer> player )
+{
+   _arena = arena;
+   _player = player;
+
    UpdatePlayerOccupyingTileIndices();
 }
 

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "IArenaPhysics.h"
 #include "TileIndices.h"
 
@@ -9,17 +7,15 @@ namespace MegaManLofi
 {
    class IFrameRateProvider;
    class IFrameActionRegistry;
-   class IArena;
-   class IPlayer;
 
    class ArenaPhysics : public IArenaPhysics
    {
    public:
       ArenaPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
-                    const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                    const std::shared_ptr<IArena> arena,
-                    const std::shared_ptr<IPlayer> player );
+                    const std::shared_ptr<IFrameActionRegistry> frameActionRegistry );
 
+      void AssignTo( const std::shared_ptr<IArena> arena,
+                     const std::shared_ptr<IPlayer> player ) override;
       void Tick() override;
 
    private:
@@ -34,8 +30,8 @@ namespace MegaManLofi
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
-      const std::shared_ptr<IArena> _arena;
-      const std::shared_ptr<IPlayer> _player;
+      std::shared_ptr<IArena> _arena;
+      std::shared_ptr<IPlayer> _player;
 
       TileIndices _playerOccupyingTileIndices;
    };

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -11,14 +11,18 @@
 using namespace std;
 using namespace MegaManLofi;
 
-Game::Game( const std::shared_ptr<IGameEventAggregator> eventAggregator,
-            const std::shared_ptr<IPlayerPhysics> playerPhysics,
-            const std::shared_ptr<IArenaPhysics> arenaPhysics ) :
+Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
+            const shared_ptr<IPlayer> player,
+            const shared_ptr<IArena> arena,
+            const shared_ptr<IPlayerPhysics> playerPhysics,
+            const shared_ptr<IArenaPhysics> arenaPhysics ) :
    _eventAggregator( eventAggregator ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
    _state( GameState::Startup )
 {
+   _playerPhysics->AssignTo( player );
+   _arenaPhysics->AssignTo( arena, player );
 }
 
 void Game::Tick()

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -9,6 +9,8 @@
 namespace MegaManLofi
 {
    class IGameEventAggregator;
+   class IPlayer;
+   class IArena;
    class IPlayerPhysics;
    class IArenaPhysics;
 
@@ -18,6 +20,8 @@ namespace MegaManLofi
    {
    public:
       Game( const std::shared_ptr<IGameEventAggregator> eventAggregator,
+            const std::shared_ptr<IPlayer> player,
+            const std::shared_ptr<IArena> arena,
             const std::shared_ptr<IPlayerPhysics> playerPhysics,
             const std::shared_ptr<IArenaPhysics> arenaPhysics );
 

--- a/MegaManLofi/IArenaPhysics.h
+++ b/MegaManLofi/IArenaPhysics.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <memory>
+
 namespace MegaManLofi
 {
+   class IArena;
+   class IPlayer;
+
    class __declspec( novtable ) IArenaPhysics
    {
    public:
+      virtual void AssignTo( std::shared_ptr<IArena> arena,
+                             std::shared_ptr<IPlayer> player ) = 0;
       virtual void Tick() = 0;
    };
 }

--- a/MegaManLofi/IPlayerPhysics.h
+++ b/MegaManLofi/IPlayerPhysics.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <memory>
+
 namespace MegaManLofi
 {
+   class IPlayer;
    enum class Direction;
 
    class __declspec( novtable ) IPlayerPhysics
    {
    public:
+      virtual void AssignTo( const std::shared_ptr<IPlayer> player ) = 0;
       virtual void Tick() = 0;
 
       virtual void PointTo( Direction direction ) const = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -105,16 +105,14 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClock, sleeper, config->FramesPerSecond ) );
    auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( keyboardInputConfig, keyboard ) );
 
-   // game sub-objects
+   // utilities
+   auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, config->PlayerPhysicsConfig ) );
+   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry ) );
+
+   // game objects
    auto player = shared_ptr<Player>( new Player( config->PlayerConfig, frameActionRegistry, clock ) );
    auto arena = shared_ptr<Arena>( new Arena( config->ArenaConfig ) );
-
-   // utilities
-   auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, player, config->PlayerPhysicsConfig ) );
-   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry, arena, player ) );
-
-   // game object
-   auto game = shared_ptr<Game>( new Game( eventAggregator, playerPhysics, arenaPhysics ) );
+   auto game = shared_ptr<Game>( new Game( eventAggregator, player, arena, playerPhysics, arenaPhysics ) );
 
    // input objects
    auto startupStateInputHandler = shared_ptr<StartupStateInputHandler>( new StartupStateInputHandler( keyboardInputReader, game ) );

--- a/MegaManLofi/PlayerPhysics.cpp
+++ b/MegaManLofi/PlayerPhysics.cpp
@@ -13,15 +13,22 @@ using namespace MegaManLofi;
 
 PlayerPhysics::PlayerPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
                               const shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                              const shared_ptr<IPlayer> player,
                               const shared_ptr<PlayerPhysicsConfig> config ) :
    _frameRateProvider( frameRateProvider ),
    _frameActionRegistry( frameActionRegistry ),
-   _player( player ),
    _config( config ),
+   _player( nullptr ),
    _lastExtendJumpFrame( 0 ),
    _elapsedJumpExtensionSeconds( 0. )
 {
+}
+
+void PlayerPhysics::AssignTo( const shared_ptr<IPlayer> player )
+{
+   _player = player;
+
+   _lastExtendJumpFrame = 0;
+   _elapsedJumpExtensionSeconds = 0;
 }
 
 void PlayerPhysics::Tick()

--- a/MegaManLofi/PlayerPhysics.h
+++ b/MegaManLofi/PlayerPhysics.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "IPlayerPhysics.h"
 
 namespace MegaManLofi
 {
    class IFrameRateProvider;
    class IFrameActionRegistry;
-   class IPlayer;
    class PlayerPhysicsConfig;
 
    class PlayerPhysics : public IPlayerPhysics
@@ -16,9 +13,9 @@ namespace MegaManLofi
    public:
       PlayerPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                      const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                     const std::shared_ptr<IPlayer> player,
                      const std::shared_ptr<PlayerPhysicsConfig> config );
 
+      void AssignTo( const std::shared_ptr<IPlayer> player ) override;
       void Tick() override;
 
       void PointTo( Direction direction ) const override;
@@ -33,8 +30,8 @@ namespace MegaManLofi
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
-      const std::shared_ptr<IPlayer> _player;
       const std::shared_ptr<PlayerPhysicsConfig> _config;
+      std::shared_ptr<IPlayer> _player;
 
       long long _lastExtendJumpFrame;
       double _elapsedJumpExtensionSeconds;

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -46,7 +46,8 @@ public:
 
    void BuildArenaPhysics()
    {
-      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _frameActionRegistryMock, _arenaMock, _playerMock ) );
+      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _frameActionRegistryMock ) );
+      _arenaPhysics->AssignTo( _arenaMock, _playerMock );
    }
 
 protected:
@@ -60,6 +61,11 @@ protected:
 
    shared_ptr<ArenaPhysics> _arenaPhysics;
 };
+
+TEST_F( ArenaPhysicsTests, AssignTo_Always_UpdatesPlayerOccupyingTileIndices )
+{
+   // MUFFINS
+}
 
 TEST_F( ArenaPhysicsTests, Tick_PlayerDidNotMove_DoesNotFlagMoveActions )
 {

--- a/MegaManLofiTests/PlayerPhysicsTests.cpp
+++ b/MegaManLofiTests/PlayerPhysicsTests.cpp
@@ -39,7 +39,8 @@ public:
 
    void BuildPhysics()
    {
-      _physics.reset( new PlayerPhysics( _frameRateProviderMock, _frameActionRegistryMock, _playerMock, _config ) );
+      _physics.reset( new PlayerPhysics( _frameRateProviderMock, _frameActionRegistryMock, _config ) );
+      _physics->AssignTo( _playerMock );
    }
 
 protected:
@@ -50,6 +51,11 @@ protected:
 
    shared_ptr<PlayerPhysics> _physics;
 };
+
+TEST_F( PlayerPhysicsTests, AssignTo_Always_ResetsExtendJumpParameters )
+{
+   // MUFFINS
+}
 
 TEST_F( PlayerPhysicsTests, Tick_PlayerWasPushed_DoesNotApplyFriction )
 {

--- a/MegaManLofiTests/mock_ArenaPhysics.h
+++ b/MegaManLofiTests/mock_ArenaPhysics.h
@@ -7,5 +7,7 @@
 class mock_ArenaPhysics : public MegaManLofi::IArenaPhysics
 {
 public:
+   MOCK_METHOD( void, AssignTo, ( std::shared_ptr<MegaManLofi::IArena>,
+                                  std::shared_ptr<MegaManLofi::IPlayer> ), ( override ) );
    MOCK_METHOD( void, Tick, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_PlayerPhysics.h
+++ b/MegaManLofiTests/mock_PlayerPhysics.h
@@ -8,6 +8,7 @@
 class mock_PlayerPhysics : public MegaManLofi::IPlayerPhysics
 {
 public:
+   MOCK_METHOD( void, AssignTo, ( std::shared_ptr<MegaManLofi::IPlayer> ), ( override ) );
    MOCK_METHOD( void, Tick, (), ( override ) );
    MOCK_METHOD( void, PointTo, ( MegaManLofi::Direction ), ( const, override ) );
    MOCK_METHOD( void, PushTo, ( MegaManLofi::Direction ), ( const, override ) );


### PR DESCRIPTION
I like this better, it means we can use a single physics class for whatever different player or arena objects we want.