### PR TITLE
Scroll the arena inside a viewport

### DIFF
--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <vector>
 
 #include "IGameRenderConfig.h"
 #include "ConsoleSprite.h"
@@ -34,7 +35,7 @@ namespace MegaManLofi
       std::map<Direction, ConsoleSprite> PlayerStaticSpriteMap;
       std::map<Direction, ConsoleSprite> PlayerMovingSpriteMap;
 
-      std::map<int, ConsoleSprite> ArenaSprites;
-      std::map<int, int> ArenaSpriteMap;
+      std::map<int, ConsoleSprite> ArenaSpriteMap;
+      std::vector<int> ArenaSprites;
    };
 }

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -16,11 +16,14 @@ namespace MegaManLofi
       short ConsoleWidth = 0;
       short ConsoleHeight = 0;
 
-      short ArenaX = 0;
-      short ArenaY = 0;
+      short ArenaViewportX = 0;
+      short ArenaViewportY = 0;
 
-      short ArenaCharWidth = 0;
-      short ArenaCharHeight = 0;
+      long long ArenaCharWidth = 0;
+      long long ArenaCharHeight = 0;
+
+      short ArenaViewportWidthChar = 0;
+      short ArenaViewportHeightChar = 0;
 
       double GameStartSingleBlinkSeconds = 0;
       int GameStartBlinkCount = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -171,14 +171,14 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->ArenaSprites[1].Height = 1;
    renderConfig->ArenaSprites[1].Pixels.push_back( { '-', ConsoleColor::DarkGrey } );
 
-   // platform on the 13th row, extending 50 tiles from the left edge of the arena
-   for ( int i = ( 120 * 12 ); i < ( ( 120 * 12 ) + 50 ); i++ )
+   // platform on the 13th row, extending 100 tiles from the left edge of the arena
+   for ( int i = ( 360 * 12 ); i < ( ( 360 * 12 ) + 100 ); i++ )
    {
       renderConfig->ArenaSpriteMap[i] = 0;
    }
 
    // platform on the 21st row, extending 50 tiles from the right edge of the arena
-   for ( int i = ( ( 120 * 21 ) - 1 ); i > ( ( 120 * 21 ) - 50 ); i-- )
+   for ( int i = ( ( 360 * 21 ) - 1 ); i > ( ( 360 * 21 ) - 50 ); i-- )
    {
       renderConfig->ArenaSpriteMap[i] = 1;
    }
@@ -271,11 +271,11 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
 {
    auto arenaConfig = make_shared<ArenaConfig>();
 
-   // this results in a 4560 x 2340 arena, which translates super well to a 120 x 30 console
+   // this results in a 4560 x 2340 unit viewport, which translates super well to a 120 x 30 character console
    arenaConfig->DefaultTileWidth = 38;
    arenaConfig->DefaultTileHeight = 78;
 
-   arenaConfig->DefaultHorizontalTiles = 120;
+   arenaConfig->DefaultHorizontalTiles = 360;
    arenaConfig->DefaultVerticalTiles = 30;
 
    // start with all passable tiles
@@ -284,14 +284,14 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
       arenaConfig->DefaultTiles.push_back( { true, true, true, true } );
    }
 
-   // platform on the 13th row, extending 50 tiles from the left edge of the arena
-   for ( int i = ( 120 * 12 ); i < ( ( 120 * 12 ) + 50 ); i++ )
+   // platform on the 13th row, extending 100 tiles from the left edge of the arena
+   for ( int i = ( 360 * 12 ); i < ( ( 360 * 12 ) + 100 ); i++ )
    {
       arenaConfig->DefaultTiles[i] = { false, false, false, false };
    }
 
    // platform on the 21st row, extending 50 tiles from the right edge of the arena
-   for ( int i = ( ( 120 * 21 ) - 1 ); i > ( ( 120 * 21 ) - 50 ); i-- )
+   for ( int i = ( ( 360 * 21 ) - 1 ); i > ( ( 360 * 21 ) - 50 ); i-- )
    {
       arenaConfig->DefaultTiles[i] = { true, true, true, false }; // passable in all ways except down
    }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -162,25 +162,30 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->PlayerMovingSpriteMap = PlayerSpriteGenerator::GenerateMovingSpriteMap();
 
    // ground that is impassable in all directions
-   renderConfig->ArenaSprites[0].Width = 1;
-   renderConfig->ArenaSprites[0].Height = 1;
-   renderConfig->ArenaSprites[0].Pixels.push_back( { '=', ConsoleColor::DarkGrey } );
+   renderConfig->ArenaSpriteMap[0].Width = 1;
+   renderConfig->ArenaSpriteMap[0].Height = 1;
+   renderConfig->ArenaSpriteMap[0].Pixels.push_back( { '=', ConsoleColor::DarkGrey } );
 
    // ground that is only impassable downward
-   renderConfig->ArenaSprites[1].Width = 1;
-   renderConfig->ArenaSprites[1].Height = 1;
-   renderConfig->ArenaSprites[1].Pixels.push_back( { '-', ConsoleColor::DarkGrey } );
+   renderConfig->ArenaSpriteMap[1].Width = 1;
+   renderConfig->ArenaSpriteMap[1].Height = 1;
+   renderConfig->ArenaSpriteMap[1].Pixels.push_back( { '-', ConsoleColor::DarkGrey } );
+
+   for ( int i = 0; i < 360 * 30; i++ )
+   {
+      renderConfig->ArenaSprites.push_back( -1 );
+   }
 
    // platform on the 13th row, extending 100 tiles from the left edge of the arena
    for ( int i = ( 360 * 12 ); i < ( ( 360 * 12 ) + 100 ); i++ )
    {
-      renderConfig->ArenaSpriteMap[i] = 0;
+      renderConfig->ArenaSprites[i] = 0;
    }
 
    // platform on the 21st row, extending 50 tiles from the right edge of the arena
    for ( int i = ( ( 360 * 21 ) - 1 ); i > ( ( 360 * 21 ) - 50 ); i-- )
    {
-      renderConfig->ArenaSpriteMap[i] = 1;
+      renderConfig->ArenaSprites[i] = 1;
    }
 
    return renderConfig;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -142,11 +142,14 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->ConsoleWidth = 120;
    renderConfig->ConsoleHeight = 30;
 
-   renderConfig->ArenaX = 0;
-   renderConfig->ArenaY = 0;
+   renderConfig->ArenaViewportX = 0;
+   renderConfig->ArenaViewportY = 0;
 
-   renderConfig->ArenaCharWidth = 120;
-   renderConfig->ArenaCharHeight = 30;
+   renderConfig->ArenaCharWidth = 38;
+   renderConfig->ArenaCharHeight = 78;
+
+   renderConfig->ArenaViewportWidthChar = 120;
+   renderConfig->ArenaViewportHeightChar = 30;
 
    // "GET READY!" message should blink for 2 seconds
    renderConfig->GameStartSingleBlinkSeconds = .25;
@@ -268,7 +271,7 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
 {
    auto arenaConfig = make_shared<ArenaConfig>();
 
-   // this results in a 4332 x 1872 arena, which translates super well to a 120 x 30 console
+   // this results in a 4560 x 2340 arena, which translates super well to a 120 x 30 console
    arenaConfig->DefaultTileWidth = 38;
    arenaConfig->DefaultTileHeight = 78;
 

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -88,21 +88,33 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
 void PlayingStateConsoleRenderer::DrawArenaSprites()
 {
-   auto spriteOffsetX = (int)min( max( _viewportOffsetX / _renderConfig->ArenaCharWidth, 0ll ), _viewportOffsetX + _viewportWidth );
-   auto spriteOffsetY = (int)min( max( _viewportOffsetY / _renderConfig->ArenaCharHeight, 0ll ), _viewportOffsetY + _viewportHeight );
+   auto spriteOffsetX = (int)max( _viewportOffsetX / _renderConfig->ArenaCharWidth, 0ll );
+   auto spriteOffsetY = (int)max( _viewportOffsetY / _renderConfig->ArenaCharHeight, 0ll );
+   auto arenaWidthChar = (int)( _arenaInfoProvider->GetWidth() / _renderConfig->ArenaCharWidth );
+   auto arenaHeightChar = (int)( _arenaInfoProvider->GetHeight() / _renderConfig->ArenaCharHeight );
+
+   if ( ( spriteOffsetX + _renderConfig->ArenaViewportWidthChar ) > arenaWidthChar )
+   {
+      spriteOffsetX = arenaWidthChar - _renderConfig->ArenaViewportWidthChar;
+   }
+   if ( ( spriteOffsetY + _renderConfig->ArenaViewportHeightChar ) > arenaHeightChar )
+   {
+      spriteOffsetY = arenaHeightChar - _renderConfig->ArenaViewportHeightChar;
+   }
    
-   for ( int y = spriteOffsetY; y < _renderConfig->ArenaViewportHeightChar; y++ )
+   // TODO: this will probably crash if the arena is smaller than the viewport
+   for ( int y = 0; y < _renderConfig->ArenaViewportHeightChar; y++ )
    {
       for ( int x = 0; x < _renderConfig->ArenaViewportWidthChar; x++ )
       {
-         auto arenaIndex = ( y * _renderConfig->ArenaViewportWidthChar ) + x;
-         auto spriteIterator = _renderConfig->ArenaSpriteMap.find( arenaIndex );
+         auto spriteIndex = ( ( y + spriteOffsetY ) * arenaWidthChar ) + ( x + spriteOffsetX );
+         auto spriteIterator = _renderConfig->ArenaSpriteMap.find( spriteIndex );
 
          if ( spriteIterator != _renderConfig->ArenaSpriteMap.end() )
          {
-            auto spriteX = _renderConfig->ArenaViewportX + x;
-            auto spriteY = _renderConfig->ArenaViewportY + y;
-            _consoleBuffer->Draw( spriteX, spriteY, _renderConfig->ArenaSprites[ spriteIterator->second ] );
+            auto viewportX = _renderConfig->ArenaViewportX + x;
+            auto viewportY = _renderConfig->ArenaViewportY + y;
+            _consoleBuffer->Draw( viewportX, viewportY, _renderConfig->ArenaSprites[ spriteIterator->second ] );
          }
       }
    }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -26,8 +26,10 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _arenaInfoProvider( arenaInfoProvider ),
    _eventAggregator( eventAggregator ),
    _frameRateProvider( frameRateProvider ),
-   _arenaCoordConverterX( renderConfig->ArenaCharWidth / (double)arenaInfoProvider->GetWidth() ),
-   _arenaCoordConverterY( renderConfig->ArenaCharHeight / (double)arenaInfoProvider->GetHeight() ),
+   _viewportWidth( _renderConfig->ArenaViewportWidthChar * _renderConfig->ArenaCharWidth ),
+   _viewportHeight( _renderConfig->ArenaViewportHeightChar * _renderConfig->ArenaCharHeight ),
+   _viewportOffsetX( 0 ),
+   _viewportOffsetY( 0 ),
    _isAnimatingGameStart( false ),
    _gameStartBlinkElapsedSeconds( 0 )
 {
@@ -46,6 +48,7 @@ void PlayingStateConsoleRenderer::Render()
    }
    else
    {
+      CalculateViewportOffsets();
       DrawArenaSprites();
       DrawPlayer();
    }
@@ -62,13 +65,19 @@ void PlayingStateConsoleRenderer::HandleGameStartedEvent()
    _gameStartBlinkElapsedSeconds = 0;
 }
 
+void PlayingStateConsoleRenderer::CalculateViewportOffsets()
+{
+   _viewportOffsetX = _arenaInfoProvider->GetPlayerPositionX() - ( _viewportWidth / 2 );
+   _viewportOffsetY = _arenaInfoProvider->GetPlayerPositionY() - ( _viewportHeight / 2 );
+}
+
 void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 {
    _gameStartBlinkElapsedSeconds += 1 / (double)_frameRateProvider->GetFramesPerSecond();
 
    if ( (int)( _gameStartBlinkElapsedSeconds / _renderConfig->GameStartSingleBlinkSeconds ) % 2 == 0 )
    {
-      _consoleBuffer->Draw( ( _renderConfig->ArenaCharWidth / 2 ) - 5, _renderConfig->ArenaCharHeight / 2, "GET READY!" );
+      _consoleBuffer->Draw( ( _renderConfig->ArenaViewportWidthChar / 2 ) - 5, _renderConfig->ArenaViewportHeightChar / 2, "GET READY!" );
    }
 
    if ( _gameStartBlinkElapsedSeconds >= ( _renderConfig->GameStartSingleBlinkSeconds * _renderConfig->GameStartBlinkCount ) )
@@ -79,18 +88,21 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
 void PlayingStateConsoleRenderer::DrawArenaSprites()
 {
-   for ( int i = 0; i < _renderConfig->ArenaCharHeight; i++ )
+   auto spriteOffsetX = (int)min( max( _viewportOffsetX / _renderConfig->ArenaCharWidth, 0ll ), _viewportOffsetX + _viewportWidth );
+   auto spriteOffsetY = (int)min( max( _viewportOffsetY / _renderConfig->ArenaCharHeight, 0ll ), _viewportOffsetY + _viewportHeight );
+   
+   for ( int y = spriteOffsetY; y < _renderConfig->ArenaViewportHeightChar; y++ )
    {
-      for ( int j = 0; j < _renderConfig->ArenaCharWidth; j++ )
+      for ( int x = 0; x < _renderConfig->ArenaViewportWidthChar; x++ )
       {
-         auto arenaIndex = ( i * _renderConfig->ArenaCharWidth ) + j;
+         auto arenaIndex = ( y * _renderConfig->ArenaViewportWidthChar ) + x;
          auto spriteIterator = _renderConfig->ArenaSpriteMap.find( arenaIndex );
 
          if ( spriteIterator != _renderConfig->ArenaSpriteMap.end() )
          {
-            auto x = _renderConfig->ArenaX + j;
-            auto y = _renderConfig->ArenaY + i;
-            _consoleBuffer->Draw( x, y, _renderConfig->ArenaSprites[ spriteIterator->second ] );
+            auto spriteX = _renderConfig->ArenaViewportX + x;
+            auto spriteY = _renderConfig->ArenaViewportY + y;
+            _consoleBuffer->Draw( spriteX, spriteY, _renderConfig->ArenaSprites[ spriteIterator->second ] );
          }
       }
    }
@@ -98,14 +110,32 @@ void PlayingStateConsoleRenderer::DrawArenaSprites()
 
 void PlayingStateConsoleRenderer::DrawPlayer()
 {
-   auto convertedPlayerX = (short)( _arenaInfoProvider->GetPlayerPositionX() * _arenaCoordConverterX );
-   auto convertedPlayerY = (short)( _arenaInfoProvider->GetPlayerPositionY() * _arenaCoordConverterY );
+   auto playerDrawX = _arenaInfoProvider->GetPlayerPositionX() - _viewportOffsetX;
+   auto playerDrawY = _arenaInfoProvider->GetPlayerPositionY() - _viewportOffsetY;
 
-   auto playerX = convertedPlayerX + _renderConfig->ArenaX;
-   auto playerY = convertedPlayerY + _renderConfig->ArenaY;
+   if ( _viewportOffsetX < 0 )
+   {
+      playerDrawX += _viewportOffsetX;
+   }
+   else if ( _viewportOffsetX + _viewportWidth > _arenaInfoProvider->GetWidth() )
+   {
+      playerDrawX += ( _viewportOffsetX + _viewportWidth ) - _arenaInfoProvider->GetWidth();
+   }
+
+   if ( _viewportOffsetY < 0 )
+   {
+      playerDrawY += _viewportOffsetY;
+   }
+   else if ( _viewportOffsetY + _viewportHeight > _arenaInfoProvider->GetHeight() )
+   {
+      playerDrawY += ( _viewportOffsetY + _viewportHeight ) - _arenaInfoProvider->GetHeight();
+   }
+
+   auto convertedPlayerDrawX = (short)( playerDrawX / _renderConfig->ArenaCharWidth );
+   auto convertedPlayerDrawY = (short)( playerDrawY / _renderConfig->ArenaCharHeight );
 
    auto direction = _playerInfoProvider->GetDirection();
    auto sprite = _playerInfoProvider->IsMoving() ? _renderConfig->PlayerMovingSpriteMap[direction] : _renderConfig->PlayerStaticSpriteMap[direction];
 
-   _consoleBuffer->Draw( playerX, playerY, sprite );
+   _consoleBuffer->Draw( convertedPlayerDrawX, convertedPlayerDrawY, sprite );
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -108,13 +108,13 @@ void PlayingStateConsoleRenderer::DrawArenaSprites()
       for ( int x = 0; x < _renderConfig->ArenaViewportWidthChar; x++ )
       {
          auto spriteIndex = ( ( y + spriteOffsetY ) * arenaWidthChar ) + ( x + spriteOffsetX );
-         auto spriteIterator = _renderConfig->ArenaSpriteMap.find( spriteIndex );
+         auto spriteId = _renderConfig->ArenaSprites[spriteIndex];
 
-         if ( spriteIterator != _renderConfig->ArenaSpriteMap.end() )
+         if ( spriteId != -1 )
          {
             auto viewportX = _renderConfig->ArenaViewportX + x;
             auto viewportY = _renderConfig->ArenaViewportY + y;
-            _consoleBuffer->Draw( viewportX, viewportY, _renderConfig->ArenaSprites[ spriteIterator->second ] );
+            _consoleBuffer->Draw( viewportX, viewportY, _renderConfig->ArenaSpriteMap[ spriteId ] );
          }
       }
    }

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -28,6 +28,7 @@ namespace MegaManLofi
 
    private:
       void HandleGameStartedEvent();
+      void CalculateViewportOffsets();
       void DrawGameStartAnimation();
       void DrawArenaSprites();
       void DrawPlayer();
@@ -40,8 +41,10 @@ namespace MegaManLofi
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
-      double _arenaCoordConverterX;
-      double _arenaCoordConverterY;
+      long long _viewportWidth;
+      long long _viewportHeight;
+      long long _viewportOffsetX;
+      long long _viewportOffsetY;
 
       bool _isAnimatingGameStart;
       double _gameStartBlinkElapsedSeconds;


### PR DESCRIPTION
The arena used to be purposely exactly the same size as the console window, this introduces a "viewport", so the arena can be any size and the viewport will scroll along with the player.

The only problem is this doesn't allow for an arena smaller than the viewport, I'll have to fix that later.