### PR TITLE
Arena fills the whole console

### DIFF
--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -16,11 +16,11 @@ namespace MegaManLofi
       short ConsoleWidth = 0;
       short ConsoleHeight = 0;
 
+      short ArenaX = 0;
+      short ArenaY = 0;
+
       short ArenaCharWidth = 0;
       short ArenaCharHeight = 0;
-
-      short ArenaFenceX = 0;
-      short ArenaFenceY = 0;
 
       double GameStartSingleBlinkSeconds = 0;
       int GameStartBlinkCount = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -142,11 +142,11 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->ConsoleWidth = 120;
    renderConfig->ConsoleHeight = 30;
 
-   renderConfig->ArenaCharWidth = 114;
-   renderConfig->ArenaCharHeight = 24;
+   renderConfig->ArenaX = 0;
+   renderConfig->ArenaY = 0;
 
-   renderConfig->ArenaFenceX = 2;
-   renderConfig->ArenaFenceY = 3;
+   renderConfig->ArenaCharWidth = 120;
+   renderConfig->ArenaCharHeight = 30;
 
    // "GET READY!" message should blink for 2 seconds
    renderConfig->GameStartSingleBlinkSeconds = .25;
@@ -169,13 +169,13 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->ArenaSprites[1].Pixels.push_back( { '-', ConsoleColor::DarkGrey } );
 
    // platform on the 13th row, extending 50 tiles from the left edge of the arena
-   for ( int i = ( 114 * 12 ); i < ( ( 114 * 12 ) + 50 ); i++ )
+   for ( int i = ( 120 * 12 ); i < ( ( 120 * 12 ) + 50 ); i++ )
    {
       renderConfig->ArenaSpriteMap[i] = 0;
    }
 
    // platform on the 21st row, extending 50 tiles from the right edge of the arena
-   for ( int i = ( ( 114 * 21 ) - 1 ); i > ( ( 114 * 21 ) - 50 ); i-- )
+   for ( int i = ( ( 120 * 21 ) - 1 ); i > ( ( 120 * 21 ) - 50 ); i-- )
    {
       renderConfig->ArenaSpriteMap[i] = 1;
    }
@@ -272,8 +272,8 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
    arenaConfig->DefaultTileWidth = 38;
    arenaConfig->DefaultTileHeight = 78;
 
-   arenaConfig->DefaultHorizontalTiles = 114;
-   arenaConfig->DefaultVerticalTiles = 24;
+   arenaConfig->DefaultHorizontalTiles = 120;
+   arenaConfig->DefaultVerticalTiles = 30;
 
    // start with all passable tiles
    for ( int i = 0; i < arenaConfig->DefaultHorizontalTiles * arenaConfig->DefaultVerticalTiles; i++ )
@@ -282,13 +282,13 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
    }
 
    // platform on the 13th row, extending 50 tiles from the left edge of the arena
-   for ( int i = ( 114 * 12 ); i < ( ( 114 * 12 ) + 50 ); i++ )
+   for ( int i = ( 120 * 12 ); i < ( ( 120 * 12 ) + 50 ); i++ )
    {
       arenaConfig->DefaultTiles[i] = { false, false, false, false };
    }
 
    // platform on the 21st row, extending 50 tiles from the right edge of the arena
-   for ( int i = ( ( 114 * 21 ) - 1 ); i > ( ( 114 * 21 ) - 50 ); i-- )
+   for ( int i = ( ( 120 * 21 ) - 1 ); i > ( ( 120 * 21 ) - 50 ); i-- )
    {
       arenaConfig->DefaultTiles[i] = { true, true, true, false }; // passable in all ways except down
    }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -36,6 +36,7 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
 
 void PlayingStateConsoleRenderer::Render()
 {
+   // TODO: move these into a config somewhere
    _consoleBuffer->SetDefaultBackgroundColor( ConsoleColor::Black );
    _consoleBuffer->SetDefaultForegroundColor( ConsoleColor::White );
 
@@ -45,9 +46,6 @@ void PlayingStateConsoleRenderer::Render()
    }
    else
    {
-      _consoleBuffer->Draw( 2, 1, "Use the direction buttons to move around, or press the select button to quit." );
-
-      DrawArenaFence();
       DrawArenaSprites();
       DrawPlayer();
    }
@@ -79,29 +77,6 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
    }
 }
 
-void PlayingStateConsoleRenderer::DrawArenaFence()
-{
-   // corners
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX, _renderConfig->ArenaFenceY, ',');
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, _renderConfig->ArenaFenceY, '.' );
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '\'' );
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '\'' );
-
-   // top and bottom fences
-   for ( int left = _renderConfig->ArenaFenceX; left < _renderConfig->ArenaCharWidth + 1; left++ )
-   {
-      _consoleBuffer->Draw( left + 1, _renderConfig->ArenaFenceY, '-' );
-      _consoleBuffer->Draw( left + 1, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '-' );
-   }
-
-   // side fences
-   for ( int top = _renderConfig->ArenaFenceY + 1; top < _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1; top++ )
-   {
-      _consoleBuffer->Draw( _renderConfig->ArenaFenceX, top, '|' );
-      _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, top, '|' );
-   }
-}
-
 void PlayingStateConsoleRenderer::DrawArenaSprites()
 {
    for ( int i = 0; i < _renderConfig->ArenaCharHeight; i++ )
@@ -113,8 +88,8 @@ void PlayingStateConsoleRenderer::DrawArenaSprites()
 
          if ( spriteIterator != _renderConfig->ArenaSpriteMap.end() )
          {
-            auto x = _renderConfig->ArenaFenceX + j + 1;
-            auto y = _renderConfig->ArenaFenceY + i + 1;
+            auto x = _renderConfig->ArenaX + j;
+            auto y = _renderConfig->ArenaY + i;
             _consoleBuffer->Draw( x, y, _renderConfig->ArenaSprites[ spriteIterator->second ] );
          }
       }
@@ -126,8 +101,8 @@ void PlayingStateConsoleRenderer::DrawPlayer()
    auto convertedPlayerX = (short)( _arenaInfoProvider->GetPlayerPositionX() * _arenaCoordConverterX );
    auto convertedPlayerY = (short)( _arenaInfoProvider->GetPlayerPositionY() * _arenaCoordConverterY );
 
-   auto playerX = convertedPlayerX + _renderConfig->ArenaFenceX + 1;
-   auto playerY = convertedPlayerY + _renderConfig->ArenaFenceY + 1;
+   auto playerX = convertedPlayerX + _renderConfig->ArenaX;
+   auto playerY = convertedPlayerY + _renderConfig->ArenaY;
 
    auto direction = _playerInfoProvider->GetDirection();
    auto sprite = _playerInfoProvider->IsMoving() ? _renderConfig->PlayerMovingSpriteMap[direction] : _renderConfig->PlayerStaticSpriteMap[direction];

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -29,7 +29,6 @@ namespace MegaManLofi
    private:
       void HandleGameStartedEvent();
       void DrawGameStartAnimation();
-      void DrawArenaFence();
       void DrawArenaSprites();
       void DrawPlayer();
 


### PR DESCRIPTION
There's really no point in drawing a fence around the arena, it should just fill the whole screen. Later on we can add things like a life bar and other stats on top of that (or make a small space at the top for it).