### PR TITLE
Allow real transparency in sprite pixels

### DIFF
--- a/MegaManLofi/ConsoleBuffer.cpp
+++ b/MegaManLofi/ConsoleBuffer.cpp
@@ -176,7 +176,10 @@ void ConsoleBuffer::Draw( short left, short top, const ConsoleSprite& sprite )
    {
       if ( pixel.HasTransparency )
       {
-         Draw( left + i, top + j, pixel.Value, pixel.ForegroundColor );
+         if ( pixel.Value != ' ' )
+         {
+            Draw( left + i, top + j, pixel.Value, pixel.ForegroundColor );
+         }
       }
       else
       {

--- a/MegaManLofi/TitleSpriteGenerator.cpp
+++ b/MegaManLofi/TitleSpriteGenerator.cpp
@@ -83,21 +83,21 @@ ConsoleSprite TitleSpriteGenerator::GenerateBuildingSprite()
 
    string content =
       "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     " \
-      "|       |       |       |     ";
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.," \
+      "|,.,.,.,|,.,.,.,|,.,.,.,|,.,.,";
 
    for ( int i = 0; i < (int)content.size(); i++ )
    {
-      sprite.Pixels.push_back( { content[i], true, ConsoleColor::DarkGrey, ConsoleColor::Black } );
+      sprite.Pixels.push_back( { content[i], false, ConsoleColor::DarkGrey, ConsoleColor::Black } );
    }
 
    return sprite;


### PR DESCRIPTION
There was an issue where blank pixels in a sprite weren't REALLY transparent, because we still technically draw a space on top of whatever other character might be behind it. This makes sure that if a transparent pixel is a space, we don't draw anything at all.