### PR TITLE
Show a GET READY! blinking message on GameStart event

### DIFF
--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -22,6 +22,9 @@ namespace MegaManLofi
       short ArenaFenceX = 0;
       short ArenaFenceY = 0;
 
+      double GameStartSingleBlinkSeconds = 0;
+      int GameStartBlinkCount = 0;
+
       ConsoleColor DefaultForegroundColor = (ConsoleColor)0;
       ConsoleColor DefaultBackgroundColor = (ConsoleColor)0;
 

--- a/MegaManLofi/DiagnosticsConsoleRenderer.h
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.h
@@ -18,6 +18,7 @@ namespace MegaManLofi
                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
       void Render() override;
+      bool HasFocus() const override { return false; }
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -45,6 +45,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    {
       case GameCommand::Start:
          _state = GameState::Playing;
+         _eventAggregator->RaiseEvent( GameEvent::GameStarted );
          break;
       case GameCommand::Quit:
          _eventAggregator->RaiseEvent( GameEvent::Shutdown );

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -5,6 +5,8 @@ namespace MegaManLofi
    enum class GameEvent
    {
       Shutdown = 0,
-      ToggleDiagnostics
+      ToggleDiagnostics,
+
+      GameStarted
    };
 }

--- a/MegaManLofi/GameRenderer.cpp
+++ b/MegaManLofi/GameRenderer.cpp
@@ -53,6 +53,11 @@ void GameRenderer::Render()
    _screenBuffer->Flip();
 }
 
+bool GameRenderer::HasFocus() const
+{
+   return _stateRenderers.at( _gameInfoProvider->GetGameState() )->HasFocus();
+}
+
 void GameRenderer::HandleShutdownEvent()
 {
    _isCleaningUp = true;

--- a/MegaManLofi/GameRenderer.h
+++ b/MegaManLofi/GameRenderer.h
@@ -27,7 +27,7 @@ namespace MegaManLofi
       void AddRendererForGameState( GameState state, std::shared_ptr<IGameRenderer> renderer );
 
       void Render() override;
-      bool HasFocus() const override { return false; }
+      bool HasFocus() const override;
 
    private:
       void HandleShutdownEvent();

--- a/MegaManLofi/GameRenderer.h
+++ b/MegaManLofi/GameRenderer.h
@@ -27,6 +27,7 @@ namespace MegaManLofi
       void AddRendererForGameState( GameState state, std::shared_ptr<IGameRenderer> renderer );
 
       void Render() override;
+      bool HasFocus() const override { return false; }
 
    private:
       void HandleShutdownEvent();

--- a/MegaManLofi/GameRunner.cpp
+++ b/MegaManLofi/GameRunner.cpp
@@ -36,10 +36,10 @@ void GameRunner::Run()
    while ( _isRunning )
    {
       _clock->StartFrame();
-      _inputHandler->HandleInput();
 
       if ( !_renderer->HasFocus() )
       {
+         _inputHandler->HandleInput();
          _game->Tick();
       }
 

--- a/MegaManLofi/GameRunner.cpp
+++ b/MegaManLofi/GameRunner.cpp
@@ -36,12 +36,15 @@ void GameRunner::Run()
    while ( _isRunning )
    {
       _clock->StartFrame();
-
       _inputHandler->HandleInput();
-      _game->Tick();
+
+      if ( !_renderer->HasFocus() )
+      {
+         _game->Tick();
+      }
+
       _renderer->Render();
       _frameActionRegistry->Clear();
-
       _clock->WaitForNextFrame();
    }
 

--- a/MegaManLofi/IGameRenderer.h
+++ b/MegaManLofi/IGameRenderer.h
@@ -6,5 +6,6 @@ namespace MegaManLofi
    {
    public:
       virtual void Render() = 0;
+      virtual bool HasFocus() const = 0;
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -124,7 +124,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
    auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
-   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, player, arena ) );
+   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, player, arena, eventAggregator ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::Playing, playingStateConsoleRenderer );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -124,7 +124,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
    auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
-   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, player, arena, eventAggregator ) );
+   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, player, arena, eventAggregator, clock ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::Playing, playingStateConsoleRenderer );
@@ -147,6 +147,10 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
 
    renderConfig->ArenaFenceX = 2;
    renderConfig->ArenaFenceY = 3;
+
+   // "GET READY!" message should blink for 2 seconds
+   renderConfig->GameStartSingleBlinkSeconds = .25;
+   renderConfig->GameStartBlinkCount = 8;
 
    renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
    renderConfig->DefaultBackgroundColor = ConsoleColor::Black;

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -3,10 +3,12 @@
 #include "ConsoleRenderConfig.h"
 #include "IPlayerInfoProvider.h"
 #include "IArenaInfoProvider.h"
+#include "IGameEventAggregator.h"
 #include "ConsoleColor.h"
 #include "Direction.h"
 #include "ConsoleSprite.h"
 #include "ConsolePixel.h"
+#include "GameEvent.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -14,14 +16,17 @@ using namespace MegaManLofi;
 PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                           const shared_ptr<ConsoleRenderConfig> renderConfig,
                                                           const shared_ptr<IPlayerInfoProvider> playerInfoProvider,
-                                                          const shared_ptr<IArenaInfoProvider> arenaInfoProvider ) :
+                                                          const shared_ptr<IArenaInfoProvider> arenaInfoProvider,
+                                                          const shared_ptr<IGameEventAggregator> eventAggregator ) :
    _consoleBuffer( consoleBuffer ),
    _renderConfig( renderConfig ),
    _playerInfoProvider( playerInfoProvider ),
    _arenaInfoProvider( arenaInfoProvider ),
+   _eventAggregator( eventAggregator ),
    _arenaCoordConverterX( renderConfig->ArenaCharWidth / (double)arenaInfoProvider->GetWidth() ),
    _arenaCoordConverterY( renderConfig->ArenaCharHeight / (double)arenaInfoProvider->GetHeight() )
 {
+   eventAggregator->RegisterEventHandler( GameEvent::GameStarted, std::bind( &PlayingStateConsoleRenderer::HandleGameStartedEvent, this ) );
 }
 
 void PlayingStateConsoleRenderer::Render()
@@ -34,6 +39,11 @@ void PlayingStateConsoleRenderer::Render()
    DrawArenaFence();
    DrawArenaSprites();
    DrawPlayer();
+}
+
+void PlayingStateConsoleRenderer::HandleGameStartedEvent()
+{
+   // TODO: show a blinking animation
 }
 
 void PlayingStateConsoleRenderer::DrawArenaFence()

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -11,6 +11,7 @@ namespace MegaManLofi
    class IPlayerInfoProvider;
    class IArenaInfoProvider;
    class IGameEventAggregator;
+   class IFrameRateProvider;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
@@ -19,13 +20,15 @@ namespace MegaManLofi
                                    const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                    const std::shared_ptr<IPlayerInfoProvider> playerInfoProvider,
                                    const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
-                                   const std::shared_ptr<IGameEventAggregator> eventAggregator );
+                                   const std::shared_ptr<IGameEventAggregator> eventAggregator,
+                                   const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
       void Render() override;
-      bool HasFocus() const override { return false; }
+      bool HasFocus() const override;
 
    private:
       void HandleGameStartedEvent();
+      void DrawGameStartAnimation();
       void DrawArenaFence();
       void DrawArenaSprites();
       void DrawPlayer();
@@ -36,8 +39,12 @@ namespace MegaManLofi
       const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
       const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
       double _arenaCoordConverterX;
       double _arenaCoordConverterY;
+
+      bool _isAnimatingGameStart;
+      double _gameStartBlinkElapsedSeconds;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -20,6 +20,7 @@ namespace MegaManLofi
                                    const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider );
 
       void Render() override;
+      bool HasFocus() const override { return false; }
 
    private:
       void DrawArenaFence();

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -10,6 +10,7 @@ namespace MegaManLofi
    class ConsoleRenderConfig;
    class IPlayerInfoProvider;
    class IArenaInfoProvider;
+   class IGameEventAggregator;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
@@ -17,12 +18,14 @@ namespace MegaManLofi
       PlayingStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                    const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                    const std::shared_ptr<IPlayerInfoProvider> playerInfoProvider,
-                                   const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider );
+                                   const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
+                                   const std::shared_ptr<IGameEventAggregator> eventAggregator );
 
       void Render() override;
       bool HasFocus() const override { return false; }
 
    private:
+      void HandleGameStartedEvent();
       void DrawArenaFence();
       void DrawArenaSprites();
       void DrawPlayer();
@@ -32,6 +35,7 @@ namespace MegaManLofi
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
       const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
+      const std::shared_ptr<IGameEventAggregator> _eventAggregator;
 
       double _arenaCoordConverterX;
       double _arenaCoordConverterY;

--- a/MegaManLofi/StartupStateConsoleRenderer.h
+++ b/MegaManLofi/StartupStateConsoleRenderer.h
@@ -18,6 +18,7 @@ namespace MegaManLofi
                                    const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
       void Render() override;
+      bool HasFocus() const override { return false; }
 
    private:
       void DrawKeyBindings( short middleX, short top ) const;

--- a/MegaManLofiTests/GameRendererTests.cpp
+++ b/MegaManLofiTests/GameRendererTests.cpp
@@ -35,6 +35,7 @@ public:
       _renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
 
       ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
+      ON_CALL( *_startupStateRendererMock, HasFocus() ).WillByDefault( Return( false ) );
    }
 
    void BuildRenderer()
@@ -116,11 +117,20 @@ TEST_F( GameRendererTests, Render_StateWasRendered_FlipsConsoleBuffer )
    _renderer->Render();
 }
 
-TEST_F( GameRendererTests, HasFocus_Always_ReturnsFalse )
+TEST_F( GameRendererTests, HasFocus_StateRendererDoesNotHaveFocus_ReturnsFalse )
 {
    BuildRenderer();
 
    EXPECT_FALSE( _renderer->HasFocus() );
+}
+
+TEST_F( GameRendererTests, HasFocus_StateRendererHasFocus_ReturnsTrue )
+{
+   BuildRenderer();
+
+   EXPECT_CALL( *_startupStateRendererMock, HasFocus() ).WillOnce( Return( true ) );
+
+   EXPECT_TRUE( _renderer->HasFocus() );
 }
 
 TEST_F( GameRendererTests, ShutdownEventRaised_Always_CleansUpConsoleBuffer )

--- a/MegaManLofiTests/GameRendererTests.cpp
+++ b/MegaManLofiTests/GameRendererTests.cpp
@@ -116,6 +116,13 @@ TEST_F( GameRendererTests, Render_StateWasRendered_FlipsConsoleBuffer )
    _renderer->Render();
 }
 
+TEST_F( GameRendererTests, HasFocus_Always_ReturnsFalse )
+{
+   BuildRenderer();
+
+   EXPECT_FALSE( _renderer->HasFocus() );
+}
+
 TEST_F( GameRendererTests, ShutdownEventRaised_Always_CleansUpConsoleBuffer )
 {
    BuildRenderer();

--- a/MegaManLofiTests/GameRunnerTests.cpp
+++ b/MegaManLofiTests/GameRunnerTests.cpp
@@ -106,7 +106,7 @@ TEST_F( GameRunnerTests, Run_EveryLoop_StartsFrameClock )
    runWorker.join();
 }
 
-TEST_F( GameRunnerTests, Run_EveryLoop_HandlesInput )
+TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererDoesNotHaveFocus_HandlesInput )
 {
    thread runWorker( RunWorker, _runner );
    while( FrameCount < 10 ) { }
@@ -115,6 +115,19 @@ TEST_F( GameRunnerTests, Run_EveryLoop_HandlesInput )
    runWorker.join();
 
    EXPECT_EQ( HandleInputCount, FrameCount );
+}
+
+TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererHasFocus_DoesNotHandleInput )
+{
+   ON_CALL( *_rendererMock, HasFocus() ).WillByDefault( Return( true ) );
+
+   thread runWorker( RunWorker, _runner );
+   while( FrameCount < 10 ) { }
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+
+   EXPECT_EQ( HandleInputCount, 0 );
 }
 
 TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererDoesNotHaveFocus_TicksGame )
@@ -128,7 +141,7 @@ TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererDoesNotHaveFocus_TicksGame )
    EXPECT_EQ( RunFrameCount, FrameCount );
 }
 
-TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererHasFocus_TicksGame )
+TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererHasFocus_DoesNotTickGame )
 {
    ON_CALL( *_rendererMock, HasFocus() ).WillByDefault( Return( true ) );
 

--- a/MegaManLofiTests/GameRunnerTests.cpp
+++ b/MegaManLofiTests/GameRunnerTests.cpp
@@ -65,6 +65,7 @@ public:
       ON_CALL( *_clockMock, WaitForNextFrame() ).WillByDefault( Invoke( IncrementFrameCount ) );
       ON_CALL( *_inputHandlerMock, HandleInput() ).WillByDefault( Invoke( IncrementHandleInputCount ) );
       ON_CALL( *_gameMock, Tick() ).WillByDefault( Invoke( IncrementRunFrameCount ) );
+      ON_CALL( *_rendererMock, HasFocus() ).WillByDefault( Return( false ) );
       ON_CALL( *_rendererMock, Render() ).WillByDefault( Invoke( IncrementRenderCount ) );
       ON_CALL( *_frameActionRegistryMock, Clear() ).WillByDefault( Invoke( IncrementFrameActionRegistryClearCount ) );
    }
@@ -116,7 +117,7 @@ TEST_F( GameRunnerTests, Run_EveryLoop_HandlesInput )
    EXPECT_EQ( HandleInputCount, FrameCount );
 }
 
-TEST_F( GameRunnerTests, Run_EveryLoop_TicksGame )
+TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererDoesNotHaveFocus_TicksGame )
 {
    thread runWorker( RunWorker, _runner );
    while( FrameCount < 10 ) { }
@@ -125,6 +126,19 @@ TEST_F( GameRunnerTests, Run_EveryLoop_TicksGame )
    runWorker.join();
 
    EXPECT_EQ( RunFrameCount, FrameCount );
+}
+
+TEST_F( GameRunnerTests, Run_EveryLoopWhenRendererHasFocus_TicksGame )
+{
+   ON_CALL( *_rendererMock, HasFocus() ).WillByDefault( Return( true ) );
+
+   thread runWorker( RunWorker, _runner );
+   while( FrameCount < 10 ) { }
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+
+   EXPECT_EQ( RunFrameCount, 0 );
 }
 
 TEST_F( GameRunnerTests, Run_EveryLoop_RendersGame )

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -65,9 +65,11 @@ TEST_F( GameTests, Constructor_Always_AssignsPhysicsObjects )
    BuildGame();
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
+TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlayingAndRaisesEvent )
 {
    BuildGame();
+
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::GameStarted ) );
 
    _game->ExecuteCommand( GameCommand::Start );
 

--- a/MegaManLofiTests/mock_GameRenderer.h
+++ b/MegaManLofiTests/mock_GameRenderer.h
@@ -8,4 +8,5 @@ class mock_GameRenderer : public MegaManLofi::IGameRenderer
 {
 public:
    MOCK_METHOD( void, Render, ( ), ( override ) );
+   MOCK_METHOD( bool, HasFocus, ( ), ( const, override ) );
 };


### PR DESCRIPTION
This adds the ability for any state renderer to have "focus" whenever it wants, meaning the game is essentially paused and will not handle input or Tick the game until it gives focus back. This is handy for showing certain animations, such as flashing a "GET READY!" message before the game starts, and a death animation. I haven't added the death thing yet, but there is now a blinking message when the game starts.