### PR TITLE
Game Over screen and pitfall death

### DIFF
--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -6,14 +6,20 @@ using namespace std;
 using namespace MegaManLofi;
 
 Arena::Arena( const shared_ptr<ArenaConfig> config ) :
+   _config( config ),
    _tiles( config->DefaultTiles ),
    _width( config->DefaultTileWidth* config->DefaultHorizontalTiles ),
    _height( config->DefaultTileHeight* config->DefaultVerticalTiles ),
-   _playerPositionX( config->DefaultPlayerPositionX ),
-   _playerPositionY( config->DefaultPlayerPositionY ),
    _tileWidth( config->DefaultTileWidth ),
    _tileHeight( config->DefaultTileHeight ),
    _horizontalTiles( config->DefaultHorizontalTiles ),
    _verticalTiles( config->DefaultVerticalTiles )
 {
+   Reset();
+}
+
+void Arena::Reset()
+{
+   _playerPositionX = _config->DefaultPlayerPositionX;
+   _playerPositionY = _config->DefaultPlayerPositionY;
 }

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -14,6 +14,8 @@ namespace MegaManLofi
    public:
       Arena( const std::shared_ptr<ArenaConfig> config );
 
+      void Reset();
+
       long long GetWidth() const override { return _width; }
       long long GetHeight() const override { return _height; }
 
@@ -32,6 +34,8 @@ namespace MegaManLofi
       const ArenaTile& GetTile( long long index ) const override { return _tiles[index]; }
 
    private:
+      const std::shared_ptr<ArenaConfig> _config;
+
       std::vector<ArenaTile> _tiles;
 
       long long _width;

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -1,17 +1,21 @@
 #include "ArenaPhysics.h"
 #include "IFrameRateProvider.h"
 #include "IFrameActionRegistry.h"
+#include "IGameEventAggregator.h"
 #include "IPlayer.h"
 #include "IArena.h"
 #include "FrameAction.h"
+#include "GameEvent.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
 ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
-                            const shared_ptr<IFrameActionRegistry> frameActionRegistry ) :
+                            const shared_ptr<IFrameActionRegistry> frameActionRegistry,
+                            const shared_ptr<IGameEventAggregator> eventAggregator ) :
    _frameRateProvider( frameRateProvider ),
    _frameActionRegistry( frameActionRegistry ),
+   _eventAggregator( eventAggregator ),
    _arena( nullptr ),
    _player( nullptr )
 {
@@ -193,7 +197,7 @@ void ArenaPhysics::DetectPlayerTileCollisionY( long long& newPositionY )
          {
             // we've collided with the bottom edge of the arena
             newPositionY = arenaHeight - hitBox.Height;
-            _player->StopY();
+            _eventAggregator->RaiseEvent( GameEvent::Pitfall );
             break;
          }
          else if ( newPositionYBottom > bottomOccupyingTileBottomEdge )

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -7,12 +7,14 @@ namespace MegaManLofi
 {
    class IFrameRateProvider;
    class IFrameActionRegistry;
+   class IGameEventAggregator;
 
    class ArenaPhysics : public IArenaPhysics
    {
    public:
       ArenaPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
-                    const std::shared_ptr<IFrameActionRegistry> frameActionRegistry );
+                    const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
+                    const std::shared_ptr<IGameEventAggregator> eventAggregator );
 
       void AssignTo( const std::shared_ptr<IArena> arena,
                      const std::shared_ptr<IPlayer> player ) override;
@@ -30,6 +32,7 @@ namespace MegaManLofi
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
+      const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       std::shared_ptr<IArena> _arena;
       std::shared_ptr<IPlayer> _player;
 

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -29,6 +29,8 @@ namespace MegaManLofi
       double GameStartSingleBlinkSeconds = 0;
       int GameStartBlinkCount = 0;
 
+      double PitfallAnimationSeconds = 0;
+
       ConsoleColor DefaultForegroundColor = (ConsoleColor)0;
       ConsoleColor DefaultBackgroundColor = (ConsoleColor)0;
 

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -23,13 +23,16 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _arena( arena ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
-   _state( GameState::Startup )
+   _state( GameState::Startup ),
+   _nextState( GameState::Startup )
 {
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );
 }
 
 void Game::Tick()
 {
+   _state = _nextState;
+
    if ( _state == GameState::Playing )
    {
       _playerPhysics->Tick();
@@ -51,7 +54,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
          _arena->Reset();
          _playerPhysics->AssignTo( _player );
          _arenaPhysics->AssignTo( _arena, _player );
-         _state = GameState::Playing;
+         _nextState = GameState::Playing;
          _eventAggregator->RaiseEvent( GameEvent::GameStarted );
          break;
       case GameCommand::Quit:
@@ -74,5 +77,5 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
 
 void Game::HandlePitfallEvent()
 {
-   _state = GameState::GameOver;
+   _nextState = GameState::GameOver;
 }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -1,5 +1,6 @@
 #include "Game.h"
 #include "IGameEventAggregator.h"
+#include "IPlayer.h"
 #include "IArena.h"
 #include "IPlayerPhysics.h"
 #include "IArenaPhysics.h"
@@ -18,6 +19,7 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
             const shared_ptr<IPlayerPhysics> playerPhysics,
             const shared_ptr<IArenaPhysics> arenaPhysics ) :
    _eventAggregator( eventAggregator ),
+   _player( player ),
    _arena( arena ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
@@ -48,6 +50,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    switch ( command )
    {
       case GameCommand::Start:
+         _player->Reset();
          _arena->Reset();
          _state = GameState::Playing;
          _eventAggregator->RaiseEvent( GameEvent::GameStarted );

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -25,7 +25,6 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _arenaPhysics->AssignTo( arena, player );
 
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );
-   _eventAggregator->RegisterEventHandler( GameEvent::GameOver, std::bind( &Game::HandleGameOverEvent, this ) );
 }
 
 void Game::Tick()
@@ -69,11 +68,6 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
 }
 
 void Game::HandlePitfallEvent()
-{
-   _state = GameState::GameOver;
-}
-
-void Game::HandleGameOverEvent()
 {
    _state = GameState::GameOver;
 }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -25,9 +25,6 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _arenaPhysics( arenaPhysics ),
    _state( GameState::Startup )
 {
-   _playerPhysics->AssignTo( player );
-   _arenaPhysics->AssignTo( arena, player );
-
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );
 }
 
@@ -52,6 +49,8 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
       case GameCommand::Start:
          _player->Reset();
          _arena->Reset();
+         _playerPhysics->AssignTo( _player );
+         _arenaPhysics->AssignTo( _arena, _player );
          _state = GameState::Playing;
          _eventAggregator->RaiseEvent( GameEvent::GameStarted );
          break;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -24,6 +24,7 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _playerPhysics->AssignTo( player );
    _arenaPhysics->AssignTo( arena, player );
 
+   _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );
    _eventAggregator->RegisterEventHandler( GameEvent::GameOver, std::bind( &Game::HandleGameOverEvent, this ) );
 }
 
@@ -65,6 +66,11 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
          _playerPhysics->ExtendJump();
          break;
    }
+}
+
+void Game::HandlePitfallEvent()
+{
+   _state = GameState::GameOver;
 }
 
 void Game::HandleGameOverEvent()

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -1,5 +1,6 @@
 #include "Game.h"
 #include "IGameEventAggregator.h"
+#include "IArena.h"
 #include "IPlayerPhysics.h"
 #include "IArenaPhysics.h"
 #include "GameState.h"
@@ -17,6 +18,7 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
             const shared_ptr<IPlayerPhysics> playerPhysics,
             const shared_ptr<IArenaPhysics> arenaPhysics ) :
    _eventAggregator( eventAggregator ),
+   _arena( arena ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
    _state( GameState::Startup )
@@ -46,6 +48,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    switch ( command )
    {
       case GameCommand::Start:
+         _arena->Reset();
          _state = GameState::Playing;
          _eventAggregator->RaiseEvent( GameEvent::GameStarted );
          break;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -23,6 +23,8 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
 {
    _playerPhysics->AssignTo( player );
    _arenaPhysics->AssignTo( arena, player );
+
+   _eventAggregator->RegisterEventHandler( GameEvent::GameOver, std::bind( &Game::HandleGameOverEvent, this ) );
 }
 
 void Game::Tick()
@@ -63,4 +65,9 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
          _playerPhysics->ExtendJump();
          break;
    }
+}
+
+void Game::HandleGameOverEvent()
+{
+   _state = GameState::GameOver;
 }

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -43,5 +43,6 @@ namespace MegaManLofi
       const std::shared_ptr<IArenaPhysics> _arenaPhysics;
 
       GameState _state;
+      GameState _nextState;
    };
 }

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -37,6 +37,7 @@ namespace MegaManLofi
 
    private:
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
+      const std::shared_ptr<IArena> _arena;
       const std::shared_ptr<IPlayerPhysics> _playerPhysics;
       const std::shared_ptr<IArenaPhysics> _arenaPhysics;
 

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -33,6 +33,9 @@ namespace MegaManLofi
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
    private:
+      void HandleGameOverEvent();
+
+   private:
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IPlayerPhysics> _playerPhysics;
       const std::shared_ptr<IArenaPhysics> _arenaPhysics;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -34,7 +34,6 @@ namespace MegaManLofi
 
    private:
       void HandlePitfallEvent();
-      void HandleGameOverEvent();
 
    private:
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -37,6 +37,7 @@ namespace MegaManLofi
 
    private:
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
+      const std::shared_ptr<IPlayer> _player;
       const std::shared_ptr<IArena> _arena;
       const std::shared_ptr<IPlayerPhysics> _playerPhysics;
       const std::shared_ptr<IArenaPhysics> _arenaPhysics;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -33,6 +33,7 @@ namespace MegaManLofi
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
    private:
+      void HandlePitfallEvent();
       void HandleGameOverEvent();
 
    private:

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -8,7 +8,6 @@ namespace MegaManLofi
       ToggleDiagnostics,
 
       GameStarted,
-      GameOver,
 
       Pitfall
    };

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -7,6 +7,7 @@ namespace MegaManLofi
       Shutdown = 0,
       ToggleDiagnostics,
 
-      GameStarted
+      GameStarted,
+      GameOver
    };
 }

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -8,6 +8,8 @@ namespace MegaManLofi
       ToggleDiagnostics,
 
       GameStarted,
-      GameOver
+      GameOver,
+
+      Pitfall
    };
 }

--- a/MegaManLofi/GameOverStateConsoleRenderer.cpp
+++ b/MegaManLofi/GameOverStateConsoleRenderer.cpp
@@ -1,0 +1,29 @@
+#include "GameOverStateConsoleRenderer.h"
+#include "IConsoleBuffer.h"
+#include "ConsoleRenderConfig.h"
+#include "KeyboardInputConfig.h"
+#include "ConsoleColor.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+GameOverStateConsoleRenderer::GameOverStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                            const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                            const shared_ptr<KeyboardInputConfig> inputConfig ) :
+   _consoleBuffer( consoleBuffer ),
+   _renderConfig( renderConfig ),
+   _inputConfig( inputConfig )
+{
+}
+
+void GameOverStateConsoleRenderer::Render()
+{
+   _consoleBuffer->SetDefaultBackgroundColor( ConsoleColor::DarkMagenta );
+   _consoleBuffer->SetDefaultForegroundColor( ConsoleColor::White );
+
+   auto left = _renderConfig->ArenaViewportWidthChar / 2;
+   auto top = _renderConfig->ArenaViewportHeightChar / 2;
+
+   _consoleBuffer->Draw( left - 5, top - 1, "GAME OVER!" );
+   _consoleBuffer->Draw( left - 15, top + 1, "(press any button to continue)" );
+}

--- a/MegaManLofi/GameOverStateConsoleRenderer.h
+++ b/MegaManLofi/GameOverStateConsoleRenderer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+#include "IGameRenderer.h"
+
+namespace MegaManLofi
+{
+   class IConsoleBuffer;
+   class ConsoleRenderConfig;
+   class KeyboardInputConfig;
+
+   class GameOverStateConsoleRenderer : public IGameRenderer
+   {
+   public:
+      GameOverStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                    const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                    const std::shared_ptr<KeyboardInputConfig> inputConfig );
+
+      void Render() override;
+      bool HasFocus() const override { return false; }
+
+   private:
+      const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<KeyboardInputConfig> _inputConfig;
+   };
+}

--- a/MegaManLofi/GameOverStateInputHandler.cpp
+++ b/MegaManLofi/GameOverStateInputHandler.cpp
@@ -1,0 +1,22 @@
+#include "GameOverStateInputHandler.h"
+#include "IGameInputReader.h"
+#include "IGameCommandExecutor.h"
+#include "GameCommand.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+GameOverStateInputHandler::GameOverStateInputHandler( const shared_ptr<IGameInputReader> inputReader,
+                                                      const shared_ptr<IGameCommandExecutor> commandExecutor ) :
+   _inputReader( inputReader ),
+   _commandExecutor( commandExecutor )
+{
+}
+
+void GameOverStateInputHandler::HandleInput()
+{
+   if ( _inputReader->WasAnyButtonPressed() )
+   {
+      _commandExecutor->ExecuteCommand( GameCommand::Start );
+   }
+}

--- a/MegaManLofi/GameOverStateInputHandler.h
+++ b/MegaManLofi/GameOverStateInputHandler.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+#include "IGameInputHandler.h"
+
+namespace MegaManLofi
+{
+   class IGameInputReader;
+   class IGameCommandExecutor;
+
+   class GameOverStateInputHandler : public IGameInputHandler
+   {
+   public:
+      GameOverStateInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
+                                 const std::shared_ptr<IGameCommandExecutor> commandExecutor );
+
+      void HandleInput() override;
+
+   private:
+      const std::shared_ptr<IGameInputReader> _inputReader;
+      const std::shared_ptr<IGameCommandExecutor> _commandExecutor;
+   };
+}

--- a/MegaManLofi/GameState.h
+++ b/MegaManLofi/GameState.h
@@ -5,6 +5,7 @@ namespace MegaManLofi
    enum class GameState
    {
       Startup = 0,
-      Playing
+      Playing,
+      GameOver
    };
 }

--- a/MegaManLofi/IArena.h
+++ b/MegaManLofi/IArena.h
@@ -7,6 +7,8 @@ namespace MegaManLofi
    class __declspec( novtable ) IArena : public IArenaInfoProvider
    {
    public:
+      virtual void Reset() = 0;
+
       virtual void SetPlayerPositionX( long long positionX ) = 0;
       virtual void SetPlayerPositionY( long long positionY ) = 0;
    };

--- a/MegaManLofi/IPlayer.h
+++ b/MegaManLofi/IPlayer.h
@@ -10,6 +10,8 @@ namespace MegaManLofi
    class __declspec( novtable ) IPlayer : public IPlayerInfoProvider
    {
    public:
+      virtual void Reset() = 0;
+
       virtual const Rectangle& GetHitBox() const = 0;
 
       virtual void SetDirection( Direction direction ) = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -29,6 +29,7 @@
 #include "DiagnosticsConsoleRenderer.h"
 #include "StartupStateInputHandler.h"
 #include "PlayingStateInputHandler.h"
+#include "GameOverStateInputHandler.h"
 #include "GameInputHandler.h"
 #include "ConsoleBuffer.h"
 #include "StartupStateConsoleRenderer.h"
@@ -120,9 +121,11 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // input objects
    auto startupStateInputHandler = shared_ptr<StartupStateInputHandler>( new StartupStateInputHandler( keyboardInputReader, game ) );
    auto playingStateInputHandler = shared_ptr<PlayingStateInputHandler>( new PlayingStateInputHandler( keyboardInputReader, game ) );
+   auto gameOverStateInputHandler = shared_ptr<GameOverStateInputHandler>( new GameOverStateInputHandler( keyboardInputReader, game ) );
    auto inputHandler = shared_ptr<GameInputHandler>( new GameInputHandler( keyboardInputReader, game, eventAggregator ) );
    inputHandler->AddInputHandlerForGameState( GameState::Startup, startupStateInputHandler );
    inputHandler->AddInputHandlerForGameState( GameState::Playing, playingStateInputHandler );
+   inputHandler->AddInputHandlerForGameState( GameState::GameOver, gameOverStateInputHandler );
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -33,6 +33,7 @@
 #include "ConsoleBuffer.h"
 #include "StartupStateConsoleRenderer.h"
 #include "PlayingStateConsoleRenderer.h"
+#include "GameOverStateConsoleRenderer.h"
 #include "GameRenderer.h"
 #include "GameRunner.h"
 #include "GameState.h"
@@ -127,9 +128,11 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
    auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, player, arena, eventAggregator, clock ) );
+   auto gameOverStateConsoleRenderer = shared_ptr<GameOverStateConsoleRenderer>( new GameOverStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::Playing, playingStateConsoleRenderer );
+   renderer->AddRendererForGameState( GameState::GameOver, gameOverStateConsoleRenderer );
 
    // game loop
    auto runner = shared_ptr<GameRunner>( new GameRunner( eventAggregator, clock, inputHandler, renderer, frameActionRegistry, game, thread ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -163,6 +163,8 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->GameStartSingleBlinkSeconds = .25;
    renderConfig->GameStartBlinkCount = 8;
 
+   renderConfig->PitfallAnimationSeconds = 2;
+
    renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
    renderConfig->DefaultBackgroundColor = ConsoleColor::Black;
 

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -111,7 +111,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // utilities
    auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, config->PlayerPhysicsConfig ) );
-   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry ) );
+   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry, eventAggregator ) );
 
    // game objects
    auto player = shared_ptr<Player>( new Player( config->PlayerConfig, frameActionRegistry, clock ) );

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -155,6 +155,7 @@
     <ClCompile Include="ArenaPhysics.cpp" />
     <ClCompile Include="ConsoleBuffer.cpp" />
     <ClCompile Include="FrameActionRegistry.cpp" />
+    <ClCompile Include="GameOverStateConsoleRenderer.cpp" />
     <ClCompile Include="MegaManLofi.cpp" />
     <ClCompile Include="DiagnosticsConsoleRenderer.cpp" />
     <ClCompile Include="Game.cpp" />
@@ -198,6 +199,7 @@
     <ClInclude Include="GameCommand.h" />
     <ClInclude Include="GameCommandArgs.h" />
     <ClInclude Include="GameConfig.h" />
+    <ClInclude Include="GameOverStateConsoleRenderer.h" />
     <ClInclude Include="GameRenderer.h" />
     <ClInclude Include="GameEvent.h" />
     <ClInclude Include="GameEventAggregator.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="ConsoleBuffer.cpp" />
     <ClCompile Include="FrameActionRegistry.cpp" />
     <ClCompile Include="GameOverStateConsoleRenderer.cpp" />
+    <ClCompile Include="GameOverStateInputHandler.cpp" />
     <ClCompile Include="MegaManLofi.cpp" />
     <ClCompile Include="DiagnosticsConsoleRenderer.cpp" />
     <ClCompile Include="Game.cpp" />
@@ -200,6 +201,7 @@
     <ClInclude Include="GameCommandArgs.h" />
     <ClInclude Include="GameConfig.h" />
     <ClInclude Include="GameOverStateConsoleRenderer.h" />
+    <ClInclude Include="GameOverStateInputHandler.h" />
     <ClInclude Include="GameRenderer.h" />
     <ClInclude Include="GameEvent.h" />
     <ClInclude Include="GameEventAggregator.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClCompile Include="ArenaConsoleSpriteGenerator.cpp">
       <Filter>Source Files\ConfigGenerators</Filter>
     </ClCompile>
+    <ClCompile Include="GameOverStateConsoleRenderer.cpp">
+      <Filter>Source Files\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -367,6 +370,9 @@
     </ClInclude>
     <ClInclude Include="ArenaConsoleSpriteGenerator.h">
       <Filter>Header Files\ConfigGenerators</Filter>
+    </ClInclude>
+    <ClInclude Include="GameOverStateConsoleRenderer.h">
+      <Filter>Header Files\Render</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="GameOverStateConsoleRenderer.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
+    <ClCompile Include="GameOverStateInputHandler.cpp">
+      <Filter>Source Files\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -373,6 +376,9 @@
     </ClInclude>
     <ClInclude Include="GameOverStateConsoleRenderer.h">
       <Filter>Header Files\Render</Filter>
+    </ClInclude>
+    <ClInclude Include="GameOverStateInputHandler.h">
+      <Filter>Header Files\Input</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -13,15 +13,21 @@ using namespace MegaManLofi;
 Player::Player( const shared_ptr<PlayerConfig> config,
                 const shared_ptr<IFrameActionRegistry> frameActionRegistry,
                 const shared_ptr<IFrameRateProvider> frameRateProvider ) :
+   _config( config ),
    _frameActionRegistry( frameActionRegistry ),
-   _frameRateProvider( frameRateProvider ),
-   _hitBox( config->DefaultHitBox ),
-   _velocityX( config->DefaultVelocityX ),
-   _velocityY( config->DefaultVelocityY ),
-   _direction( config->DefaultDirection ),
-   _isStanding( false ),
-   _isJumping( false )
+   _frameRateProvider( frameRateProvider )
 {
+   Reset();
+}
+
+void Player::Reset()
+{
+   _hitBox = _config->DefaultHitBox;
+   _velocityX = _config->DefaultVelocityX;
+   _velocityY = _config->DefaultVelocityY;
+   _direction = _config->DefaultDirection;
+   _isStanding = false;
+   _isJumping = false;
 }
 
 bool Player::IsMoving() const

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -19,6 +19,8 @@ namespace MegaManLofi
               const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
               const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
+      void Reset();
+
       Direction GetDirection() const override { return _direction; }
 
       bool IsMoving() const override;
@@ -42,6 +44,7 @@ namespace MegaManLofi
       void StopY() override;
 
    private:
+      const std::shared_ptr<PlayerConfig> _config;
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -28,8 +28,10 @@ namespace MegaManLofi
 
    private:
       void HandleGameStartedEvent();
+      void HandlePitfallEvent();
       void CalculateViewportOffsets();
       void DrawGameStartAnimation();
+      void DrawPitfallAnimation();
       void DrawArenaSprites();
       void DrawPlayer();
 
@@ -47,6 +49,9 @@ namespace MegaManLofi
       long long _viewportOffsetY;
 
       bool _isAnimatingGameStart;
-      double _gameStartBlinkElapsedSeconds;
+      bool _isAnimatingPitfall;
+
+      double _gameStartElapsedSeconds;
+      double _pitfallElapsedSeconds;
    };
 }

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -65,3 +65,19 @@ TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnConfig )
    EXPECT_FALSE( _arena->GetTile( 5 ).RightPassable );
    EXPECT_TRUE( _arena->GetTile( 5 ).DownPassable );
 }
+
+TEST_F( ArenaTests, Reset_Always_ResetsPlayerPosition )
+{
+   BuildArena();
+
+   _arena->SetPlayerPositionX( -1'000'000 );
+   _arena->SetPlayerPositionY( -2'000'000 );
+
+   EXPECT_EQ( _arena->GetPlayerPositionX(), -1'000'000 );
+   EXPECT_EQ( _arena->GetPlayerPositionY(), -2'000'000 );
+
+   _arena->Reset();
+
+   EXPECT_EQ( _arena->GetPlayerPositionX(), 10 );
+   EXPECT_EQ( _arena->GetPlayerPositionY(), 8 );
+}

--- a/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
@@ -1,0 +1,53 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/GameOverStateInputHandler.h>
+#include <MegaManLofi/GameButton.h>
+#include <MegaManLofi/GameCommand.h>
+#include <MegaManLofi/GameCommandArgs.h>
+
+#include "mock_GameInputReader.h"
+#include "mock_GameCommandExecutor.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class GameOverStateInputHandlerTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _inputReaderMock.reset( new NiceMock<mock_GameInputReader> );
+      _commandExecutorMock.reset( new NiceMock<mock_GameCommandExecutor> );
+
+      _inputHandler.reset( new GameOverStateInputHandler( _inputReaderMock,
+                                                          _commandExecutorMock ) );
+   }
+
+protected:
+   shared_ptr<mock_GameInputReader> _inputReaderMock;
+   shared_ptr<mock_GameCommandExecutor> _commandExecutorMock;
+
+   shared_ptr<GameOverStateInputHandler> _inputHandler;
+};
+
+TEST_F( GameOverStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExecuteAnyCommand )
+{
+   ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( false ) );
+
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _, _ ) ).Times( 0 );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( GameOverStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
+{
+   ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
+
+   auto args = shared_ptr<GameCommandArgs>();
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Start ) );
+
+   _inputHandler->HandleInput();
+}

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -145,6 +145,16 @@ TEST_F( GameTests, Tick_GameStateIsPlaying_DoesPlayerAndArenaActions )
    _game->Tick();
 }
 
+TEST_F( GameTests, EventHandling_PitfallEventRaised_ChangesGameStateToGameOver )
+{
+   auto eventAggregator = make_shared<GameEventAggregator>();
+   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock ) );
+
+   eventAggregator->RaiseEvent( GameEvent::Pitfall );
+
+   EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
+}
+
 TEST_F( GameTests, EventHandling_GameOverEventRaised_ChangesGameStateToGameOver )
 {
    auto eventAggregator = make_shared<GameEventAggregator>();

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -55,23 +55,25 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
    EXPECT_EQ( _game->GetGameState(), GameState::Startup );
 }
 
-TEST_F( GameTests, Constructor_Always_AssignsPhysicsObjects )
-{
-   auto basePlayer = static_pointer_cast<IPlayer>( _playerMock );
-   auto baseArena = static_pointer_cast<IArena>( _arenaMock );
-
-   EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
-   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena, basePlayer ) );
-
-   BuildGame();
-}
-
 TEST_F( GameTests, ExecuteCommand_Start_ResetsGameObjects )
 {
    BuildGame();
 
    EXPECT_CALL( *_playerMock, Reset() );
    EXPECT_CALL( *_arenaMock, Reset() );
+
+   _game->ExecuteCommand( GameCommand::Start );
+}
+
+TEST_F( GameTests, ExecuteCommand_Start_AssignsObjectsToPhysics )
+{
+   BuildGame();
+
+   auto basePlayer = static_pointer_cast<IPlayer>( _playerMock );
+   auto baseArena = static_pointer_cast<IArena>( _arenaMock );
+
+   EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena, basePlayer ) );
 
    _game->ExecuteCommand( GameCommand::Start );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -154,13 +154,3 @@ TEST_F( GameTests, EventHandling_PitfallEventRaised_ChangesGameStateToGameOver )
 
    EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
 }
-
-TEST_F( GameTests, EventHandling_GameOverEventRaised_ChangesGameStateToGameOver )
-{
-   auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock ) );
-
-   eventAggregator->RaiseEvent( GameEvent::GameOver );
-
-   EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
-}

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -66,15 +66,31 @@ TEST_F( GameTests, Constructor_Always_AssignsPhysicsObjects )
    BuildGame();
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlayingAndRaisesEvent )
+TEST_F( GameTests, ExecuteCommand_Start_ResetsArena )
+{
+   BuildGame();
+
+   EXPECT_CALL( *_arenaMock, Reset() );
+
+   _game->ExecuteCommand( GameCommand::Start );
+}
+
+TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
+{
+   BuildGame();
+
+   _game->ExecuteCommand( GameCommand::Start );
+
+   EXPECT_EQ( _game->GetGameState(), GameState::Playing );
+}
+
+TEST_F( GameTests, ExecuteCommand_Start_RaisesGameStartedEvent )
 {
    BuildGame();
 
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::GameStarted ) );
 
    _game->ExecuteCommand( GameCommand::Start );
-
-   EXPECT_EQ( _game->GetGameState(), GameState::Playing );
 }
 
 TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -9,6 +9,7 @@
 #include <MegaManLofi/GameEvent.h>
 #include <MegaManLofi/PushPlayerCommandArgs.h>
 #include <MegaManLofi/PointPlayerCommandArgs.h>
+#include <MegaManLofi/GameEventAggregator.h>
 
 #include "mock_GameEventAggregator.h"
 #include "mock_Player.h"
@@ -142,4 +143,14 @@ TEST_F( GameTests, Tick_GameStateIsPlaying_DoesPlayerAndArenaActions )
    EXPECT_CALL( *_arenaPhysicsMock, Tick() );
 
    _game->Tick();
+}
+
+TEST_F( GameTests, EventHandling_GameOverEventRaised_ChangesGameStateToGameOver )
+{
+   auto eventAggregator = make_shared<GameEventAggregator>();
+   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock ) );
+
+   eventAggregator->RaiseEvent( GameEvent::GameOver );
+
+   EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -66,10 +66,11 @@ TEST_F( GameTests, Constructor_Always_AssignsPhysicsObjects )
    BuildGame();
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_ResetsArena )
+TEST_F( GameTests, ExecuteCommand_Start_ResetsGameObjects )
 {
    BuildGame();
 
+   EXPECT_CALL( *_playerMock, Reset() );
    EXPECT_CALL( *_arenaMock, Reset() );
 
    _game->ExecuteCommand( GameCommand::Start );

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -78,11 +78,12 @@ TEST_F( GameTests, ExecuteCommand_Start_AssignsObjectsToPhysics )
    _game->ExecuteCommand( GameCommand::Start );
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
+TEST_F( GameTests, ExecuteCommand_Start_SetsNextGameStateToPlaying )
 {
    BuildGame();
 
    _game->ExecuteCommand( GameCommand::Start );
+   _game->Tick();
 
    EXPECT_EQ( _game->GetGameState(), GameState::Playing );
 }
@@ -164,12 +165,13 @@ TEST_F( GameTests, Tick_GameStateIsPlaying_DoesPlayerAndArenaActions )
    _game->Tick();
 }
 
-TEST_F( GameTests, EventHandling_PitfallEventRaised_ChangesGameStateToGameOver )
+TEST_F( GameTests, EventHandling_PitfallEventRaised_ChangesNextGameStateToGameOver )
 {
    auto eventAggregator = make_shared<GameEventAggregator>();
    _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock ) );
 
    eventAggregator->RaiseEvent( GameEvent::Pitfall );
+   _game->Tick();
 
    EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
 }

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="ArenaTests.cpp" />
     <ClCompile Include="FrameActionRegistryTests.cpp" />
     <ClCompile Include="GameClockTests.cpp" />
+    <ClCompile Include="GameOverStateInputHandlerTests.cpp" />
     <ClCompile Include="GameRendererTests.cpp" />
     <ClCompile Include="GameEventAggregatorTests.cpp" />
     <ClCompile Include="GameInputHandlerTests.cpp" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="ArenaPhysicsTests.cpp">
       <Filter>Tests\Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="GameOverStateInputHandlerTests.cpp">
+      <Filter>Tests\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -48,14 +48,46 @@ protected:
 
 TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
 {
+   _config->DefaultHitBox = { 1, 2, 3, 4 };
    _config->DefaultVelocityX = 100;
    _config->DefaultVelocityY = 200;
    _config->DefaultDirection = Direction::Right;
    BuildPlayer();
 
+   EXPECT_EQ( _player->GetHitBox().Left, 1 );
+   EXPECT_EQ( _player->GetHitBox().Top, 2 );
+   EXPECT_EQ( _player->GetHitBox().Width, 3 );
+   EXPECT_EQ( _player->GetHitBox().Height, 4 );
    EXPECT_EQ( _player->GetVelocityX(), 100 );
    EXPECT_EQ( _player->GetVelocityY(), 200 );
    EXPECT_EQ( _player->GetDirection(), Direction::Right );
+   EXPECT_FALSE( _player->IsStanding() );
+   EXPECT_FALSE( _player->IsJumping() );
+}
+
+TEST_F( PlayerTests, Reset_Always_ResetsDefaultPropertiesFromConfig )
+{
+   BuildPlayer();
+
+   _player->SetVelocityX( 100 );
+   _player->SetVelocityY( 200 );
+   _player->SetDirection( Direction::Right );
+   _player->SetIsStanding( true );
+   _player->SetIsJumping( true );
+
+   EXPECT_EQ( _player->GetVelocityX(), 100 );
+   EXPECT_EQ( _player->GetVelocityY(), 200 );
+   EXPECT_EQ( _player->GetDirection(), Direction::Right );
+   EXPECT_TRUE( _player->IsStanding() );
+   EXPECT_TRUE( _player->IsJumping() );
+
+   _player->Reset();
+
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
+   EXPECT_EQ( _player->GetDirection(), Direction::Left );
+   EXPECT_FALSE( _player->IsStanding() );
+   EXPECT_FALSE( _player->IsJumping() );
 }
 
 TEST_F( PlayerTests, GetDirection_Always_ReturnsDirection )

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -7,6 +7,7 @@
 class mock_Arena : public MegaManLofi::IArena
 {
 public:
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( long long, GetWidth, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetHeight, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetPlayerPositionX, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -7,6 +7,7 @@
 class mock_Player : public MegaManLofi::IPlayer
 {
 public:
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( MegaManLofi::Direction, GetDirection, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsMoving, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsStanding, ( ), ( const, override ) );


### PR DESCRIPTION
Kind of a lot is happening in here:

- Falling into a pit kills the player
- There's a game-over screen when that happens
- A death "animation" plays out (really it's just a 2-second pause)
- Potentially a noteworthy state refactor

What I mean by "potentially noteworthy state refactor" is that I added the idea of a "next state" to the `Game` object, so any renderers that aren't finished with the current state can finish before the game enters the next state.