### PR TITLE
Added title screen "thwip out" animation

### DIFF
--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -79,6 +79,7 @@ namespace MegaManLofi
       int TitleStarCount = 0;
       long long MinTitleStarVelocity = 0;
       long long MaxTitleStarVelocity = 0;
+      double TitlePostThwipDelaySeconds = 0;
 
       ConsoleSprite GetReadySprite;
       ConsoleSprite PauseOverlaySprite;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -62,20 +62,15 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    // commands that don't observe _isPaused
    switch ( command )
    {
+      case GameCommand::StartGame:
+         StartStage();
+         _eventAggregator->RaiseEvent( GameEvent::GameStarted );
+         break;
       case GameCommand::StartStage:
-         _player->Reset();
-         _arena->Reset();
-         _playerPhysics->AssignTo( _player );
-         _arenaPhysics->AssignTo( _arena, _player );
-         _nextState = GameState::Playing;
-         _isPaused = false;
-         _eventAggregator->RaiseEvent( GameEvent::StageStarted );
+         StartStage();
          break;
       case GameCommand::TogglePause:
-         if ( _nextState == GameState::Playing )
-         {
-            _isPaused = !_isPaused;
-         }
+         TogglePause();
          break;
       case GameCommand::ExitToTitle:
          _nextState = GameState::Title;
@@ -105,6 +100,25 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
       case GameCommand::ExtendJump:
          _playerPhysics->ExtendJump();
          break;
+   }
+}
+
+void Game::StartStage()
+{
+   _player->Reset();
+   _arena->Reset();
+   _playerPhysics->AssignTo( _player );
+   _arenaPhysics->AssignTo( _arena, _player );
+   _nextState = GameState::Playing;
+   _isPaused = false;
+   _eventAggregator->RaiseEvent( GameEvent::StageStarted );
+}
+
+void Game::TogglePause()
+{
+   if ( _nextState == GameState::Playing )
+   {
+      _isPaused = !_isPaused;
    }
 }
 

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -35,6 +35,7 @@ namespace MegaManLofi
 
    private:
       void StartStage();
+      void TogglePause();
       void KillPlayer();
 
    private:

--- a/MegaManLofi/GameCommand.h
+++ b/MegaManLofi/GameCommand.h
@@ -4,7 +4,8 @@ namespace MegaManLofi
 {
    enum class GameCommand
    {
-      StartStage = 0,
+      StartGame = 0,
+      StartStage,
       PushPlayer,
       PointPlayer,
       Jump,

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -7,6 +7,7 @@ namespace MegaManLofi
       Shutdown = 0,
       ToggleDiagnostics,
 
+      GameStarted,
       StageStarted,
 
       Pitfall,

--- a/MegaManLofi/GameRenderer.cpp
+++ b/MegaManLofi/GameRenderer.cpp
@@ -20,6 +20,7 @@ GameRenderer::GameRenderer( const shared_ptr<ConsoleRenderConfig> renderConfig,
    _screenBuffer( screenBuffer ),
    _gameInfoProvider( gameInfoProvider ),
    _diagnosticsRenderer( diagnosticsRenderer ),
+   _stateRendererCache( nullptr ),
    _showDiagnostics( false ),
    _isCleaningUp( false )
 {
@@ -43,7 +44,13 @@ void GameRenderer::Render()
 
    _screenBuffer->Clear();
 
-   _stateRenderers.at( _gameInfoProvider->GetGameState() )->Render();
+   // if the cached renderer still has focus, let it finish before swapping
+   if ( _stateRendererCache == nullptr || !_stateRendererCache->HasFocus() )
+   {
+      _stateRendererCache = _stateRenderers.at( _gameInfoProvider->GetGameState() );
+   }
+
+   _stateRendererCache->Render();
 
    if ( _showDiagnostics )
    {
@@ -55,7 +62,8 @@ void GameRenderer::Render()
 
 bool GameRenderer::HasFocus() const
 {
-   return _stateRenderers.at( _gameInfoProvider->GetGameState() )->HasFocus();
+   // the cached renderer will be null on the first frame
+   return !_stateRendererCache ? _stateRenderers.at( _gameInfoProvider->GetGameState() )->HasFocus() : _stateRendererCache->HasFocus();
 }
 
 void GameRenderer::HandleShutdownEvent()

--- a/MegaManLofi/GameRenderer.h
+++ b/MegaManLofi/GameRenderer.h
@@ -39,6 +39,7 @@ namespace MegaManLofi
       const std::shared_ptr<IGameRenderer> _diagnosticsRenderer;
 
       std::map<GameState, std::shared_ptr<IGameRenderer>> _stateRenderers;
+      std::shared_ptr<IGameRenderer> _stateRendererCache;
 
       bool _showDiagnostics;
       bool _isCleaningUp;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -206,7 +206,7 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStarSprite = TitleSpriteGenerator::GenerateStarSprite();
 
    renderConfig->PlayerThwipSprite = PlayerSpriteGenerator::GeneratePlayerThwipSprite();
-   renderConfig->PlayerThwipVelocity = 10'000;
+   renderConfig->PlayerThwipVelocity = 6'000;
 
    renderConfig->TitleTextLeftChars = 6;
    renderConfig->TitleTextTopChars = 1;
@@ -223,6 +223,7 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStarCount = 20;
    renderConfig->MinTitleStarVelocity = 200;
    renderConfig->MaxTitleStarVelocity = 2'000;
+   renderConfig->TitlePostThwipDelaySeconds = 1;
 
    renderConfig->GetReadySprite = ArenaSpriteGenerator::GenerateGetReadySprite();
    renderConfig->PauseOverlaySprite = ArenaSpriteGenerator::GeneratePauseOverlaySprite();

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -132,7 +132,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
-   auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, consoleRenderConfig, keyboardInputConfig ) );
+   auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, eventAggregator, consoleRenderConfig, keyboardInputConfig ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game, player, arena, eventAggregator, clock ) );
    auto gameOverStateConsoleRenderer = shared_ptr<GameOverStateConsoleRenderer>( new GameOverStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -9,6 +9,7 @@
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"
 #include "ConsoleColor.h"
+#include "GameEvent.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -25,7 +26,8 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
    _eventAggregator( eventAggregator ),
    _renderConfig( renderConfig ),
    _inputConfig( inputConfig ),
-   _isAnimatingPlayerThwipOut( false )
+   _isAnimatingPlayerThwipOut( false ),
+   _playerThwipBottomUnits( 0 )
 {
    for ( int i = 0; i < renderConfig->TitleStarCount; i++ )
    {
@@ -34,11 +36,14 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
       _starVelocities.push_back( random->GetUnsignedInt( (unsigned int)renderConfig->MinTitleStarVelocity,
                                                          (unsigned int)renderConfig->MaxTitleStarVelocity ) );
    }
+
+   _eventAggregator->RegisterEventHandler( GameEvent::StageStarted, std::bind( &TitleStateConsoleRenderer::HandleStageStartedEvent, this ) );
 }
 
 void TitleStateConsoleRenderer::HandleStageStartedEvent()
 {
-   // MUFFINS: start the thwip animation
+   _isAnimatingPlayerThwipOut = true;
+   _playerThwipBottomUnits = ( (long long)_renderConfig->TitlePlayerTopChars + (long long)_renderConfig->TitlePlayerSprite.Height ) * _renderConfig->ArenaCharHeight;
 }
 
 void TitleStateConsoleRenderer::Render()
@@ -50,9 +55,17 @@ void TitleStateConsoleRenderer::Render()
 
    _consoleBuffer->Draw( _renderConfig->TitleTextLeftChars, _renderConfig->TitleTextTopChars, _renderConfig->TitleTextSprite );
    _consoleBuffer->Draw( _renderConfig->TitleSubTextLeftChars, _renderConfig->TitleSubTextTopChars, _renderConfig->TitleSubTextSprite );
-   _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars, _renderConfig->TitlePlayerTopChars, _renderConfig->TitlePlayerSprite );
    _consoleBuffer->Draw( _renderConfig->TitleBuildingLeftChars, _renderConfig->TitleBuildingTopChars, _renderConfig->TitleBuildingSprite );
    _consoleBuffer->Draw( _renderConfig->TitleStartMessageLeftChars, _renderConfig->TitleStartMessageTopChars, _renderConfig->TitleStartMessageSprite );
+
+   if ( _isAnimatingPlayerThwipOut )
+   {
+      DrawPlayerThwipOutAnimation();
+   }
+   else
+   {
+      _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars, _renderConfig->TitlePlayerTopChars, _renderConfig->TitlePlayerSprite );
+   }
 
    DrawKeyBindings();
 }
@@ -95,4 +108,24 @@ void TitleStateConsoleRenderer::DrawKeyBindings() const
 
       top++;
    }
+}
+
+void TitleStateConsoleRenderer::DrawPlayerThwipOutAnimation()
+{
+   auto thwipDeltaUnits = ( _renderConfig->PlayerThwipVelocity / _frameRateProvider->GetFramesPerSecond() );
+   _playerThwipBottomUnits -= thwipDeltaUnits;
+
+   auto playerSprite = _renderConfig->TitlePlayerSprite;
+   auto thwipSpriteLeftOffsetChars = (short)( ( playerSprite.Width - _renderConfig->PlayerThwipSprite.Width ) / 2 );
+   auto playerThwipBottomChars = (short)( _playerThwipBottomUnits / _renderConfig->ArenaCharHeight );
+
+   if ( playerThwipBottomChars <= 0 )
+   {
+      _isAnimatingPlayerThwipOut = false;
+      return;
+   }
+
+   _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars + thwipSpriteLeftOffsetChars,
+                         playerThwipBottomChars - _renderConfig->PlayerThwipSprite.Height,
+                         _renderConfig->PlayerThwipSprite );
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -5,6 +5,7 @@
 #include "IConsoleBuffer.h"
 #include "IRandom.h"
 #include "IFrameRateProvider.h"
+#include "IGameEventAggregator.h"
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"
 #include "ConsoleColor.h"
@@ -15,13 +16,16 @@ using namespace MegaManLofi;
 TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                       const shared_ptr<IRandom> random,
                                                       const shared_ptr<IFrameRateProvider> frameRateProvider,
+                                                      const shared_ptr<IGameEventAggregator> eventAggregator,
                                                       const shared_ptr<ConsoleRenderConfig> renderConfig,
                                                       const shared_ptr<KeyboardInputConfig> inputConfig ) :
    _consoleBuffer( consoleBuffer ),
    _random( random ),
    _frameRateProvider( frameRateProvider ),
+   _eventAggregator( eventAggregator ),
    _renderConfig( renderConfig ),
-   _inputConfig( inputConfig )
+   _inputConfig( inputConfig ),
+   _isAnimatingPlayerThwipOut( false )
 {
    for ( int i = 0; i < renderConfig->TitleStarCount; i++ )
    {
@@ -30,6 +34,11 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
       _starVelocities.push_back( random->GetUnsignedInt( (unsigned int)renderConfig->MinTitleStarVelocity,
                                                          (unsigned int)renderConfig->MaxTitleStarVelocity ) );
    }
+}
+
+void TitleStateConsoleRenderer::HandleStageStartedEvent()
+{
+   // MUFFINS: start the thwip animation
 }
 
 void TitleStateConsoleRenderer::Render()
@@ -46,6 +55,11 @@ void TitleStateConsoleRenderer::Render()
    _consoleBuffer->Draw( _renderConfig->TitleStartMessageLeftChars, _renderConfig->TitleStartMessageTopChars, _renderConfig->TitleStartMessageSprite );
 
    DrawKeyBindings();
+}
+
+bool TitleStateConsoleRenderer::HasFocus() const
+{
+   return _isAnimatingPlayerThwipOut;
 }
 
 void TitleStateConsoleRenderer::DrawStars()

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -39,10 +39,10 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
                                                          (unsigned int)renderConfig->MaxTitleStarVelocity ) );
    }
 
-   _eventAggregator->RegisterEventHandler( GameEvent::StageStarted, std::bind( &TitleStateConsoleRenderer::HandleStageStartedEvent, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::GameStarted, std::bind( &TitleStateConsoleRenderer::HandleGameStartedEvent, this ) );
 }
 
-void TitleStateConsoleRenderer::HandleStageStartedEvent()
+void TitleStateConsoleRenderer::HandleGameStartedEvent()
 {
    _isAnimatingPlayerThwipOut = true;
    _playerThwipBottomUnits = ( (long long)_renderConfig->TitlePlayerTopChars + (long long)_renderConfig->TitlePlayerSprite.Height ) * _renderConfig->ArenaCharHeight;

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -27,7 +27,9 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
    _renderConfig( renderConfig ),
    _inputConfig( inputConfig ),
    _isAnimatingPlayerThwipOut( false ),
-   _playerThwipBottomUnits( 0 )
+   _isAnimatingPostThwipDelay( false ),
+   _playerThwipBottomUnits( 0 ),
+   _postThwipElapsedSeconds( 0 )
 {
    for ( int i = 0; i < renderConfig->TitleStarCount; i++ )
    {
@@ -62,6 +64,10 @@ void TitleStateConsoleRenderer::Render()
    {
       DrawPlayerThwipOutAnimation();
    }
+   else if ( _isAnimatingPostThwipDelay )
+   {
+      DrawPostThwipDelayAnimation();
+   }
    else
    {
       _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars, _renderConfig->TitlePlayerTopChars, _renderConfig->TitlePlayerSprite );
@@ -72,7 +78,7 @@ void TitleStateConsoleRenderer::Render()
 
 bool TitleStateConsoleRenderer::HasFocus() const
 {
-   return _isAnimatingPlayerThwipOut;
+   return _isAnimatingPlayerThwipOut || _isAnimatingPostThwipDelay;
 }
 
 void TitleStateConsoleRenderer::DrawStars()
@@ -122,10 +128,24 @@ void TitleStateConsoleRenderer::DrawPlayerThwipOutAnimation()
    if ( playerThwipBottomChars <= 0 )
    {
       _isAnimatingPlayerThwipOut = false;
+
+      _postThwipElapsedSeconds = 0;
+      _isAnimatingPostThwipDelay = true;
+
       return;
    }
 
    _consoleBuffer->Draw( _renderConfig->TitlePlayerLeftChars + thwipSpriteLeftOffsetChars,
                          playerThwipBottomChars - _renderConfig->PlayerThwipSprite.Height,
                          _renderConfig->PlayerThwipSprite );
+}
+
+void TitleStateConsoleRenderer::DrawPostThwipDelayAnimation()
+{
+   _postThwipElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+
+   if ( _postThwipElapsedSeconds >= _renderConfig->TitlePostThwipDelaySeconds )
+   {
+      _isAnimatingPostThwipDelay = false;
+   }
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -25,7 +25,7 @@ namespace MegaManLofi
                                  const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                  const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
-      void HandleStageStartedEvent();
+      void HandleGameStartedEvent();
       void Render() override;
       bool HasFocus() const override;
 

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -11,6 +11,7 @@ namespace MegaManLofi
    class IConsoleBuffer;
    class IRandom;
    class IFrameRateProvider;
+   class IGameEventAggregator;
    class ConsoleRenderConfig;
    class KeyboardInputConfig;
 
@@ -20,11 +21,13 @@ namespace MegaManLofi
       TitleStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                  const std::shared_ptr<IRandom> random,
                                  const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                                 const std::shared_ptr<IGameEventAggregator> eventAggregator,
                                  const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                  const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
+      void HandleStageStartedEvent();
       void Render() override;
-      bool HasFocus() const override { return false; }
+      bool HasFocus() const override;
 
    private:
       void DrawStars();
@@ -34,10 +37,13 @@ namespace MegaManLofi
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
       const std::shared_ptr<IRandom> _random;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+      const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<KeyboardInputConfig> _inputConfig;
 
       std::vector<Coordinate<long long>> _starCoordinates;
       std::vector<long long> _starVelocities;
+
+      bool _isAnimatingPlayerThwipOut;
    };
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -33,6 +33,7 @@ namespace MegaManLofi
       void DrawStars();
       void DrawKeyBindings() const;
       void DrawPlayerThwipOutAnimation();
+      void DrawPostThwipDelayAnimation();
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
@@ -46,6 +47,8 @@ namespace MegaManLofi
       std::vector<long long> _starVelocities;
 
       bool _isAnimatingPlayerThwipOut;
+      bool _isAnimatingPostThwipDelay;
       long long _playerThwipBottomUnits;
+      double _postThwipElapsedSeconds;
    };
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -32,6 +32,7 @@ namespace MegaManLofi
    private:
       void DrawStars();
       void DrawKeyBindings() const;
+      void DrawPlayerThwipOutAnimation();
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
@@ -45,5 +46,6 @@ namespace MegaManLofi
       std::vector<long long> _starVelocities;
 
       bool _isAnimatingPlayerThwipOut;
+      long long _playerThwipBottomUnits;
    };
 }

--- a/MegaManLofi/TitleStateInputHandler.cpp
+++ b/MegaManLofi/TitleStateInputHandler.cpp
@@ -17,6 +17,6 @@ void TitleStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasAnyButtonPressed() )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::StartStage );
+      _commandExecutor->ExecuteCommand( GameCommand::StartGame );
    }
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -57,6 +57,49 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToTitle )
    EXPECT_EQ( _game->GetGameState(), GameState::Title );
 }
 
+TEST_F( GameTests, ExecuteCommand_StartGame_ResetsGameObjects )
+{
+   BuildGame();
+
+   EXPECT_CALL( *_playerMock, Reset() );
+   EXPECT_CALL( *_arenaMock, Reset() );
+
+   _game->ExecuteCommand( GameCommand::StartGame );
+}
+
+TEST_F( GameTests, ExecuteCommand_StartGame_AssignsObjectsToPhysics )
+{
+   BuildGame();
+
+   auto basePlayer = static_pointer_cast<IPlayer>( _playerMock );
+   auto baseArena = static_pointer_cast<IArena>( _arenaMock );
+
+   EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena, basePlayer ) );
+
+   _game->ExecuteCommand( GameCommand::StartGame );
+}
+
+TEST_F( GameTests, ExecuteCommand_StartGame_SetsNextGameStateToPlaying )
+{
+   BuildGame();
+
+   _game->ExecuteCommand( GameCommand::StartGame );
+   _game->Tick();
+
+   EXPECT_EQ( _game->GetGameState(), GameState::Playing );
+}
+
+TEST_F( GameTests, ExecuteCommand_StartGame_RaisesGameStartedAndStageStartedEvents )
+{
+   BuildGame();
+
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::GameStarted ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::StageStarted ) );
+
+   _game->ExecuteCommand( GameCommand::StartGame );
+}
+
 TEST_F( GameTests, ExecuteCommand_StartStage_ResetsGameObjects )
 {
    BuildGame();

--- a/MegaManLofiTests/TitleStateInputHandlerTests.cpp
+++ b/MegaManLofiTests/TitleStateInputHandlerTests.cpp
@@ -47,7 +47,7 @@ TEST_F( TitleStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartS
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
    auto args = shared_ptr<GameCommandArgs>();
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::StartStage ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::StartGame ) );
 
    _inputHandler->HandleInput();
 }


### PR DESCRIPTION
There's much more going on under the hood. A couple big things:

- `GameRenderer` now has the concept of state renderer caching. This was done to solve a problem where the Title state renderer has focus and wants to animate a twhip out, but the engine has already changed to the Playing state. Now whenever the engine swaps state renderers, `GameRenderer` checks if the previous state renderer has focus, and allows it to finish animating first.
- On top of the `StartStage` command and `StageStarted` event, there's now a `StartGame` command and `GameStarted` event. This will be useful later on, but for now it solves an issue where every time a stage starts (ex: the player dies and restarts the stage), the title screen sets its "animate thwip" flag to true.