### PR TITLE
Implement player Lives

### DIFF
--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -26,6 +26,10 @@ namespace MegaManLofi
       short ArenaViewportWidthChar = 0;
       short ArenaViewportHeightChar = 0;
 
+      short ArenaStatusBarX = 0;
+      short ArenaStatusBarY = 0;
+      short ArenaStatusBarWidth = 0;
+
       double GameStartSingleBlinkSeconds = 0;
       int GameStartBlinkCount = 0;
 

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -40,7 +40,7 @@ void Game::Tick()
       _arena->Reset();
       _arenaPhysics->AssignTo( _arena, _player );
       _restartStageNextFrame = false;
-      _eventAggregator->RaiseEvent( GameEvent::GameStarted );
+      _eventAggregator->RaiseEvent( GameEvent::StageStarted );
    }
 
    _state = _nextState;
@@ -69,7 +69,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
          _arenaPhysics->AssignTo( _arena, _player );
          _nextState = GameState::Playing;
          _isPaused = false;
-         _eventAggregator->RaiseEvent( GameEvent::GameStarted );
+         _eventAggregator->RaiseEvent( GameEvent::StageStarted );
          break;
       case GameCommand::TogglePause:
          if ( _nextState == GameState::Playing )

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -27,8 +27,8 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _nextState( GameState::Title ),
    _isPaused( false )
 {
-   _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );
-   _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::HandleTileDeathEvent, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::KillPlayer, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::KillPlayer, this ) );
 }
 
 void Game::Tick()
@@ -95,12 +95,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    }
 }
 
-void Game::HandlePitfallEvent()
-{
-   _nextState = GameState::GameOver;
-}
-
-void Game::HandleTileDeathEvent()
+void Game::KillPlayer()
 {
    _nextState = GameState::GameOver;
 }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -77,6 +77,9 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
             _isPaused = !_isPaused;
          }
          break;
+      case GameCommand::ExitToTitle:
+         _nextState = GameState::Title;
+         break;
       case GameCommand::Quit:
          _eventAggregator->RaiseEvent( GameEvent::Shutdown );
          break;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -52,7 +52,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    // commands that don't observe _isPaused
    switch ( command )
    {
-      case GameCommand::Start:
+      case GameCommand::StartStage:
          _player->Reset();
          _arena->Reset();
          _playerPhysics->AssignTo( _player );

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -23,8 +23,8 @@ Game::Game( const shared_ptr<IGameEventAggregator> eventAggregator,
    _arena( arena ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
-   _state( GameState::Startup ),
-   _nextState( GameState::Startup ),
+   _state( GameState::Title ),
+   _nextState( GameState::Title ),
    _isPaused( false )
 {
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandlePitfallEvent, this ) );

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -34,8 +34,7 @@ namespace MegaManLofi
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
    private:
-      void HandlePitfallEvent();
-      void HandleTileDeathEvent();
+      void KillPlayer();
 
    private:
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -34,6 +34,7 @@ namespace MegaManLofi
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
    private:
+      void StartStage();
       void KillPlayer();
 
    private:
@@ -47,5 +48,6 @@ namespace MegaManLofi
       GameState _nextState;
 
       bool _isPaused;
+      bool _restartStageNextFrame;
    };
 }

--- a/MegaManLofi/GameCommand.h
+++ b/MegaManLofi/GameCommand.h
@@ -4,7 +4,7 @@ namespace MegaManLofi
 {
    enum class GameCommand
    {
-      Start = 0,
+      StartStage = 0,
       PushPlayer,
       PointPlayer,
       Jump,

--- a/MegaManLofi/GameCommand.h
+++ b/MegaManLofi/GameCommand.h
@@ -10,6 +10,7 @@ namespace MegaManLofi
       Jump,
       ExtendJump,
       TogglePause,
+      ExitToTitle,
       Quit
    };
 }

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -7,7 +7,7 @@ namespace MegaManLofi
       Shutdown = 0,
       ToggleDiagnostics,
 
-      GameStarted,
+      StageStarted,
 
       Pitfall,
       TileDeath

--- a/MegaManLofi/GameOverStateInputHandler.cpp
+++ b/MegaManLofi/GameOverStateInputHandler.cpp
@@ -17,6 +17,6 @@ void GameOverStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasAnyButtonPressed() )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::StartStage );
+      _commandExecutor->ExecuteCommand( GameCommand::ExitToTitle );
    }
 }

--- a/MegaManLofi/GameOverStateInputHandler.cpp
+++ b/MegaManLofi/GameOverStateInputHandler.cpp
@@ -17,6 +17,6 @@ void GameOverStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasAnyButtonPressed() )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::Start );
+      _commandExecutor->ExecuteCommand( GameCommand::StartStage );
    }
 }

--- a/MegaManLofi/GameState.h
+++ b/MegaManLofi/GameState.h
@@ -4,7 +4,7 @@ namespace MegaManLofi
 {
    enum class GameState
    {
-      Startup = 0,
+      Title = 0,
       Playing,
       GameOver
    };

--- a/MegaManLofi/IPlayer.h
+++ b/MegaManLofi/IPlayer.h
@@ -10,6 +10,7 @@ namespace MegaManLofi
    {
    public:
       virtual void Reset() = 0;
+      virtual void ResetPhysics() = 0;
 
       virtual void SetLivesRemaining( unsigned int lives ) = 0;
       virtual void SetDirection( Direction direction ) = 0;

--- a/MegaManLofi/IPlayer.h
+++ b/MegaManLofi/IPlayer.h
@@ -11,6 +11,7 @@ namespace MegaManLofi
    public:
       virtual void Reset() = 0;
 
+      virtual void SetLivesRemaining( unsigned int lives ) = 0;
       virtual void SetDirection( Direction direction ) = 0;
 
       virtual long long GetVelocityX() const = 0;

--- a/MegaManLofi/IPlayerInfoProvider.h
+++ b/MegaManLofi/IPlayerInfoProvider.h
@@ -9,8 +9,8 @@ namespace MegaManLofi
    class __declspec( novtable ) IPlayerInfoProvider
    {
    public:
+      virtual unsigned int GetLivesRemaining() const = 0;
       virtual Direction GetDirection() const = 0;
-
       virtual const Rectangle& GetHitBox() const = 0;
 
       virtual bool IsMoving() const = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -162,6 +162,10 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->ArenaViewportWidthChar = 120;
    renderConfig->ArenaViewportHeightChar = 30;
 
+   renderConfig->ArenaStatusBarX = renderConfig->ArenaViewportX;
+   renderConfig->ArenaStatusBarY = renderConfig->ArenaViewportY;
+   renderConfig->ArenaStatusBarWidth = 20;
+
    // "GET READY!" message should blink for 2 seconds
    renderConfig->GameStartSingleBlinkSeconds = .25;
    renderConfig->GameStartBlinkCount = 8;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -28,12 +28,12 @@
 #include "ArenaPhysics.h"
 #include "Game.h"
 #include "DiagnosticsConsoleRenderer.h"
-#include "StartupStateInputHandler.h"
+#include "TitleStateInputHandler.h"
 #include "PlayingStateInputHandler.h"
 #include "GameOverStateInputHandler.h"
 #include "GameInputHandler.h"
 #include "ConsoleBuffer.h"
-#include "StartupStateConsoleRenderer.h"
+#include "TitleStateConsoleRenderer.h"
 #include "PlayingStateConsoleRenderer.h"
 #include "GameOverStateConsoleRenderer.h"
 #include "GameRenderer.h"
@@ -122,21 +122,21 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    auto game = shared_ptr<Game>( new Game( eventAggregator, player, arena, playerPhysics, arenaPhysics ) );
 
    // input objects
-   auto startupStateInputHandler = shared_ptr<StartupStateInputHandler>( new StartupStateInputHandler( keyboardInputReader, game ) );
+   auto startupStateInputHandler = shared_ptr<TitleStateInputHandler>( new TitleStateInputHandler( keyboardInputReader, game ) );
    auto playingStateInputHandler = shared_ptr<PlayingStateInputHandler>( new PlayingStateInputHandler( keyboardInputReader, game ) );
    auto gameOverStateInputHandler = shared_ptr<GameOverStateInputHandler>( new GameOverStateInputHandler( keyboardInputReader, game ) );
    auto inputHandler = shared_ptr<GameInputHandler>( new GameInputHandler( keyboardInputReader, game, eventAggregator ) );
-   inputHandler->AddInputHandlerForGameState( GameState::Startup, startupStateInputHandler );
+   inputHandler->AddInputHandlerForGameState( GameState::Title, startupStateInputHandler );
    inputHandler->AddInputHandlerForGameState( GameState::Playing, playingStateInputHandler );
    inputHandler->AddInputHandlerForGameState( GameState::GameOver, gameOverStateInputHandler );
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
-   auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, random, clock, consoleRenderConfig, keyboardInputConfig ) );
+   auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, consoleRenderConfig, keyboardInputConfig ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game, player, arena, eventAggregator, clock ) );
    auto gameOverStateConsoleRenderer = shared_ptr<GameOverStateConsoleRenderer>( new GameOverStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
-   renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
+   renderer->AddRendererForGameState( GameState::Title, titleStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::Playing, playingStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::GameOver, gameOverStateConsoleRenderer );
 

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -320,6 +320,7 @@ shared_ptr<PlayerConfig> BuildPlayerConfig()
    playerConfig->DefaultVelocityX = 0;
    playerConfig->DefaultVelocityY = 0;
 
+   playerConfig->DefaultLives = 3;
    playerConfig->DefaultDirection = Direction::Right;
 
    return playerConfig;

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -176,8 +176,8 @@
     <ClCompile Include="RandomWrapper.cpp" />
     <ClCompile Include="RectangleUtilities.cpp" />
     <ClCompile Include="SleeperWrapper.cpp" />
-    <ClCompile Include="StartupStateConsoleRenderer.cpp" />
-    <ClCompile Include="StartupStateInputHandler.cpp" />
+    <ClCompile Include="TitleStateConsoleRenderer.cpp" />
+    <ClCompile Include="TitleStateInputHandler.cpp" />
     <ClCompile Include="ThreadWrapper.cpp" />
     <ClCompile Include="TitleSpriteGenerator.cpp" />
   </ItemGroup>
@@ -257,8 +257,8 @@
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
     <ClInclude Include="SleeperWrapper.h" />
-    <ClInclude Include="StartupStateInputHandler.h" />
-    <ClInclude Include="StartupStateConsoleRenderer.h" />
+    <ClInclude Include="TitleStateInputHandler.h" />
+    <ClInclude Include="TitleStateConsoleRenderer.h" />
     <ClInclude Include="ThreadWrapper.h" />
     <ClInclude Include="Quad.h" />
     <ClInclude Include="TitleSpriteGenerator.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -87,10 +87,10 @@
     <ClCompile Include="ConsoleBuffer.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
-    <ClCompile Include="StartupStateInputHandler.cpp">
+    <ClCompile Include="TitleStateInputHandler.cpp">
       <Filter>Source Files\Input</Filter>
     </ClCompile>
-    <ClCompile Include="StartupStateConsoleRenderer.cpp">
+    <ClCompile Include="TitleStateConsoleRenderer.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
     <ClCompile Include="DiagnosticsConsoleRenderer.cpp">
@@ -215,10 +215,10 @@
     <ClInclude Include="KeyCode.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
-    <ClInclude Include="StartupStateInputHandler.h">
+    <ClInclude Include="TitleStateInputHandler.h">
       <Filter>Header Files\Input</Filter>
     </ClInclude>
-    <ClInclude Include="StartupStateConsoleRenderer.h">
+    <ClInclude Include="TitleStateConsoleRenderer.h">
       <Filter>Header Files\Render</Filter>
     </ClInclude>
     <ClInclude Include="GameConfig.h">

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -22,10 +22,15 @@ Player::Player( const shared_ptr<PlayerConfig> config,
 
 void Player::Reset()
 {
+   ResetPhysics();
+   _lives = _config->DefaultLives;
+}
+
+void Player::ResetPhysics()
+{
    _hitBox = _config->DefaultHitBox;
    _velocityX = _config->DefaultVelocityX;
    _velocityY = _config->DefaultVelocityY;
-   _lives = _config->DefaultLives;
    _direction = _config->DefaultDirection;
    _isStanding = false;
    _isJumping = false;

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -25,6 +25,7 @@ void Player::Reset()
    _hitBox = _config->DefaultHitBox;
    _velocityX = _config->DefaultVelocityX;
    _velocityY = _config->DefaultVelocityY;
+   _lives = _config->DefaultLives;
    _direction = _config->DefaultDirection;
    _isStanding = false;
    _isJumping = false;

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -21,15 +21,15 @@ namespace MegaManLofi
 
       void Reset();
 
+      unsigned int GetLivesRemaining() const override { return _lives; }
       Direction GetDirection() const override { return _direction; }
+      const Rectangle& GetHitBox() const override { return _hitBox; }
 
       bool IsMoving() const override;
       bool IsStanding() const override { return _isStanding; }
       bool IsJumping() const override { return _isJumping; }
 
       void SetDirection( Direction direction ) override { _direction = direction; }
-
-      const Rectangle& GetHitBox() const override { return _hitBox; }
 
       long long GetVelocityX() const override { return _velocityX; }
       long long GetVelocityY() const override { return _velocityY; }
@@ -48,12 +48,12 @@ namespace MegaManLofi
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
-      Rectangle _hitBox;
-
       long long _velocityX;
       long long _velocityY;
 
+      unsigned int _lives;
       Direction _direction;
+      Rectangle _hitBox;
 
       bool _isStanding;
       bool _isJumping;

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -29,6 +29,7 @@ namespace MegaManLofi
       bool IsStanding() const override { return _isStanding; }
       bool IsJumping() const override { return _isJumping; }
 
+      void SetLivesRemaining( unsigned int lives ) override { _lives = lives; };
       void SetDirection( Direction direction ) override { _direction = direction; }
 
       long long GetVelocityX() const override { return _velocityX; }

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -20,6 +20,7 @@ namespace MegaManLofi
               const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
       void Reset();
+      void ResetPhysics();
 
       unsigned int GetLivesRemaining() const override { return _lives; }
       Direction GetDirection() const override { return _direction; }

--- a/MegaManLofi/PlayerConfig.h
+++ b/MegaManLofi/PlayerConfig.h
@@ -8,11 +8,11 @@ namespace MegaManLofi
    class PlayerConfig
    {
    public:
-      Rectangle DefaultHitBox = { 0, 0, 0, 0 };
-
       long long DefaultVelocityX = 0;
       long long DefaultVelocityY = 0;
 
+      unsigned int DefaultLives = 0;
       Direction DefaultDirection = (Direction)0;
+      Rectangle DefaultHitBox = { 0, 0, 0, 0 };
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -33,15 +33,15 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _viewportHeight( _renderConfig->ArenaViewportHeightChar * _renderConfig->ArenaCharHeight ),
    _viewportOffsetX( 0 ),
    _viewportOffsetY( 0 ),
-   _isAnimatingGameStart( false ),
+   _isAnimatingStageStart( false ),
    _isAnimatingPitfall( false ),
    _isAnimatingPlayerExplosion( false ),
-   _gameStartElapsedSeconds( 0 ),
-   _pitfallElapsedSeconds( 0 ),
-   _playerExplosionElapsedSeconds( 0 ),
+   _stageStartAnimationElapsedSeconds( 0 ),
+   _pitfallAnimationElapsedSeconds( 0 ),
+   _playerExplosionAnimationElapsedSeconds( 0 ),
    _playerExplosionStartFrame( 0 )
 {
-   eventAggregator->RegisterEventHandler( GameEvent::GameStarted, std::bind( &PlayingStateConsoleRenderer::HandleGameStartedEvent, this ) );
+   eventAggregator->RegisterEventHandler( GameEvent::StageStarted, std::bind( &PlayingStateConsoleRenderer::HandleStageStartedEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &PlayingStateConsoleRenderer::HandlePitfallEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &PlayingStateConsoleRenderer::HandleTileDeathEvent, this ) );
 }
@@ -54,7 +54,7 @@ void PlayingStateConsoleRenderer::Render()
    CalculateViewportOffsets();
    DrawArenaSprites();
 
-   if ( _isAnimatingGameStart )
+   if ( _isAnimatingStageStart )
    {
       DrawGameStartAnimation();
    }
@@ -78,25 +78,25 @@ void PlayingStateConsoleRenderer::Render()
 
 bool PlayingStateConsoleRenderer::HasFocus() const
 {
-   return _isAnimatingGameStart || _isAnimatingPitfall || _isAnimatingPlayerExplosion;
+   return _isAnimatingStageStart || _isAnimatingPitfall || _isAnimatingPlayerExplosion;
 }
 
-void PlayingStateConsoleRenderer::HandleGameStartedEvent()
+void PlayingStateConsoleRenderer::HandleStageStartedEvent()
 {
-   _isAnimatingGameStart = true;
-   _gameStartElapsedSeconds = 0;
+   _isAnimatingStageStart = true;
+   _stageStartAnimationElapsedSeconds = 0;
 }
 
 void PlayingStateConsoleRenderer::HandlePitfallEvent()
 {
    _isAnimatingPitfall = true;
-   _pitfallElapsedSeconds = 0;
+   _pitfallAnimationElapsedSeconds = 0;
 }
 
 void PlayingStateConsoleRenderer::HandleTileDeathEvent()
 {
    _isAnimatingPlayerExplosion = true;
-   _playerExplosionElapsedSeconds = 0;
+   _playerExplosionAnimationElapsedSeconds = 0;
    _playerExplosionStartFrame = _frameRateProvider->GetCurrentFrame();
 }
 
@@ -108,9 +108,9 @@ void PlayingStateConsoleRenderer::CalculateViewportOffsets()
 
 void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 {
-   _gameStartElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+   _stageStartAnimationElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
 
-   if ( (int)( _gameStartElapsedSeconds / _renderConfig->GameStartSingleBlinkSeconds ) % 2 == 0 )
+   if ( (int)( _stageStartAnimationElapsedSeconds / _renderConfig->GameStartSingleBlinkSeconds ) % 2 == 0 )
    {
       auto left = ( _renderConfig->ArenaViewportWidthChar / 2 ) - ( _renderConfig->GetReadySprite.Width / 2 ) + _renderConfig->ArenaViewportX;
       auto top = ( _renderConfig->ArenaViewportHeightChar / 2 ) - ( _renderConfig->GetReadySprite.Height / 2 ) + _renderConfig->ArenaViewportY;
@@ -118,17 +118,17 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
       _consoleBuffer->Draw( left, top, _renderConfig->GetReadySprite );
    }
 
-   if ( _gameStartElapsedSeconds >= ( _renderConfig->GameStartSingleBlinkSeconds * _renderConfig->GameStartBlinkCount ) )
+   if ( _stageStartAnimationElapsedSeconds >= ( _renderConfig->GameStartSingleBlinkSeconds * _renderConfig->GameStartBlinkCount ) )
    {
-      _isAnimatingGameStart = false;
+      _isAnimatingStageStart = false;
    }
 }
 
 void PlayingStateConsoleRenderer::DrawPitfallAnimation()
 {
-   _pitfallElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+   _pitfallAnimationElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
 
-   if ( _pitfallElapsedSeconds >= _renderConfig->PitfallAnimationSeconds )
+   if ( _pitfallAnimationElapsedSeconds >= _renderConfig->PitfallAnimationSeconds )
    {
       _isAnimatingPitfall = false;
    }
@@ -137,9 +137,9 @@ void PlayingStateConsoleRenderer::DrawPitfallAnimation()
 void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
 {
    auto frameRateScalar = ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
-   _playerExplosionElapsedSeconds += frameRateScalar;
+   _playerExplosionAnimationElapsedSeconds += frameRateScalar;
 
-   const auto& particleSprite = (int)( _playerExplosionElapsedSeconds / _renderConfig->PlayerExplosionSpriteSwapSeconds ) % 2 == 0 ?
+   const auto& particleSprite = (int)( _playerExplosionAnimationElapsedSeconds / _renderConfig->PlayerExplosionSpriteSwapSeconds ) % 2 == 0 ?
       _renderConfig->PlayerExplosionParticleSprite1 : _renderConfig->PlayerExplosionParticleSprite2;
 
    const auto& hitBox = _playerInfoProvider->GetHitBox();
@@ -163,7 +163,7 @@ void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
    _consoleBuffer->Draw( particleStartX + (short)( particleDeltaX / 1.5 ), particleStartY - (short)( particleDeltaY / 1.5 ), particleSprite );
    _consoleBuffer->Draw( particleStartX - (short)( particleDeltaX / 1.5 ), particleStartY - (short)( particleDeltaY / 1.5 ), particleSprite );
 
-   if ( _playerExplosionElapsedSeconds >= _renderConfig->PlayerExplosionAnimationSeconds )
+   if ( _playerExplosionAnimationElapsedSeconds >= _renderConfig->PlayerExplosionAnimationSeconds )
    {
       _isAnimatingPlayerExplosion = false;
    }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -1,3 +1,5 @@
+#include <format>
+
 #include "PlayingStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderConfig.h"
@@ -73,6 +75,7 @@ void PlayingStateConsoleRenderer::Render()
    else
    {
       DrawPlayer();
+      DrawStatusBar();
    }
 }
 
@@ -212,6 +215,11 @@ void PlayingStateConsoleRenderer::DrawPlayer()
    auto sprite = _playerInfoProvider->IsMoving() ? _renderConfig->PlayerMovingSpriteMap[direction] : _renderConfig->PlayerStaticSpriteMap[direction];
 
    _consoleBuffer->Draw( playerDrawX, playerDrawY, sprite );
+}
+
+void PlayingStateConsoleRenderer::DrawStatusBar()
+{
+   _consoleBuffer->Draw( _renderConfig->ArenaStatusBarX, _renderConfig->ArenaStatusBarY, format( "Lives: {}", _playerInfoProvider->GetLivesRemaining() ) );
 }
 
 void PlayingStateConsoleRenderer::DrawPauseOverlay()

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -38,6 +38,7 @@ namespace MegaManLofi
       void DrawPlayerExplosionAnimation();
       void DrawArenaSprites();
       void DrawPlayer();
+      void DrawStatusBar();
       void DrawPauseOverlay();
 
       short GetPlayerViewportX() const;

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -29,7 +29,7 @@ namespace MegaManLofi
       bool HasFocus() const override;
 
    private:
-      void HandleGameStartedEvent();
+      void HandleStageStartedEvent();
       void HandlePitfallEvent();
       void HandleTileDeathEvent();
       void CalculateViewportOffsets();
@@ -57,13 +57,13 @@ namespace MegaManLofi
       long long _viewportOffsetX;
       long long _viewportOffsetY;
 
-      bool _isAnimatingGameStart;
+      bool _isAnimatingStageStart;
       bool _isAnimatingPitfall;
       bool _isAnimatingPlayerExplosion;
 
-      double _gameStartElapsedSeconds;
-      double _pitfallElapsedSeconds;
-      double _playerExplosionElapsedSeconds;
+      double _stageStartAnimationElapsedSeconds;
+      double _pitfallAnimationElapsedSeconds;
+      double _playerExplosionAnimationElapsedSeconds;
 
       long long _playerExplosionStartFrame;
    };

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <format>
 
-#include "StartupStateConsoleRenderer.h"
+#include "TitleStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
 #include "IRandom.h"
 #include "IFrameRateProvider.h"
@@ -12,11 +12,11 @@
 using namespace std;
 using namespace MegaManLofi;
 
-StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                          const shared_ptr<IRandom> random,
-                                                          const shared_ptr<IFrameRateProvider> frameRateProvider,
-                                                          const shared_ptr<ConsoleRenderConfig> renderConfig,
-                                                          const shared_ptr<KeyboardInputConfig> inputConfig ) :
+TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                      const shared_ptr<IRandom> random,
+                                                      const shared_ptr<IFrameRateProvider> frameRateProvider,
+                                                      const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                      const shared_ptr<KeyboardInputConfig> inputConfig ) :
    _consoleBuffer( consoleBuffer ),
    _random( random ),
    _frameRateProvider( frameRateProvider ),
@@ -32,7 +32,7 @@ StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<ICons
    }
 }
 
-void StartupStateConsoleRenderer::Render()
+void TitleStateConsoleRenderer::Render()
 {
    _consoleBuffer->SetDefaultForegroundColor( _renderConfig->TitleScreenForegroundColor );
    _consoleBuffer->SetDefaultBackgroundColor( _renderConfig->TitleScreenBackgroundColor );
@@ -48,7 +48,7 @@ void StartupStateConsoleRenderer::Render()
    DrawKeyBindings();
 }
 
-void StartupStateConsoleRenderer::DrawStars()
+void TitleStateConsoleRenderer::DrawStars()
 {
    for ( int i = 0; i < (int)_starCoordinates.size(); i++ )
    {
@@ -67,7 +67,7 @@ void StartupStateConsoleRenderer::DrawStars()
    }
 }
 
-void StartupStateConsoleRenderer::DrawKeyBindings() const
+void TitleStateConsoleRenderer::DrawKeyBindings() const
 {
    auto leftOfMiddleX = _renderConfig->TitleKeyBindingsMiddleX - 2;
    auto top = _renderConfig->TitleKeyBindingsY;

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -14,14 +14,14 @@ namespace MegaManLofi
    class ConsoleRenderConfig;
    class KeyboardInputConfig;
 
-   class StartupStateConsoleRenderer : public IGameRenderer
+   class TitleStateConsoleRenderer : public IGameRenderer
    {
    public:
-      StartupStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
-                                   const std::shared_ptr<IRandom> random,
-                                   const std::shared_ptr<IFrameRateProvider> frameRateProvider,
-                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig,
-                                   const std::shared_ptr<KeyboardInputConfig> inputConfig );
+      TitleStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                 const std::shared_ptr<IRandom> random,
+                                 const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                                 const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                 const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
       void Render() override;
       bool HasFocus() const override { return false; }

--- a/MegaManLofi/TitleStateInputHandler.cpp
+++ b/MegaManLofi/TitleStateInputHandler.cpp
@@ -17,6 +17,6 @@ void TitleStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasAnyButtonPressed() )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::Start );
+      _commandExecutor->ExecuteCommand( GameCommand::StartStage );
    }
 }

--- a/MegaManLofi/TitleStateInputHandler.cpp
+++ b/MegaManLofi/TitleStateInputHandler.cpp
@@ -1,4 +1,4 @@
-#include "StartupStateInputHandler.h"
+#include "TitleStateInputHandler.h"
 #include "IGameInputReader.h"
 #include "IGameCommandExecutor.h"
 #include "GameCommand.h"
@@ -6,14 +6,14 @@
 using namespace std;
 using namespace MegaManLofi;
 
-StartupStateInputHandler::StartupStateInputHandler( const shared_ptr<IGameInputReader> inputReader,
-                                                    const shared_ptr<IGameCommandExecutor> commandExecutor ) :
+TitleStateInputHandler::TitleStateInputHandler( const shared_ptr<IGameInputReader> inputReader,
+                                                const shared_ptr<IGameCommandExecutor> commandExecutor ) :
    _inputReader( inputReader ),
    _commandExecutor( commandExecutor )
 {
 }
 
-void StartupStateInputHandler::HandleInput()
+void TitleStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasAnyButtonPressed() )
    {

--- a/MegaManLofi/TitleStateInputHandler.h
+++ b/MegaManLofi/TitleStateInputHandler.h
@@ -9,11 +9,11 @@ namespace MegaManLofi
    class IGameInputReader;
    class IGameCommandExecutor;
 
-   class StartupStateInputHandler : public IGameInputHandler
+   class TitleStateInputHandler : public IGameInputHandler
    {
    public:
-      StartupStateInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
-                                const std::shared_ptr<IGameCommandExecutor> commandExecutor );
+      TitleStateInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
+                              const std::shared_ptr<IGameCommandExecutor> commandExecutor );
 
       void HandleInput() override;
 

--- a/MegaManLofiTests/GameInputHandlerTests.cpp
+++ b/MegaManLofiTests/GameInputHandlerTests.cpp
@@ -30,9 +30,9 @@ public:
                                                  _gameInfoProviderMock,
                                                  _eventAggregatorMock ) );
 
-      _inputHandler->AddInputHandlerForGameState( GameState::Startup, _startupInputHandlerMock );
+      _inputHandler->AddInputHandlerForGameState( GameState::Title, _startupInputHandlerMock );
 
-      ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
+      ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Title ) );
       ON_CALL( *_inputReaderMock, WasButtonPressed( _ ) ).WillByDefault( Return( false ) );
    }
 

--- a/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
@@ -42,12 +42,12 @@ TEST_F( GameOverStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNot
    _inputHandler->HandleInput();
 }
 
-TEST_F( GameOverStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
+TEST_F( GameOverStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartStageCommand )
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
    auto args = shared_ptr<GameCommandArgs>();
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Start ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::StartStage ) );
 
    _inputHandler->HandleInput();
 }

--- a/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/GameOverStateInputHandlerTests.cpp
@@ -47,7 +47,7 @@ TEST_F( GameOverStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesSta
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
    auto args = shared_ptr<GameCommandArgs>();
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::StartStage ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::ExitToTitle ) );
 
    _inputHandler->HandleInput();
 }

--- a/MegaManLofiTests/GameRendererTests.cpp
+++ b/MegaManLofiTests/GameRendererTests.cpp
@@ -34,7 +34,7 @@ public:
       _renderConfig->DefaultBackgroundColor = ConsoleColor::Black;
       _renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
 
-      ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
+      ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Title ) );
       ON_CALL( *_startupStateRendererMock, HasFocus() ).WillByDefault( Return( false ) );
    }
 
@@ -46,7 +46,7 @@ public:
                                          _diagnosticsRendererMock,
                                          _eventAggregator ) );
 
-      _renderer->AddRendererForGameState( GameState::Startup, _startupStateRendererMock );
+      _renderer->AddRendererForGameState( GameState::Title, _startupStateRendererMock );
    }
 
 protected:

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -48,11 +48,11 @@ protected:
    shared_ptr<Game> _game;
 };
 
-TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
+TEST_F( GameTests, Constructor_Always_SetsGameStateToTitle )
 {
    BuildGame();
 
-   EXPECT_EQ( _game->GetGameState(), GameState::Startup );
+   EXPECT_EQ( _game->GetGameState(), GameState::Title );
 }
 
 TEST_F( GameTests, ExecuteCommand_Start_ResetsGameObjects )

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -90,11 +90,11 @@ TEST_F( GameTests, ExecuteCommand_StartStage_SetsNextGameStateToPlaying )
    EXPECT_EQ( _game->GetGameState(), GameState::Playing );
 }
 
-TEST_F( GameTests, ExecuteCommand_StartStage_RaisesGameStartedEvent )
+TEST_F( GameTests, ExecuteCommand_StartStage_RaisesStageStartedEvent )
 {
    BuildGame();
 
-   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::GameStarted ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::StageStarted ) );
 
    _game->ExecuteCommand( GameCommand::StartStage );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -122,6 +122,15 @@ TEST_F( GameTests, ExecuteCommand_TogglePauseAndInPlayingState_TogglesPause )
    EXPECT_TRUE( _game->IsPaused() );
 }
 
+TEST_F( GameTests, ExecuteCommand_ExitToTitle_SetsNextStateToExitToTitle )
+{
+   BuildGame();
+   _game->ExecuteCommand( GameCommand::ExitToTitle );
+   _game->Tick();
+
+   EXPECT_EQ( _game->GetGameState(), GameState::Title );
+}
+
 TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )
 {
    BuildGame();
@@ -217,6 +226,12 @@ TEST_F( GameTests, ExecuteCommand_ExtendJumpAndGameIsNotPaused_ExtendsJump )
    EXPECT_CALL( *_playerPhysicsMock, ExtendJump() );
 
    _game->ExecuteCommand( GameCommand::ExtendJump );
+}
+
+TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsAllAppropriateObjects )
+{
+   // MUFFINS: need to kill the player...
+   BuildGame();
 }
 
 TEST_F( GameTests, Tick_GameStateIsNotPlaying_DoesNotDoPlayerOrArenaActions )

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -55,17 +55,17 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToTitle )
    EXPECT_EQ( _game->GetGameState(), GameState::Title );
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_ResetsGameObjects )
+TEST_F( GameTests, ExecuteCommand_StartStage_ResetsGameObjects )
 {
    BuildGame();
 
    EXPECT_CALL( *_playerMock, Reset() );
    EXPECT_CALL( *_arenaMock, Reset() );
 
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_AssignsObjectsToPhysics )
+TEST_F( GameTests, ExecuteCommand_StartStage_AssignsObjectsToPhysics )
 {
    BuildGame();
 
@@ -75,26 +75,26 @@ TEST_F( GameTests, ExecuteCommand_Start_AssignsObjectsToPhysics )
    EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
    EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena, basePlayer ) );
 
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_SetsNextGameStateToPlaying )
+TEST_F( GameTests, ExecuteCommand_StartStage_SetsNextGameStateToPlaying )
 {
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->Tick();
 
    EXPECT_EQ( _game->GetGameState(), GameState::Playing );
 }
 
-TEST_F( GameTests, ExecuteCommand_Start_RaisesGameStartedEvent )
+TEST_F( GameTests, ExecuteCommand_StartStage_RaisesGameStartedEvent )
 {
    BuildGame();
 
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::GameStarted ) );
 
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 }
 
 TEST_F( GameTests, ExecuteCommand_TogglePauseAndNotInPlayingState_DoesNotTogglePause )
@@ -111,7 +111,7 @@ TEST_F( GameTests, ExecuteCommand_TogglePauseAndNotInPlayingState_DoesNotToggleP
 TEST_F( GameTests, ExecuteCommand_TogglePauseAndInPlayingState_TogglesPause )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_FALSE( _game->IsPaused() );
 
@@ -132,7 +132,7 @@ TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )
 TEST_F( GameTests, ExecuteCommand_PushPlayerAndGameIsPaused_DoesNotPushPlayer )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->ExecuteCommand( GameCommand::TogglePause );
 
    EXPECT_CALL( *_playerPhysicsMock, PushTo( _ ) ).Times( 0 );
@@ -144,7 +144,7 @@ TEST_F( GameTests, ExecuteCommand_PushPlayerAndGameIsPaused_DoesNotPushPlayer )
 TEST_F( GameTests, ExecuteCommand_PushPlayerAndGameIsNotPaused_PushesPlayerInSpecifiedDirection )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_CALL( *_playerPhysicsMock, PushTo( Direction::UpLeft ) );
 
@@ -155,7 +155,7 @@ TEST_F( GameTests, ExecuteCommand_PushPlayerAndGameIsNotPaused_PushesPlayerInSpe
 TEST_F( GameTests, ExecuteCommand_PointPlayerAndGameIsPaused_DoesNotPointPlayer )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->ExecuteCommand( GameCommand::TogglePause );
 
    EXPECT_CALL( *_playerPhysicsMock, PointTo( _ ) ).Times( 0 );
@@ -167,7 +167,7 @@ TEST_F( GameTests, ExecuteCommand_PointPlayerAndGameIsPaused_DoesNotPointPlayer 
 TEST_F( GameTests, ExecuteCommand_PointPlayerAndGameIsNotPaused_PointsPlayerInSpecifiedDirection )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_CALL( *_playerPhysicsMock, PointTo( Direction::DownLeft ) );
 
@@ -178,7 +178,7 @@ TEST_F( GameTests, ExecuteCommand_PointPlayerAndGameIsNotPaused_PointsPlayerInSp
 TEST_F( GameTests, ExecuteCommand_JumpAndGameIsPaused_DoesNotJump )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->ExecuteCommand( GameCommand::TogglePause );
 
    EXPECT_CALL( *_playerPhysicsMock, Jump() ).Times( 0 );
@@ -189,7 +189,7 @@ TEST_F( GameTests, ExecuteCommand_JumpAndGameIsPaused_DoesNotJump )
 TEST_F( GameTests, ExecuteCommand_JumpAndGameIsNotPaused_Jumps )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_CALL( *_playerPhysicsMock, Jump() );
 
@@ -199,7 +199,7 @@ TEST_F( GameTests, ExecuteCommand_JumpAndGameIsNotPaused_Jumps )
 TEST_F( GameTests, ExecuteCommand_ExtendJumpAndGameIsPaused_DoesNotExtendJump )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->ExecuteCommand( GameCommand::TogglePause );
 
    EXPECT_CALL( *_playerPhysicsMock, ExtendJump() ).Times( 0 );
@@ -210,7 +210,7 @@ TEST_F( GameTests, ExecuteCommand_ExtendJumpAndGameIsPaused_DoesNotExtendJump )
 TEST_F( GameTests, ExecuteCommand_ExtendJumpAndGameIsNotPaused_ExtendsJump )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_CALL( *_playerPhysicsMock, ExtendJump() );
 
@@ -230,7 +230,7 @@ TEST_F( GameTests, Tick_GameStateIsNotPlaying_DoesNotDoPlayerOrArenaActions )
 TEST_F( GameTests, Tick_GameIsPaused_DoesNotDoPlayerOrArenaActions )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
    _game->ExecuteCommand( GameCommand::TogglePause );
 
    EXPECT_CALL( *_playerPhysicsMock, Tick() ).Times( 0 );
@@ -242,7 +242,7 @@ TEST_F( GameTests, Tick_GameIsPaused_DoesNotDoPlayerOrArenaActions )
 TEST_F( GameTests, Tick_GameStateIsPlayingAndNotPaused_DoesPlayerAndArenaActions )
 {
    BuildGame();
-   _game->ExecuteCommand( GameCommand::Start );
+   _game->ExecuteCommand( GameCommand::StartStage );
 
    EXPECT_CALL( *_playerPhysicsMock, Tick() );
    EXPECT_CALL( *_arenaPhysicsMock, Tick() );

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -73,7 +73,7 @@
     <ClCompile Include="PlayerTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
     <ClCompile Include="RectangleUtilitiesTests.cpp" />
-    <ClCompile Include="StartupStateInputHandlerTests.cpp" />
+    <ClCompile Include="TitleStateInputHandlerTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MegaManLofi\MegaManLofi.vcxproj">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -13,7 +13,7 @@
     <ClCompile Include="PlayingStateInputHandlerTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
-    <ClCompile Include="StartupStateInputHandlerTests.cpp">
+    <ClCompile Include="TitleStateInputHandlerTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest-all.cc" />

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -23,10 +23,11 @@ public:
       _frameActionRegistryMock.reset( new NiceMock<mock_FrameActionRegistry> );
       _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
 
-      _config->DefaultHitBox = { 0, 0, 4, 4 };
       _config->DefaultVelocityX = 0;
       _config->DefaultVelocityY = 0;
+      _config->DefaultLives = 5;
       _config->DefaultDirection = Direction::Left;
+      _config->DefaultHitBox = { 0, 0, 4, 4 };
 
       ON_CALL( *_frameRateProviderMock, GetFramesPerSecond() ).WillByDefault( Return( 100 ) );
    }
@@ -48,19 +49,21 @@ protected:
 
 TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
 {
-   _config->DefaultHitBox = { 1, 2, 3, 4 };
    _config->DefaultVelocityX = 100;
    _config->DefaultVelocityY = 200;
+   _config->DefaultLives = 10;
    _config->DefaultDirection = Direction::Right;
+   _config->DefaultHitBox = { 1, 2, 3, 4 };
    BuildPlayer();
 
+   EXPECT_EQ( _player->GetVelocityX(), 100 );
+   EXPECT_EQ( _player->GetVelocityY(), 200 );
+   EXPECT_EQ( _player->GetLivesRemaining(), 10 );
+   EXPECT_EQ( _player->GetDirection(), Direction::Right );
    EXPECT_EQ( _player->GetHitBox().Left, 1 );
    EXPECT_EQ( _player->GetHitBox().Top, 2 );
    EXPECT_EQ( _player->GetHitBox().Width, 3 );
    EXPECT_EQ( _player->GetHitBox().Height, 4 );
-   EXPECT_EQ( _player->GetVelocityX(), 100 );
-   EXPECT_EQ( _player->GetVelocityY(), 200 );
-   EXPECT_EQ( _player->GetDirection(), Direction::Right );
    EXPECT_FALSE( _player->IsStanding() );
    EXPECT_FALSE( _player->IsJumping() );
 }
@@ -88,6 +91,13 @@ TEST_F( PlayerTests, Reset_Always_ResetsDefaultPropertiesFromConfig )
    EXPECT_EQ( _player->GetDirection(), Direction::Left );
    EXPECT_FALSE( _player->IsStanding() );
    EXPECT_FALSE( _player->IsJumping() );
+}
+
+TEST_F( PlayerTests, GetLivesRemaining_Always_ReturnsLivesRemaining )
+{
+   BuildPlayer();
+
+   EXPECT_EQ( _player->GetLivesRemaining(), 5 );
 }
 
 TEST_F( PlayerTests, GetDirection_Always_ReturnsDirection )

--- a/MegaManLofiTests/TitleStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/TitleStateInputHandlerTests.cpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include <MegaManLofi/StartupStateInputHandler.h>
+#include <MegaManLofi/TitleStateInputHandler.h>
 #include <MegaManLofi/GameButton.h>
 #include <MegaManLofi/GameCommand.h>
 #include <MegaManLofi/GameCommandArgs.h>
@@ -14,7 +14,7 @@ using namespace std;
 using namespace testing;
 using namespace MegaManLofi;
 
-class StartupStateInputHandlerTests : public Test
+class TitleStateInputHandlerTests : public Test
 {
 public:
    void SetUp() override
@@ -22,18 +22,18 @@ public:
       _inputReaderMock.reset( new NiceMock<mock_GameInputReader> );
       _commandExecutorMock.reset( new NiceMock<mock_GameCommandExecutor> );
 
-      _inputHandler.reset( new StartupStateInputHandler( _inputReaderMock,
-                                                         _commandExecutorMock ) );
+      _inputHandler.reset( new TitleStateInputHandler( _inputReaderMock,
+                                                       _commandExecutorMock ) );
    }
 
 protected:
    shared_ptr<mock_GameInputReader> _inputReaderMock;
    shared_ptr<mock_GameCommandExecutor> _commandExecutorMock;
 
-   shared_ptr<StartupStateInputHandler> _inputHandler;
+   shared_ptr<TitleStateInputHandler> _inputHandler;
 };
 
-TEST_F( StartupStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExecuteAnyCommand )
+TEST_F( TitleStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExecuteAnyCommand )
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( false ) );
 
@@ -42,7 +42,7 @@ TEST_F( StartupStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotE
    _inputHandler->HandleInput();
 }
 
-TEST_F( StartupStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
+TEST_F( TitleStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 

--- a/MegaManLofiTests/TitleStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/TitleStateInputHandlerTests.cpp
@@ -42,12 +42,12 @@ TEST_F( TitleStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExe
    _inputHandler->HandleInput();
 }
 
-TEST_F( TitleStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
+TEST_F( TitleStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartStageCommand )
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
    auto args = shared_ptr<GameCommandArgs>();
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Start ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::StartStage ) );
 
    _inputHandler->HandleInput();
 }

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -8,6 +8,7 @@ class mock_Player : public MegaManLofi::IPlayer
 {
 public:
    MOCK_METHOD( void, Reset, ( ), ( override ) );
+   MOCK_METHOD( void, ResetPhysics, ( ), ( override ) );
    MOCK_METHOD( unsigned int, GetLivesRemaining, ( ), ( const, override ) );
    MOCK_METHOD( MegaManLofi::Direction, GetDirection, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::Rectangle&, GetHitBox, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -14,6 +14,7 @@ public:
    MOCK_METHOD( bool, IsMoving, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsStanding, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsJumping, ( ), ( const, override ) );
+   MOCK_METHOD( void, SetLivesRemaining, ( unsigned int ), ( override ) );
    MOCK_METHOD( void, SetDirection, ( MegaManLofi::Direction ), ( override ) );
    MOCK_METHOD( long long, GetVelocityX, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetVelocityY, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -8,11 +8,12 @@ class mock_Player : public MegaManLofi::IPlayer
 {
 public:
    MOCK_METHOD( void, Reset, ( ), ( override ) );
+   MOCK_METHOD( unsigned int, GetLivesRemaining, ( ), ( const, override ) );
    MOCK_METHOD( MegaManLofi::Direction, GetDirection, ( ), ( const, override ) );
+   MOCK_METHOD( const MegaManLofi::Rectangle&, GetHitBox, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsMoving, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsStanding, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsJumping, ( ), ( const, override ) );
-   MOCK_METHOD( const MegaManLofi::Rectangle&, GetHitBox, ( ), ( const, override ) );
    MOCK_METHOD( void, SetDirection, ( MegaManLofi::Direction ), ( override ) );
    MOCK_METHOD( long long, GetVelocityX, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetVelocityY, ( ), ( const, override ) );


### PR DESCRIPTION
This does a bunch of stuff:

- `Startup` game state is now `Title`
- `Start` command is now `StartStage`
- `GameStarted` event is now `StageStarted`
- Players have a default of three lives.
   - When a player dies and still has lives left, they start at the beginning of the stage
   - When a player dies and has no lives left, the game is over and the title screen appears
- The player's remaining lives show up on the new (super rudimentary) status bar.