### PR TITLE
Thwip into stage

### DIFF
--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -37,6 +37,6 @@ namespace MegaManLofi
       std::shared_ptr<IArena> _arena;
       std::shared_ptr<IPlayer> _player;
 
-      Quad _playerOccupyingTileIndices;
+      Quad<long long> _playerOccupyingTileIndices;
    };
 }

--- a/MegaManLofi/ConsoleBuffer.cpp
+++ b/MegaManLofi/ConsoleBuffer.cpp
@@ -76,10 +76,10 @@ void ConsoleBuffer::LoadRenderConfig( const shared_ptr<IGameRenderConfig> config
 {
    auto consoleConfig = static_pointer_cast<ConsoleRenderConfig>( config );
 
-   _bufferInfo->ConsoleSize = { consoleConfig->ConsoleWidth, consoleConfig->ConsoleHeight };
-   _bufferInfo->DrawBufferSize = consoleConfig->ConsoleWidth * consoleConfig->ConsoleHeight;
+   _bufferInfo->ConsoleSize = { consoleConfig->ConsoleWidthChars, consoleConfig->ConsoleHeightChars };
+   _bufferInfo->DrawBufferSize = consoleConfig->ConsoleWidthChars * consoleConfig->ConsoleHeightChars;
    _bufferInfo->DrawBuffer = new CHAR_INFO[_bufferInfo->DrawBufferSize];
-   _bufferInfo->OutputRect = { 0, 0, consoleConfig->ConsoleWidth, consoleConfig->ConsoleHeight };
+   _bufferInfo->OutputRect = { 0, 0, consoleConfig->ConsoleWidthChars, consoleConfig->ConsoleHeightChars };
 
    ResetDrawBuffer();
 

--- a/MegaManLofi/ConsolePixel.h
+++ b/MegaManLofi/ConsolePixel.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "ConsoleColor.h"
+
 namespace MegaManLofi
 {
-   enum class ConsoleColor;
-
    struct ConsolePixel
    {
       char Value = '\0';

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -61,6 +61,8 @@ namespace MegaManLofi
       ConsoleSprite TitleStartMessageSprite;
       ConsoleSprite TitleStarSprite;
 
+      ConsoleSprite PlayerThwipSprite;
+
       short TitleTextX = 0;
       short TitleTextY = 0;
       short TitleSubTextX = 0;

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -14,21 +14,21 @@ namespace MegaManLofi
    class ConsoleRenderConfig : public IGameRenderConfig
    {
    public:
-      short ConsoleWidth = 0;
-      short ConsoleHeight = 0;
+      short ConsoleWidthChars = 0;
+      short ConsoleHeightChars = 0;
 
-      short ArenaViewportX = 0;
-      short ArenaViewportY = 0;
+      short ArenaViewportLeftChars = 0;
+      short ArenaViewportTopChars = 0;
 
       long long ArenaCharWidth = 0;
       long long ArenaCharHeight = 0;
 
-      short ArenaViewportWidthChar = 0;
-      short ArenaViewportHeightChar = 0;
+      short ArenaViewportWidthChars = 0;
+      short ArenaViewportHeightChars = 0;
 
-      short ArenaStatusBarX = 0;
-      short ArenaStatusBarY = 0;
-      short ArenaStatusBarWidth = 0;
+      short ArenaStatusBarLeftChars = 0;
+      short ArenaStatusBarTopChars = 0;
+      short ArenaStatusBarWidthChars = 0;
 
       double GameStartSingleBlinkSeconds = 0;
       int GameStartBlinkCount = 0;
@@ -62,19 +62,20 @@ namespace MegaManLofi
       ConsoleSprite TitleStarSprite;
 
       ConsoleSprite PlayerThwipSprite;
+      long long PlayerThwipVelocity = 0;
 
-      short TitleTextX = 0;
-      short TitleTextY = 0;
-      short TitleSubTextX = 0;
-      short TitleSubTextY = 0;
-      short TitlePlayerX = 0;
-      short TitlePlayerY = 0;
-      short TitleBuildingX = 0;
-      short TitleBuildingY = 0;
-      short TitleStartMessageX = 0;
-      short TitleStartMessageY = 0;
-      short TitleKeyBindingsMiddleX = 0;
-      short TitleKeyBindingsY = 0;
+      short TitleTextLeftChars = 0;
+      short TitleTextTopChars = 0;
+      short TitleSubTextLeftChars = 0;
+      short TitleSubTextTopChars = 0;
+      short TitlePlayerLeftChars = 0;
+      short TitlePlayerTopChars = 0;
+      short TitleBuildingLeftChars = 0;
+      short TitleBuildingTopChars = 0;
+      short TitleStartMessageLeftChars = 0;
+      short TitleStartMessageTopChars = 0;
+      short TitleKeyBindingsMiddleXChars = 0;
+      short TitleKeyBindingsTopChars = 0;
       int TitleStarCount = 0;
       long long MinTitleStarVelocity = 0;
       long long MaxTitleStarVelocity = 0;

--- a/MegaManLofi/Coordinate.h
+++ b/MegaManLofi/Coordinate.h
@@ -2,9 +2,10 @@
 
 namespace MegaManLofi
 {
+   template<typename T>
    struct Coordinate
    {
-      long long X = 0;
-      long long Y = 0;
+      T Left = 0;
+      T Top = 0;
    };
 }

--- a/MegaManLofi/DiagnosticsConsoleRenderer.cpp
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.cpp
@@ -22,7 +22,7 @@ DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsol
 
 void DiagnosticsConsoleRenderer::Render()
 {
-   auto left = _renderConfig->ConsoleWidth - DIAGNOSTICS_WIDTH;
+   auto left = _renderConfig->ConsoleWidthChars - DIAGNOSTICS_WIDTH;
 
    auto framesPerSecondString = format( " Frames per second: {0} ", _clock->GetFramesPerSecond() );
    auto totalFramesString = format( " Total frames:      {0} ", _clock->GetTotalFrameCount() );

--- a/MegaManLofi/GameOverStateConsoleRenderer.cpp
+++ b/MegaManLofi/GameOverStateConsoleRenderer.cpp
@@ -20,8 +20,8 @@ void GameOverStateConsoleRenderer::Render()
 {
    _consoleBuffer->SetDefaultBackgroundColor( _renderConfig->GameOverBackgroundColor );
 
-   auto left = ( _renderConfig->ConsoleWidth / 2 ) - ( _renderConfig->GameOverSprite.Width / 2 );
-   auto top = ( _renderConfig->ConsoleHeight / 2 ) - ( _renderConfig->GameOverSprite.Height / 2 );
+   auto left = ( _renderConfig->ConsoleWidthChars / 2 ) - ( _renderConfig->GameOverSprite.Width / 2 );
+   auto top = ( _renderConfig->ConsoleHeightChars / 2 ) - ( _renderConfig->GameOverSprite.Height / 2 );
 
    _consoleBuffer->Draw( left, top, _renderConfig->GameOverSprite );
 }

--- a/MegaManLofi/IPlayerInfoProvider.h
+++ b/MegaManLofi/IPlayerInfoProvider.h
@@ -11,7 +11,7 @@ namespace MegaManLofi
    public:
       virtual unsigned int GetLivesRemaining() const = 0;
       virtual Direction GetDirection() const = 0;
-      virtual const Rectangle& GetHitBox() const = 0;
+      virtual const Rectangle<long long>& GetHitBox() const = 0;
 
       virtual bool IsMoving() const = 0;
       virtual bool IsStanding() const = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -150,21 +150,21 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
 {
    auto renderConfig = make_shared<ConsoleRenderConfig>();
 
-   renderConfig->ConsoleWidth = 120;
-   renderConfig->ConsoleHeight = 30;
+   renderConfig->ConsoleWidthChars = 120;
+   renderConfig->ConsoleHeightChars = 30;
 
-   renderConfig->ArenaViewportX = 0;
-   renderConfig->ArenaViewportY = 0;
+   renderConfig->ArenaViewportLeftChars = 0;
+   renderConfig->ArenaViewportTopChars = 0;
 
    renderConfig->ArenaCharWidth = 38;
    renderConfig->ArenaCharHeight = 78;
 
-   renderConfig->ArenaViewportWidthChar = 120;
-   renderConfig->ArenaViewportHeightChar = 30;
+   renderConfig->ArenaViewportWidthChars = 120;
+   renderConfig->ArenaViewportHeightChars = 30;
 
-   renderConfig->ArenaStatusBarX = renderConfig->ArenaViewportX;
-   renderConfig->ArenaStatusBarY = renderConfig->ArenaViewportY;
-   renderConfig->ArenaStatusBarWidth = 20;
+   renderConfig->ArenaStatusBarLeftChars = renderConfig->ArenaViewportLeftChars;
+   renderConfig->ArenaStatusBarTopChars = renderConfig->ArenaViewportTopChars;
+   renderConfig->ArenaStatusBarWidthChars = 20;
 
    // "GET READY!" message should blink for 2 seconds
    renderConfig->GameStartSingleBlinkSeconds = .25;
@@ -206,19 +206,20 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStarSprite = TitleSpriteGenerator::GenerateStarSprite();
 
    renderConfig->PlayerThwipSprite = PlayerSpriteGenerator::GeneratePlayerThwipSprite();
+   renderConfig->PlayerThwipVelocity = 12'000;
 
-   renderConfig->TitleTextX = 6;
-   renderConfig->TitleTextY = 1;
-   renderConfig->TitleSubTextX = renderConfig->TitleTextX + renderConfig->TitleTextSprite.Width;
-   renderConfig->TitleSubTextY = renderConfig->TitleTextY;
-   renderConfig->TitleBuildingX = renderConfig->ConsoleWidth - renderConfig->TitleBuildingSprite.Width - 1;
-   renderConfig->TitleBuildingY = renderConfig->ConsoleHeight - renderConfig->TitleBuildingSprite.Height - 1;
-   renderConfig->TitlePlayerX = renderConfig->TitleBuildingX + 6;
-   renderConfig->TitlePlayerY = renderConfig->TitleBuildingY - renderConfig->TitlePlayerSprite.Height;
-   renderConfig->TitleStartMessageX = 55;
-   renderConfig->TitleStartMessageY = 15;
-   renderConfig->TitleKeyBindingsMiddleX = 25;
-   renderConfig->TitleKeyBindingsY = renderConfig->TitleTextY + renderConfig->TitleTextSprite.Height + 3;
+   renderConfig->TitleTextLeftChars = 6;
+   renderConfig->TitleTextTopChars = 1;
+   renderConfig->TitleSubTextLeftChars = renderConfig->TitleTextLeftChars + renderConfig->TitleTextSprite.Width;
+   renderConfig->TitleSubTextTopChars = renderConfig->TitleTextTopChars;
+   renderConfig->TitleBuildingLeftChars = renderConfig->ConsoleWidthChars - renderConfig->TitleBuildingSprite.Width - 1;
+   renderConfig->TitleBuildingTopChars = renderConfig->ConsoleHeightChars - renderConfig->TitleBuildingSprite.Height - 1;
+   renderConfig->TitlePlayerLeftChars = renderConfig->TitleBuildingLeftChars + 6;
+   renderConfig->TitlePlayerTopChars = renderConfig->TitleBuildingTopChars - renderConfig->TitlePlayerSprite.Height;
+   renderConfig->TitleStartMessageLeftChars = 55;
+   renderConfig->TitleStartMessageTopChars = 15;
+   renderConfig->TitleKeyBindingsMiddleXChars = 25;
+   renderConfig->TitleKeyBindingsTopChars = renderConfig->TitleTextTopChars + renderConfig->TitleTextSprite.Height + 3;
    renderConfig->TitleStarCount = 20;
    renderConfig->MinTitleStarVelocity = 200;
    renderConfig->MaxTitleStarVelocity = 2'000;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -205,6 +205,8 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStartMessageSprite = TitleSpriteGenerator::GenerateStartMessageSprite();
    renderConfig->TitleStarSprite = TitleSpriteGenerator::GenerateStarSprite();
 
+   renderConfig->PlayerThwipSprite = PlayerSpriteGenerator::GeneratePlayerThwipSprite();
+
    renderConfig->TitleTextX = 6;
    renderConfig->TitleTextY = 1;
    renderConfig->TitleSubTextX = renderConfig->TitleTextX + renderConfig->TitleTextSprite.Width;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -206,7 +206,7 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStarSprite = TitleSpriteGenerator::GenerateStarSprite();
 
    renderConfig->PlayerThwipSprite = PlayerSpriteGenerator::GeneratePlayerThwipSprite();
-   renderConfig->PlayerThwipVelocity = 12'000;
+   renderConfig->PlayerThwipVelocity = 10'000;
 
    renderConfig->TitleTextLeftChars = 6;
    renderConfig->TitleTextTopChars = 1;

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -24,7 +24,7 @@ namespace MegaManLofi
 
       unsigned int GetLivesRemaining() const override { return _lives; }
       Direction GetDirection() const override { return _direction; }
-      const Rectangle& GetHitBox() const override { return _hitBox; }
+      const Rectangle<long long>& GetHitBox() const override { return _hitBox; }
 
       bool IsMoving() const override;
       bool IsStanding() const override { return _isStanding; }
@@ -55,7 +55,7 @@ namespace MegaManLofi
 
       unsigned int _lives;
       Direction _direction;
-      Rectangle _hitBox;
+      Rectangle<long long> _hitBox;
 
       bool _isStanding;
       bool _isJumping;

--- a/MegaManLofi/PlayerConfig.h
+++ b/MegaManLofi/PlayerConfig.h
@@ -13,6 +13,6 @@ namespace MegaManLofi
 
       unsigned int DefaultLives = 0;
       Direction DefaultDirection = (Direction)0;
-      Rectangle DefaultHitBox = { 0, 0, 0, 0 };
+      Rectangle<long long> DefaultHitBox = { 0, 0, 0, 0 };
    };
 }

--- a/MegaManLofi/PlayerSpriteGenerator.cpp
+++ b/MegaManLofi/PlayerSpriteGenerator.cpp
@@ -1,9 +1,7 @@
 #include <string>
 
 #include "PlayerSpriteGenerator.h"
-#include "ConsoleSprite.h"
 #include "Direction.h"
-#include "ConsoleColor.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -75,4 +73,18 @@ map<Direction, ConsoleSprite> PlayerSpriteGenerator::GenerateMovingSpriteMap()
 {
    // TODO: figure out how to do sprite swapping based on frame count
    return GenerateStaticSpriteMap();
+}
+
+ConsoleSprite PlayerSpriteGenerator::GeneratePlayerThwipSprite()
+{
+   ConsoleSprite thwipSprite;
+
+   thwipSprite.Width = 1;
+   thwipSprite.Height = 3;
+   for ( int i = 0; i < thwipSprite.Height; i++ )
+   {
+      thwipSprite.Pixels.push_back( { '|', true, ConsoleColor::Blue, ConsoleColor::Black } );
+   }
+
+   return thwipSprite;
 }

--- a/MegaManLofi/PlayerSpriteGenerator.h
+++ b/MegaManLofi/PlayerSpriteGenerator.h
@@ -2,9 +2,10 @@
 
 #include <map>
 
+#include "ConsoleSprite.h"
+
 namespace MegaManLofi
 {
-   struct ConsoleSprite;
    enum class Direction;
 
    class PlayerSpriteGenerator
@@ -12,5 +13,6 @@ namespace MegaManLofi
    public:
       static std::map<Direction, ConsoleSprite> GenerateStaticSpriteMap();
       static std::map<Direction, ConsoleSprite> GenerateMovingSpriteMap();
+      static ConsoleSprite GeneratePlayerThwipSprite();
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -32,10 +32,8 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _eventAggregator( eventAggregator ),
    _frameRateProvider( frameRateProvider ),
    _viewportRectChars( { 0, 0, 0, 0 } ),
-   _viewportOffsetLeftChars( 0 ),
-   _viewportOffsetTopChars( 0 ),
-   _playerViewportLeftChars( 0 ),
-   _playerViewportTopChars( 0 ),
+   _viewportOffsetChars( { 0, 0 } ),
+   _playerViewportChars( { 0, 0 } ),
    _isAnimatingStageStart( false ),
    _isAnimatingPlayerThwipIn( false ),
    _isAnimatingPitfall( false ),
@@ -140,11 +138,11 @@ void PlayingStateConsoleRenderer::UpdateCaches()
    _viewportRectChars.Height = (short)( viewportHeightUnits / _renderConfig->ArenaCharHeight );
 
    // this accounts for the case where the arena is smaller than the viewport
-   _viewportOffsetLeftChars = _renderConfig->ArenaViewportLeftChars + ( ( _renderConfig->ArenaViewportWidthChars - _viewportRectChars.Width ) / 2 );
-   _viewportOffsetTopChars = _renderConfig->ArenaViewportTopChars + ( ( _renderConfig->ArenaViewportHeightChars - _viewportRectChars.Height ) / 2 );
+   _viewportOffsetChars.Left = _renderConfig->ArenaViewportLeftChars + ( ( _renderConfig->ArenaViewportWidthChars - _viewportRectChars.Width ) / 2 );
+   _viewportOffsetChars.Top = _renderConfig->ArenaViewportTopChars + ( ( _renderConfig->ArenaViewportHeightChars - _viewportRectChars.Height ) / 2 );
 
-   _playerViewportLeftChars = (short)( ( _arenaInfoProvider->GetPlayerPositionX() - viewportLeftUnits ) / _renderConfig->ArenaCharWidth );
-   _playerViewportTopChars = (short)( ( _arenaInfoProvider->GetPlayerPositionY() - viewportTopUnits ) / _renderConfig->ArenaCharHeight );
+   _playerViewportChars.Left = (short)( ( _arenaInfoProvider->GetPlayerPositionX() - viewportLeftUnits ) / _renderConfig->ArenaCharWidth );
+   _playerViewportChars.Top = (short)( ( _arenaInfoProvider->GetPlayerPositionY() - viewportTopUnits ) / _renderConfig->ArenaCharHeight );
 }
 
 void PlayingStateConsoleRenderer::DrawGameStartAnimation()
@@ -153,8 +151,8 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
    if ( (int)( _stageStartAnimationElapsedSeconds / _renderConfig->GameStartSingleBlinkSeconds ) % 2 == 0 )
    {
-      auto left = ( _viewportRectChars.Width / 2 ) - ( _renderConfig->GetReadySprite.Width / 2 ) + _viewportOffsetLeftChars;
-      auto top = ( _viewportRectChars.Height / 2 ) - ( _renderConfig->GetReadySprite.Height / 2 ) + _viewportOffsetTopChars;
+      auto left = ( _viewportRectChars.Width / 2 ) - ( _renderConfig->GetReadySprite.Width / 2 ) + _viewportOffsetChars.Left;
+      auto top = ( _viewportRectChars.Height / 2 ) - ( _renderConfig->GetReadySprite.Height / 2 ) + _viewportOffsetChars.Top;
 
       _consoleBuffer->Draw( left, top, _renderConfig->GetReadySprite );
    }
@@ -232,8 +230,8 @@ void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
       _renderConfig->PlayerExplosionParticleSprite1 : _renderConfig->PlayerExplosionParticleSprite2;
 
    const auto& hitBox = _playerInfoProvider->GetHitBox();
-   auto particleStartLeftChars = _playerViewportLeftChars + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _viewportOffsetLeftChars;
-   auto particleStartTopChars = _playerViewportTopChars + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _viewportOffsetTopChars;
+   auto particleStartLeftChars = _playerViewportChars.Left + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _viewportOffsetChars.Left;
+   auto particleStartTopChars = _playerViewportChars.Top + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _viewportOffsetChars.Top;
    
    auto elapsedFrames = _frameRateProvider->GetCurrentFrame() - _playerExplosionStartFrame;
    auto particleIncrement = ( _renderConfig->PlayerExplosionParticleVelocity * frameRateScalar );
@@ -271,7 +269,7 @@ void PlayingStateConsoleRenderer::DrawArenaSprites()
 
          if ( spriteId != -1 )
          {
-            _consoleBuffer->Draw( x + _viewportOffsetLeftChars, y + _viewportOffsetTopChars, _renderConfig->ArenaSpriteMap[ spriteId ] );
+            _consoleBuffer->Draw( x + _viewportOffsetChars.Left, y + _viewportOffsetChars.Top, _renderConfig->ArenaSpriteMap[ spriteId ] );
          }
       }
    }
@@ -282,7 +280,7 @@ void PlayingStateConsoleRenderer::DrawPlayer()
    auto direction = _playerInfoProvider->GetDirection();
    auto sprite = _playerInfoProvider->IsMoving() ? _renderConfig->PlayerMovingSpriteMap[direction] : _renderConfig->PlayerStaticSpriteMap[direction];
 
-   _consoleBuffer->Draw( _playerViewportLeftChars + _viewportOffsetLeftChars, _playerViewportTopChars + _viewportOffsetTopChars, sprite );
+   _consoleBuffer->Draw( _playerViewportChars.Left + _viewportOffsetChars.Left, _playerViewportChars.Top + _viewportOffsetChars.Top, sprite );
 }
 
 void PlayingStateConsoleRenderer::DrawStatusBar()
@@ -295,5 +293,5 @@ void PlayingStateConsoleRenderer::DrawPauseOverlay()
    auto left = ( _viewportRectChars.Width / 2 ) - ( _renderConfig->PauseOverlaySprite.Width / 2 );
    auto top = ( _viewportRectChars.Height / 2 ) - ( _renderConfig->PauseOverlaySprite.Height / 2 );
 
-   _consoleBuffer->Draw( left + _viewportOffsetLeftChars, top + _viewportOffsetTopChars, _renderConfig->PauseOverlaySprite );
+   _consoleBuffer->Draw( left + _viewportOffsetChars.Left, top + _viewportOffsetChars.Top, _renderConfig->PauseOverlaySprite );
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -31,16 +31,19 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _arenaInfoProvider( arenaInfoProvider ),
    _eventAggregator( eventAggregator ),
    _frameRateProvider( frameRateProvider ),
-   _viewportWidth( _renderConfig->ArenaViewportWidthChar * _renderConfig->ArenaCharWidth ),
-   _viewportHeight( _renderConfig->ArenaViewportHeightChar * _renderConfig->ArenaCharHeight ),
-   _viewportOffsetX( 0 ),
-   _viewportOffsetY( 0 ),
+   _viewportRectChars( { 0, 0, 0, 0 } ),
+   _viewportOffsetLeftChars( 0 ),
+   _viewportOffsetTopChars( 0 ),
+   _playerViewportLeftChars( 0 ),
+   _playerViewportTopChars( 0 ),
    _isAnimatingStageStart( false ),
+   _isAnimatingPlayerThwipIn( false ),
    _isAnimatingPitfall( false ),
    _isAnimatingPlayerExplosion( false ),
    _stageStartAnimationElapsedSeconds( 0 ),
    _pitfallAnimationElapsedSeconds( 0 ),
    _playerExplosionAnimationElapsedSeconds( 0 ),
+   _playerThwipBottom( 0 ),
    _playerExplosionStartFrame( 0 )
 {
    eventAggregator->RegisterEventHandler( GameEvent::StageStarted, std::bind( &PlayingStateConsoleRenderer::HandleStageStartedEvent, this ) );
@@ -53,12 +56,16 @@ void PlayingStateConsoleRenderer::Render()
    _consoleBuffer->SetDefaultForegroundColor( _renderConfig->ArenaForegroundColor );
    _consoleBuffer->SetDefaultBackgroundColor( _renderConfig->ArenaBackgroundColor );
 
-   CalculateViewportOffsets();
+   UpdateLocations();
    DrawArenaSprites();
 
    if ( _isAnimatingStageStart )
    {
       DrawGameStartAnimation();
+   }
+   else if ( _isAnimatingPlayerThwipIn )
+   {
+      DrawPlayerThwipInAnimation();
    }
    else if ( _isAnimatingPitfall )
    {
@@ -81,7 +88,7 @@ void PlayingStateConsoleRenderer::Render()
 
 bool PlayingStateConsoleRenderer::HasFocus() const
 {
-   return _isAnimatingStageStart || _isAnimatingPitfall || _isAnimatingPlayerExplosion;
+   return _isAnimatingStageStart || _isAnimatingPlayerThwipIn || _isAnimatingPitfall || _isAnimatingPlayerExplosion;
 }
 
 void PlayingStateConsoleRenderer::HandleStageStartedEvent()
@@ -103,10 +110,41 @@ void PlayingStateConsoleRenderer::HandleTileDeathEvent()
    _playerExplosionStartFrame = _frameRateProvider->GetCurrentFrame();
 }
 
-void PlayingStateConsoleRenderer::CalculateViewportOffsets()
+void PlayingStateConsoleRenderer::UpdateLocations()
 {
-   _viewportOffsetX = _arenaInfoProvider->GetPlayerPositionX() - ( _viewportWidth / 2 );
-   _viewportOffsetY = _arenaInfoProvider->GetPlayerPositionY() - ( _viewportHeight / 2 );
+   auto viewportWidthUnits = _renderConfig->ArenaViewportWidthChars * _renderConfig->ArenaCharWidth;
+   auto viewportHeightUnits = _renderConfig->ArenaViewportHeightChars * _renderConfig->ArenaCharHeight;
+
+   auto viewportLeftUnits = max( _arenaInfoProvider->GetPlayerPositionX() - ( viewportWidthUnits / 2 ), 0ll );
+   auto viewportTopUnits = max( _arenaInfoProvider->GetPlayerPositionY() - ( viewportHeightUnits / 2 ), 0ll );
+   auto viewportRightUnits = viewportLeftUnits + viewportWidthUnits;
+   auto viewportBottomUnits = viewportTopUnits + viewportHeightUnits;
+
+   auto arenaWidth = _arenaInfoProvider->GetWidth();
+   if ( viewportRightUnits > arenaWidth )
+   {
+      viewportRightUnits = arenaWidth;
+      viewportLeftUnits = max( 0ll, viewportRightUnits - viewportWidthUnits );
+   }
+
+   auto arenaHeight = _arenaInfoProvider->GetHeight();
+   if ( viewportBottomUnits > arenaHeight )
+   {
+      viewportBottomUnits = arenaHeight;
+      viewportTopUnits = max( 0ll, viewportBottomUnits - viewportHeightUnits );
+   }
+
+   _viewportRectChars.Left = (short)( viewportLeftUnits / _renderConfig->ArenaCharWidth );
+   _viewportRectChars.Top = (short)( viewportTopUnits / _renderConfig->ArenaCharHeight );
+   _viewportRectChars.Width = (short)( viewportWidthUnits / _renderConfig->ArenaCharWidth );
+   _viewportRectChars.Height = (short)( viewportHeightUnits / _renderConfig->ArenaCharHeight );
+
+   // this accounts for the case where the arena is smaller than the viewport
+   _viewportOffsetLeftChars = _renderConfig->ArenaViewportLeftChars + ( ( _renderConfig->ArenaViewportWidthChars - _viewportRectChars.Width ) / 2 );
+   _viewportOffsetTopChars = _renderConfig->ArenaViewportTopChars + ( ( _renderConfig->ArenaViewportHeightChars - _viewportRectChars.Height ) / 2 );
+
+   _playerViewportLeftChars = (short)( ( _arenaInfoProvider->GetPlayerPositionX() - viewportLeftUnits ) / _renderConfig->ArenaCharWidth );
+   _playerViewportTopChars = (short)( ( _arenaInfoProvider->GetPlayerPositionY() - viewportTopUnits ) / _renderConfig->ArenaCharHeight );
 }
 
 void PlayingStateConsoleRenderer::DrawGameStartAnimation()
@@ -115,8 +153,8 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
    if ( (int)( _stageStartAnimationElapsedSeconds / _renderConfig->GameStartSingleBlinkSeconds ) % 2 == 0 )
    {
-      auto left = ( _renderConfig->ArenaViewportWidthChar / 2 ) - ( _renderConfig->GetReadySprite.Width / 2 ) + _renderConfig->ArenaViewportX;
-      auto top = ( _renderConfig->ArenaViewportHeightChar / 2 ) - ( _renderConfig->GetReadySprite.Height / 2 ) + _renderConfig->ArenaViewportY;
+      auto left = ( _viewportRectChars.Width / 2 ) - ( _renderConfig->GetReadySprite.Width / 2 ) + _viewportOffsetLeftChars;
+      auto top = ( _viewportRectChars.Height / 2 ) - ( _renderConfig->GetReadySprite.Height / 2 ) + _viewportOffsetTopChars;
 
       _consoleBuffer->Draw( left, top, _renderConfig->GetReadySprite );
    }
@@ -124,7 +162,55 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
    if ( _stageStartAnimationElapsedSeconds >= ( _renderConfig->GameStartSingleBlinkSeconds * _renderConfig->GameStartBlinkCount ) )
    {
       _isAnimatingStageStart = false;
+      // MUFFINS
+      //_isAnimatingPlayerThwipIn = true;
+      //_playerThwipBottom = _viewportOffsetY;
    }
+}
+
+void PlayingStateConsoleRenderer::DrawPlayerThwipInAnimation()
+{
+   /*auto thwipSpriteHeightUnits = _renderConfig->PlayerThwipSprite.Height * _renderConfig->ArenaCharHeight;
+   auto thwipSpriteTopUnits = _playerThwipBottom - thwipSpriteHeightUnits;
+
+   auto thwipDelta = ( _renderConfig->PlayerThwipVelocity / _frameRateProvider->GetFramesPerSecond() );
+   thwipSpriteTopUnits += thwipDelta;
+   _playerThwipBottom += thwipDelta;
+
+   auto playerSprite = _renderConfig->PlayerStaticSpriteMap[_playerInfoProvider->GetDirection()];
+   auto thwipSpriteLeftOffsetChars = (short)( ( playerSprite.Width - _renderConfig->PlayerThwipSprite.Width ) / 2 );*/
+
+   // MUFFINS: we know where the player is going to be drawn in the viewport, so now:
+   // - figure out the Y location in the viewport to draw the sprite (in chars)
+   // - if the bottom of the thwip sprite is still higher than the bottom of the player's sprite,
+   //   draw the thwip sprite and keep going
+   // - if the bottom of the thwip sprite matches or is beyond the bottom of the player's sprite,
+   //   don't draw, and end the animation
+
+   // MUFFINS: this gets all messed up when viewport offsets are negative...
+   // maybe this whole class needs to be updated? It would be nice to have:
+   // - _viewportX/_viewportY: the actual coordinates in units of the viewport
+   // - _viewportWidth/_viewportHeight: the actual width and height in units of the viewport
+   // - _
+
+   /*auto thwipSpriteYUnits = thwipSpriteTopUnits - _viewportOffsetY;
+
+   if ( _viewportOffsetY < 0 )
+   {
+      thwipSpriteYUnits += _viewportOffsetY;
+   }
+   else if ( _viewportOffsetY + _viewportHeight > _arenaInfoProvider->GetHeight() )
+   {
+      thwipSpriteYUnits += ( _viewportOffsetY + _viewportHeight ) - _arenaInfoProvider->GetHeight();
+   }
+
+   auto thwipSpriteYChars = (short)( thwipSpriteYUnits / _renderConfig->ArenaCharHeight );*/
+
+   // END MUFFINS
+
+   // MUFFINS: we don't need this unless we're actually drawing the sprite
+   /*auto playerDrawX = GetPlayerViewportX() + _renderConfig->ArenaViewportX;
+   auto thwipSpriteDrawX = playerDrawX + thwipSpriteLeftOffsetChars;*/
 }
 
 void PlayingStateConsoleRenderer::DrawPitfallAnimation()
@@ -146,25 +232,25 @@ void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
       _renderConfig->PlayerExplosionParticleSprite1 : _renderConfig->PlayerExplosionParticleSprite2;
 
    const auto& hitBox = _playerInfoProvider->GetHitBox();
-   auto particleStartX = GetPlayerViewportX() + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _renderConfig->ArenaViewportX;
-   auto particleStartY = GetPlayerViewportY() + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _renderConfig->ArenaViewportY;
+   auto particleStartLeftChars = _playerViewportLeftChars + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _viewportOffsetLeftChars;
+   auto particleStartTopChars = _playerViewportTopChars + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _viewportOffsetTopChars;
    
    auto elapsedFrames = _frameRateProvider->GetCurrentFrame() - _playerExplosionStartFrame;
    auto particleIncrement = ( _renderConfig->PlayerExplosionParticleVelocity * frameRateScalar );
-   auto particleDeltaX = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharWidth );
-   auto particleDeltaY = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharHeight );
+   auto particleDeltaXChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharWidth );
+   auto particleDeltaYChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharHeight );
 
    // horizontal and vertical particles
-   _consoleBuffer->Draw( particleStartX + particleDeltaX, particleStartY, particleSprite );
-   _consoleBuffer->Draw( particleStartX - particleDeltaX, particleStartY, particleSprite );
-   _consoleBuffer->Draw( particleStartX, particleStartY + particleDeltaY, particleSprite );
-   _consoleBuffer->Draw( particleStartX, particleStartY - particleDeltaY, particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars + particleDeltaXChars, particleStartTopChars, particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars - particleDeltaXChars, particleStartTopChars, particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars, particleStartTopChars + particleDeltaYChars, particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars, particleStartTopChars - particleDeltaYChars, particleSprite );
 
    // diagonal particles
-   _consoleBuffer->Draw( particleStartX + (short)( particleDeltaX / 1.5 ), particleStartY + (short)( particleDeltaY / 1.5 ), particleSprite );
-   _consoleBuffer->Draw( particleStartX - (short)( particleDeltaX / 1.5 ), particleStartY + (short)( particleDeltaY / 1.5 ), particleSprite );
-   _consoleBuffer->Draw( particleStartX + (short)( particleDeltaX / 1.5 ), particleStartY - (short)( particleDeltaY / 1.5 ), particleSprite );
-   _consoleBuffer->Draw( particleStartX - (short)( particleDeltaX / 1.5 ), particleStartY - (short)( particleDeltaY / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars + (short)( particleDeltaXChars / 1.5 ), particleStartTopChars + (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars - (short)( particleDeltaXChars / 1.5 ), particleStartTopChars + (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars + (short)( particleDeltaXChars / 1.5 ), particleStartTopChars - (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( particleStartLeftChars - (short)( particleDeltaXChars / 1.5 ), particleStartTopChars - (short)( particleDeltaYChars / 1.5 ), particleSprite );
 
    if ( _playerExplosionAnimationElapsedSeconds >= _renderConfig->PlayerExplosionAnimationSeconds )
    {
@@ -174,33 +260,18 @@ void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
 
 void PlayingStateConsoleRenderer::DrawArenaSprites()
 {
-   auto spriteOffsetX = (int)max( _viewportOffsetX / _renderConfig->ArenaCharWidth, 0ll );
-   auto spriteOffsetY = (int)max( _viewportOffsetY / _renderConfig->ArenaCharHeight, 0ll );
-   auto arenaWidthChar = (int)( _arenaInfoProvider->GetWidth() / _renderConfig->ArenaCharWidth );
-   auto arenaHeightChar = (int)( _arenaInfoProvider->GetHeight() / _renderConfig->ArenaCharHeight );
+   auto arenaWidthChars = (short)( _arenaInfoProvider->GetWidth() / _renderConfig->ArenaCharWidth );
 
-   if ( ( spriteOffsetX + _renderConfig->ArenaViewportWidthChar ) > arenaWidthChar )
+   for ( short y = 0; y < _viewportRectChars.Height; y++ )
    {
-      spriteOffsetX = arenaWidthChar - _renderConfig->ArenaViewportWidthChar;
-   }
-   if ( ( spriteOffsetY + _renderConfig->ArenaViewportHeightChar ) > arenaHeightChar )
-   {
-      spriteOffsetY = arenaHeightChar - _renderConfig->ArenaViewportHeightChar;
-   }
-   
-   // TODO: this will probably crash if the arena is smaller than the viewport
-   for ( int y = 0; y < _renderConfig->ArenaViewportHeightChar; y++ )
-   {
-      for ( int x = 0; x < _renderConfig->ArenaViewportWidthChar; x++ )
+      for ( short x = 0; x < _viewportRectChars.Width; x++ )
       {
-         auto spriteIndex = ( ( y + spriteOffsetY ) * arenaWidthChar ) + ( x + spriteOffsetX );
+         auto spriteIndex = ( ( _viewportRectChars.Top + y ) * arenaWidthChars ) + ( _viewportRectChars.Left + x );
          auto spriteId = _renderConfig->ArenaSprites[spriteIndex];
 
          if ( spriteId != -1 )
          {
-            auto viewportX = x + _renderConfig->ArenaViewportX;
-            auto viewportY = y + _renderConfig->ArenaViewportY;
-            _consoleBuffer->Draw( viewportX, viewportY, _renderConfig->ArenaSpriteMap[ spriteId ] );
+            _consoleBuffer->Draw( x + _viewportOffsetLeftChars, y + _viewportOffsetTopChars, _renderConfig->ArenaSpriteMap[ spriteId ] );
          }
       }
    }
@@ -208,56 +279,21 @@ void PlayingStateConsoleRenderer::DrawArenaSprites()
 
 void PlayingStateConsoleRenderer::DrawPlayer()
 {
-   auto playerDrawX = GetPlayerViewportX() + _renderConfig->ArenaViewportX;
-   auto playerDrawY = GetPlayerViewportY() + _renderConfig->ArenaViewportY;
-
    auto direction = _playerInfoProvider->GetDirection();
    auto sprite = _playerInfoProvider->IsMoving() ? _renderConfig->PlayerMovingSpriteMap[direction] : _renderConfig->PlayerStaticSpriteMap[direction];
 
-   _consoleBuffer->Draw( playerDrawX, playerDrawY, sprite );
+   _consoleBuffer->Draw( _playerViewportLeftChars + _viewportOffsetLeftChars, _playerViewportTopChars + _viewportOffsetTopChars, sprite );
 }
 
 void PlayingStateConsoleRenderer::DrawStatusBar()
 {
-   _consoleBuffer->Draw( _renderConfig->ArenaStatusBarX, _renderConfig->ArenaStatusBarY, format( "Lives: {}", _playerInfoProvider->GetLivesRemaining() ) );
+   _consoleBuffer->Draw( _renderConfig->ArenaStatusBarLeftChars, _renderConfig->ArenaStatusBarTopChars, format( "Lives: {}", _playerInfoProvider->GetLivesRemaining() ) );
 }
 
 void PlayingStateConsoleRenderer::DrawPauseOverlay()
 {
-   auto left = ( _renderConfig->ArenaViewportWidthChar / 2 ) - ( _renderConfig->PauseOverlaySprite.Width / 2 );
-   auto top = ( _renderConfig->ArenaViewportHeightChar / 2 ) - ( _renderConfig->PauseOverlaySprite.Height / 2 );
+   auto left = ( _viewportRectChars.Width / 2 ) - ( _renderConfig->PauseOverlaySprite.Width / 2 );
+   auto top = ( _viewportRectChars.Height / 2 ) - ( _renderConfig->PauseOverlaySprite.Height / 2 );
 
-   _consoleBuffer->Draw( left, top, _renderConfig->PauseOverlaySprite );
-}
-
-short PlayingStateConsoleRenderer::GetPlayerViewportX() const
-{
-   auto playerDrawX = _arenaInfoProvider->GetPlayerPositionX() - _viewportOffsetX;
-
-   if ( _viewportOffsetX < 0 )
-   {
-      playerDrawX += _viewportOffsetX;
-   }
-   else if ( _viewportOffsetX + _viewportWidth > _arenaInfoProvider->GetWidth() )
-   {
-      playerDrawX += ( _viewportOffsetX + _viewportWidth ) - _arenaInfoProvider->GetWidth();
-   }
-
-   return (short)( playerDrawX / _renderConfig->ArenaCharWidth );
-}
-
-short PlayingStateConsoleRenderer::GetPlayerViewportY() const
-{
-   auto playerDrawY = _arenaInfoProvider->GetPlayerPositionY() - _viewportOffsetY;
-
-   if ( _viewportOffsetY < 0 )
-   {
-      playerDrawY += _viewportOffsetY;
-   }
-   else if ( _viewportOffsetY + _viewportHeight > _arenaInfoProvider->GetHeight() )
-   {
-      playerDrawY += ( _viewportOffsetY + _viewportHeight ) - _arenaInfoProvider->GetHeight();
-   }
-
-   return (short)( playerDrawY / _renderConfig->ArenaCharHeight );
+   _consoleBuffer->Draw( left + _viewportOffsetLeftChars, top + _viewportOffsetTopChars, _renderConfig->PauseOverlaySprite );
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -56,7 +56,7 @@ void PlayingStateConsoleRenderer::Render()
    _consoleBuffer->SetDefaultForegroundColor( _renderConfig->ArenaForegroundColor );
    _consoleBuffer->SetDefaultBackgroundColor( _renderConfig->ArenaBackgroundColor );
 
-   UpdateLocations();
+   UpdateCaches();
    DrawArenaSprites();
 
    if ( _isAnimatingStageStart )
@@ -110,7 +110,7 @@ void PlayingStateConsoleRenderer::HandleTileDeathEvent()
    _playerExplosionStartFrame = _frameRateProvider->GetCurrentFrame();
 }
 
-void PlayingStateConsoleRenderer::UpdateLocations()
+void PlayingStateConsoleRenderer::UpdateCaches()
 {
    auto viewportWidthUnits = _renderConfig->ArenaViewportWidthChars * _renderConfig->ArenaCharWidth;
    auto viewportHeightUnits = _renderConfig->ArenaViewportHeightChars * _renderConfig->ArenaCharHeight;

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "IGameRenderer.h"
+#include "Quad.h"
 #include "Rectangle.h"
 #include "Coordinate.h"
 
@@ -55,6 +56,7 @@ namespace MegaManLofi
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
+      Quad<long long> _viewportQuadUnits;
       Rectangle<short> _viewportRectChars;
       Coordinate<short> _viewportOffsetChars;
       Coordinate<short> _playerViewportChars;

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -34,7 +34,7 @@ namespace MegaManLofi
       void HandlePitfallEvent();
       void HandleTileDeathEvent();
 
-      void UpdateLocations();
+      void UpdateCaches();
 
       void DrawGameStartAnimation();
       void DrawPlayerThwipInAnimation();

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "IGameRenderer.h"
+#include "Rectangle.h"
 
 namespace MegaManLofi
 {
@@ -32,17 +33,17 @@ namespace MegaManLofi
       void HandleStageStartedEvent();
       void HandlePitfallEvent();
       void HandleTileDeathEvent();
-      void CalculateViewportOffsets();
+
+      void UpdateLocations();
+
       void DrawGameStartAnimation();
+      void DrawPlayerThwipInAnimation();
       void DrawPitfallAnimation();
       void DrawPlayerExplosionAnimation();
       void DrawArenaSprites();
       void DrawPlayer();
       void DrawStatusBar();
       void DrawPauseOverlay();
-
-      short GetPlayerViewportX() const;
-      short GetPlayerViewportY() const;
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
@@ -53,12 +54,16 @@ namespace MegaManLofi
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
-      long long _viewportWidth;
-      long long _viewportHeight;
-      long long _viewportOffsetX;
-      long long _viewportOffsetY;
+      Rectangle<short> _viewportRectChars;
+
+      short _viewportOffsetLeftChars;
+      short _viewportOffsetTopChars;
+
+      short _playerViewportLeftChars;
+      short _playerViewportTopChars;
 
       bool _isAnimatingStageStart;
+      bool _isAnimatingPlayerThwipIn;
       bool _isAnimatingPitfall;
       bool _isAnimatingPlayerExplosion;
 
@@ -66,6 +71,7 @@ namespace MegaManLofi
       double _pitfallAnimationElapsedSeconds;
       double _playerExplosionAnimationElapsedSeconds;
 
+      long long _playerThwipBottom;
       long long _playerExplosionStartFrame;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -4,6 +4,7 @@
 
 #include "IGameRenderer.h"
 #include "Rectangle.h"
+#include "Coordinate.h"
 
 namespace MegaManLofi
 {
@@ -55,12 +56,8 @@ namespace MegaManLofi
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
       Rectangle<short> _viewportRectChars;
-
-      short _viewportOffsetLeftChars;
-      short _viewportOffsetTopChars;
-
-      short _playerViewportLeftChars;
-      short _playerViewportTopChars;
+      Coordinate<short> _viewportOffsetChars;
+      Coordinate<short> _playerViewportChars;
 
       bool _isAnimatingStageStart;
       bool _isAnimatingPlayerThwipIn;

--- a/MegaManLofi/Quad.h
+++ b/MegaManLofi/Quad.h
@@ -2,11 +2,12 @@
 
 namespace MegaManLofi
 {
+   template<typename T>
    struct Quad
    {
-      long long Left = 0;
-      long long Top = 0;
-      long long Right = 0;
-      long long Bottom = 0;
+      T Left = 0;
+      T Top = 0;
+      T Right = 0;
+      T Bottom = 0;
    };
 }

--- a/MegaManLofi/Rectangle.h
+++ b/MegaManLofi/Rectangle.h
@@ -2,11 +2,12 @@
 
 namespace MegaManLofi
 {
+   template<typename T>
    struct Rectangle
    {
-      long long Left = 0;
-      long long Top = 0;
-      long long Width = 0;
-      long long Height = 0;
+      T Left = 0;
+      T Top = 0;
+      T Width = 0;
+      T Height = 0;
    };
 }

--- a/MegaManLofi/RectangleUtilities.cpp
+++ b/MegaManLofi/RectangleUtilities.cpp
@@ -1,10 +1,9 @@
 #include "RectangleUtilities.h"
-#include "Rectangle.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-bool RectangleUtilities::RectanglesIntersect( const Rectangle& rect1, const Rectangle& rect2 )
+bool RectangleUtilities::RectanglesIntersect( const Rectangle<long long>& rect1, const Rectangle<long long>& rect2 )
 {
    auto rect1Right = rect1.Left + rect1.Width;
    auto rect2Right = rect2.Left + rect2.Width;
@@ -20,7 +19,7 @@ bool RectangleUtilities::RectanglesIntersect( const Rectangle& rect1, const Rect
           ( leftInBounds && bottomInBounds ) || ( rightInBounds && bottomInBounds );
 }
 
-void RectangleUtilities::UnclipHorizontal( Rectangle& clippingRect, const Rectangle& clippedRect )
+void RectangleUtilities::UnclipHorizontal( Rectangle<long long>& clippingRect, const Rectangle<long long>& clippedRect )
 {
    auto clippingRectMiddle = clippingRect.Left + ( clippingRect.Width / 2 );
    auto clippedRectMiddle = clippedRect.Left + ( clippedRect.Width / 2 );
@@ -35,7 +34,7 @@ void RectangleUtilities::UnclipHorizontal( Rectangle& clippingRect, const Rectan
    }
 }
 
-void RectangleUtilities::UnclipVertical( Rectangle& clippingRect, const Rectangle& clippedRect )
+void RectangleUtilities::UnclipVertical( Rectangle<long long>& clippingRect, const Rectangle<long long>& clippedRect )
 {
    auto clippingRectMiddle = clippingRect.Top + ( clippingRect.Height / 2 );
    auto clippedRectMiddle = clippedRect.Top + ( clippedRect.Height / 2 );

--- a/MegaManLofi/RectangleUtilities.h
+++ b/MegaManLofi/RectangleUtilities.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include "Rectangle.h"
+
 namespace MegaManLofi
 {
-   struct Rectangle;
-
    class RectangleUtilities
    {
    public:
-      static bool RectanglesIntersect( const Rectangle& rect1, const Rectangle& rect2 );
+      static bool RectanglesIntersect( const Rectangle<long long>& rect1, const Rectangle<long long>& rect2 );
 
-      static void UnclipHorizontal( Rectangle& clippingRect, const Rectangle& clippedRect );
-      static void UnclipVertical( Rectangle& clippingRect, const Rectangle& clippedRect );
+      static void UnclipHorizontal( Rectangle<long long>& clippingRect, const Rectangle<long long>& clippedRect );
+      static void UnclipVertical( Rectangle<long long>& clippingRect, const Rectangle<long long>& clippedRect );
    };
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -52,14 +52,14 @@ void TitleStateConsoleRenderer::DrawStars()
 {
    for ( int i = 0; i < (int)_starCoordinates.size(); i++ )
    {
-      auto left = (short)( _starCoordinates[i].X / _renderConfig->ArenaCharWidth );
-      auto top = (short)( _starCoordinates[i].Y / _renderConfig->ArenaCharHeight );
+      auto left = (short)( _starCoordinates[i].Left / _renderConfig->ArenaCharWidth );
+      auto top = (short)( _starCoordinates[i].Top / _renderConfig->ArenaCharHeight );
       _consoleBuffer->Draw( left, top, _renderConfig->TitleStarSprite );
 
-      _starCoordinates[i].X += ( _starVelocities[i] / _frameRateProvider->GetFramesPerSecond() );
+      _starCoordinates[i].Left += ( _starVelocities[i] / _frameRateProvider->GetFramesPerSecond() );
 
       // if it's flown off the screen, generate a new star
-      if ( _starCoordinates[i].X >= ( _renderConfig->ArenaCharWidth * _renderConfig->ConsoleWidthChars ) )
+      if ( _starCoordinates[i].Left >= ( _renderConfig->ArenaCharWidth * _renderConfig->ConsoleWidthChars ) )
       {
          _starCoordinates[i] = { 0, _random->GetUnsignedInt( 0, (unsigned int)( ( _renderConfig->ConsoleHeightChars - 1 ) * _renderConfig->ArenaCharHeight ) ) };
          _starVelocities[i] = _random->GetUnsignedInt( (unsigned int)_renderConfig->MinTitleStarVelocity, (unsigned int)_renderConfig->MaxTitleStarVelocity );

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -25,8 +25,8 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
 {
    for ( int i = 0; i < renderConfig->TitleStarCount; i++ )
    {
-      _starCoordinates.push_back( { random->GetUnsignedInt( 0, (unsigned int)( ( renderConfig->ConsoleWidth - 1 ) * renderConfig->ArenaCharWidth ) ),
-                                    random->GetUnsignedInt( 0, (unsigned int)( ( renderConfig->ConsoleHeight - 1 ) * renderConfig->ArenaCharHeight ) ) } );
+      _starCoordinates.push_back( { random->GetUnsignedInt( 0, (unsigned int)( ( renderConfig->ConsoleWidthChars - 1 ) * renderConfig->ArenaCharWidth ) ),
+                                    random->GetUnsignedInt( 0, (unsigned int)( ( renderConfig->ConsoleHeightChars - 1 ) * renderConfig->ArenaCharHeight ) ) } );
       _starVelocities.push_back( random->GetUnsignedInt( (unsigned int)renderConfig->MinTitleStarVelocity,
                                                          (unsigned int)renderConfig->MaxTitleStarVelocity ) );
    }
@@ -39,11 +39,11 @@ void TitleStateConsoleRenderer::Render()
 
    DrawStars();
 
-   _consoleBuffer->Draw( _renderConfig->TitleTextX, _renderConfig->TitleTextY, _renderConfig->TitleTextSprite );
-   _consoleBuffer->Draw( _renderConfig->TitleSubTextX, _renderConfig->TitleSubTextY, _renderConfig->TitleSubTextSprite );
-   _consoleBuffer->Draw( _renderConfig->TitlePlayerX, _renderConfig->TitlePlayerY, _renderConfig->TitlePlayerSprite );
-   _consoleBuffer->Draw( _renderConfig->TitleBuildingX, _renderConfig->TitleBuildingY, _renderConfig->TitleBuildingSprite );
-   _consoleBuffer->Draw( _renderConfig->TitleStartMessageX, _renderConfig->TitleStartMessageY, _renderConfig->TitleStartMessageSprite );
+   _consoleBuffer->Draw( _renderConfig->TitleTextLeftChars, _renderConfig->TitleTextTopChars, _renderConfig->TitleTextSprite );
+   _consoleBuffer->Draw( _renderConfig->TitleSubTextLeftChars, _renderConfig->TitleSubTextTopChars, _renderConfig->TitleSubTextSprite );
+   _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars, _renderConfig->TitlePlayerTopChars, _renderConfig->TitlePlayerSprite );
+   _consoleBuffer->Draw( _renderConfig->TitleBuildingLeftChars, _renderConfig->TitleBuildingTopChars, _renderConfig->TitleBuildingSprite );
+   _consoleBuffer->Draw( _renderConfig->TitleStartMessageLeftChars, _renderConfig->TitleStartMessageTopChars, _renderConfig->TitleStartMessageSprite );
 
    DrawKeyBindings();
 }
@@ -59,9 +59,9 @@ void TitleStateConsoleRenderer::DrawStars()
       _starCoordinates[i].X += ( _starVelocities[i] / _frameRateProvider->GetFramesPerSecond() );
 
       // if it's flown off the screen, generate a new star
-      if ( _starCoordinates[i].X >= ( _renderConfig->ArenaCharWidth * _renderConfig->ConsoleWidth ) )
+      if ( _starCoordinates[i].X >= ( _renderConfig->ArenaCharWidth * _renderConfig->ConsoleWidthChars ) )
       {
-         _starCoordinates[i] = { 0, _random->GetUnsignedInt( 0, (unsigned int)( ( _renderConfig->ConsoleHeight - 1 ) * _renderConfig->ArenaCharHeight ) ) };
+         _starCoordinates[i] = { 0, _random->GetUnsignedInt( 0, (unsigned int)( ( _renderConfig->ConsoleHeightChars - 1 ) * _renderConfig->ArenaCharHeight ) ) };
          _starVelocities[i] = _random->GetUnsignedInt( (unsigned int)_renderConfig->MinTitleStarVelocity, (unsigned int)_renderConfig->MaxTitleStarVelocity );
       }
    }
@@ -69,8 +69,8 @@ void TitleStateConsoleRenderer::DrawStars()
 
 void TitleStateConsoleRenderer::DrawKeyBindings() const
 {
-   auto leftOfMiddleX = _renderConfig->TitleKeyBindingsMiddleX - 2;
-   auto top = _renderConfig->TitleKeyBindingsY;
+   auto leftOfMiddleX = _renderConfig->TitleKeyBindingsMiddleXChars - 2;
+   auto top = _renderConfig->TitleKeyBindingsTopChars;
 
    for ( auto const& [keyCode, mappedButton] : _inputConfig->KeyMap )
    {

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -37,7 +37,7 @@ namespace MegaManLofi
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<KeyboardInputConfig> _inputConfig;
 
-      std::vector<Coordinate> _starCoordinates;
+      std::vector<Coordinate<long long>> _starCoordinates;
       std::vector<long long> _starVelocities;
    };
 }

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -61,7 +61,7 @@ protected:
    shared_ptr<mock_Player> _playerMock;
 
    ArenaTile _defaultTile;
-   Rectangle _playerHitBox;
+   Rectangle<long long> _playerHitBox;
 
    shared_ptr<ArenaPhysics> _arenaPhysics;
 };

--- a/MegaManLofiTests/RectangleUtilitiesTests.cpp
+++ b/MegaManLofiTests/RectangleUtilitiesTests.cpp
@@ -11,72 +11,72 @@ class RectangleUtilitiesTests : public Test { };
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarUpperLeft_ReturnsFalse )
 {
-   Rectangle r1 { 0, 0, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 0, 0, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarUpperRight_ReturnsFalse )
 {
-   Rectangle r1 { 10, 0, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 10, 0, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarLowerRight_ReturnsFalse )
 {
-   Rectangle r1 { 10, 10, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 10, 10, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarLowerLeft_ReturnsFalse )
 {
-   Rectangle r1 { 0, 10, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 0, 10, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_LowerRightIntersects_ReturnsTrue )
 {
-   Rectangle r1 { 1, 1, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 1, 1, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_LowerLeftIntersects_ReturnsTrue )
 {
-   Rectangle r1 { 9, 1, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 9, 1, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_UpperRightIntersects_ReturnsTrue )
 {
-   Rectangle r1 { 1, 9, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 1, 9, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersect_UpperLeftIntersects_ReturnsTrue )
 {
-   Rectangle r1 { 9, 9, 10, 10 };
-   Rectangle r2 { 10, 10, 10, 10 };
+   Rectangle<long long> r1 { 9, 9, 10, 10 };
+   Rectangle<long long> r2 { 10, 10, 10, 10 };
 
    EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
 }
 
 TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheLeftSide_ClampsToTheLeftSide )
 {
-   Rectangle clippingRect { 1, 1, 10, 10 };
-   Rectangle clippedRect { 10, 10, 10, 10 };
+   Rectangle<long long> clippingRect { 1, 1, 10, 10 };
+   Rectangle<long long> clippedRect { 10, 10, 10, 10 };
 
    RectangleUtilities::UnclipHorizontal( clippingRect, clippedRect );
 
@@ -85,8 +85,8 @@ TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheLeftSide_ClampsToTheLeftS
 
 TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheRightSide_ClampsToTheRighttSide )
 {
-   Rectangle clippingRect { 19, 1, 10, 10 };
-   Rectangle clippedRect { 10, 10, 10, 10 };
+   Rectangle<long long> clippingRect { 19, 1, 10, 10 };
+   Rectangle<long long> clippedRect { 10, 10, 10, 10 };
 
    RectangleUtilities::UnclipHorizontal( clippingRect, clippedRect );
 
@@ -95,8 +95,8 @@ TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheRightSide_ClampsToTheRigh
 
 TEST_F( RectangleUtilitiesTests, UnclipVertical_OnTheTopSide_ClampsToTheTopSide )
 {
-   Rectangle clippingRect { 0, 1, 10, 10 };
-   Rectangle clippedRect { 10, 10, 10, 10 };
+   Rectangle<long long> clippingRect { 0, 1, 10, 10 };
+   Rectangle<long long> clippedRect { 10, 10, 10, 10 };
 
    RectangleUtilities::UnclipVertical( clippingRect, clippedRect );
 
@@ -105,8 +105,8 @@ TEST_F( RectangleUtilitiesTests, UnclipVertical_OnTheTopSide_ClampsToTheTopSide 
 
 TEST_F( RectangleUtilitiesTests, UnclipVertical_OnTheBottomSide_ClampsToTheBottomSide )
 {
-   Rectangle clippingRect { 0, 19, 10, 10 };
-   Rectangle clippedRect { 10, 10, 10, 10 };
+   Rectangle<long long> clippingRect { 0, 19, 10, 10 };
+   Rectangle<long long> clippedRect { 10, 10, 10, 10 };
 
    RectangleUtilities::UnclipVertical( clippingRect, clippedRect );
 

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -11,7 +11,7 @@ public:
    MOCK_METHOD( void, ResetPhysics, ( ), ( override ) );
    MOCK_METHOD( unsigned int, GetLivesRemaining, ( ), ( const, override ) );
    MOCK_METHOD( MegaManLofi::Direction, GetDirection, ( ), ( const, override ) );
-   MOCK_METHOD( const MegaManLofi::Rectangle&, GetHitBox, ( ), ( const, override ) );
+   MOCK_METHOD( const MegaManLofi::Rectangle<long long>&, GetHitBox, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsMoving, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsStanding, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsJumping, ( ), ( const, override ) );


### PR DESCRIPTION
This does a lot more than adding the thwipping animation. Namely:

- Changes the names of a whole bunch of things to try and use "left/right" instead of "x/y" when dealing with coordinates.
- Changes the names of a whole bunch of things to try and signify whether we're dealing with "units" or "chars".
- Changes `Rectangle`, `Quad` and `Coordinate` to be templated structs.
- Completely refactors `PlayingStateConsoleRenderer` to use caching instead of calculating values in every function.
- Adds the "thwip in" animation.