### PR TITLE
Move animations to Animation classes

### DIFF
--- a/MegaManLofi/ArenaSpriteGenerator.cpp
+++ b/MegaManLofi/ArenaSpriteGenerator.cpp
@@ -32,9 +32,9 @@ vector<int> ArenaSpriteGenerator::GenerateArenaTiles()
    return imageIds;
 }
 
-shared_ptr<IConsoleSprite> ArenaSpriteGenerator::GenerateGetReadySprite()
+shared_ptr<IConsoleSprite> ArenaSpriteGenerator::GenerateGetReadySprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .25 ) );
+   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .25 ) );
 
    ConsoleImage getReadyImage = { 10, 1 };
    string message = "GET READY!";

--- a/MegaManLofi/ArenaSpriteGenerator.cpp
+++ b/MegaManLofi/ArenaSpriteGenerator.cpp
@@ -32,7 +32,7 @@ vector<int> ArenaSpriteGenerator::GenerateArenaTiles()
    return imageIds;
 }
 
-shared_ptr<ConsoleSprite> ArenaSpriteGenerator::GenerateGetReadySprite()
+shared_ptr<IConsoleSprite> ArenaSpriteGenerator::GenerateGetReadySprite()
 {
    auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .25 ) );
 

--- a/MegaManLofi/ArenaSpriteGenerator.h
+++ b/MegaManLofi/ArenaSpriteGenerator.h
@@ -3,15 +3,17 @@
 #include <memory>
 #include <vector>
 
-#include "ConsoleSprite.h"
+#include "ConsoleImage.h"
 
 namespace MegaManLofi
 {
+   class IConsoleSprite;
+
    class ArenaSpriteGenerator
    {
    public:
       static std::vector<int> GenerateArenaTiles();
-      static std::shared_ptr<ConsoleSprite> GenerateGetReadySprite();
+      static std::shared_ptr<IConsoleSprite> GenerateGetReadySprite();
       static ConsoleImage GeneratePauseOverlayImage();
       static ConsoleImage GenerateGameOverImage();
    };

--- a/MegaManLofi/ArenaSpriteGenerator.h
+++ b/MegaManLofi/ArenaSpriteGenerator.h
@@ -8,12 +8,13 @@
 namespace MegaManLofi
 {
    class IConsoleSprite;
+   class IFrameRateProvider;
 
    class ArenaSpriteGenerator
    {
    public:
       static std::vector<int> GenerateArenaTiles();
-      static std::shared_ptr<IConsoleSprite> GenerateGetReadySprite();
+      static std::shared_ptr<IConsoleSprite> GenerateGetReadySprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
       static ConsoleImage GeneratePauseOverlayImage();
       static ConsoleImage GenerateGameOverImage();
    };

--- a/MegaManLofi/ConsoleAnimationRepository.cpp
+++ b/MegaManLofi/ConsoleAnimationRepository.cpp
@@ -1,0 +1,14 @@
+#include "ConsoleAnimationRepository.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+void ConsoleAnimationRepository::AddAnimation( ConsoleAnimationType type, const shared_ptr<IConsoleAnimation> animation )
+{
+   _animationMap[type] = animation;
+}
+
+const shared_ptr<IConsoleAnimation> ConsoleAnimationRepository::GetAnimation( ConsoleAnimationType type ) const
+{
+   return _animationMap.at( type );
+}

--- a/MegaManLofi/ConsoleAnimationRepository.h
+++ b/MegaManLofi/ConsoleAnimationRepository.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <map>
+
+#include "IConsoleAnimationProvider.h"
+
+namespace MegaManLofi
+{
+   class ConsoleAnimationRepository : public IConsoleAnimationProvider
+   {
+   public:
+      void AddAnimation( ConsoleAnimationType type, std::shared_ptr<IConsoleAnimation> animation );
+
+      const std::shared_ptr<IConsoleAnimation> GetAnimation( ConsoleAnimationType type ) const;
+
+   private:
+      std::map<ConsoleAnimationType, std::shared_ptr<IConsoleAnimation>> _animationMap;
+   };
+}

--- a/MegaManLofi/ConsoleAnimationType.h
+++ b/MegaManLofi/ConsoleAnimationType.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace MegaManLofi
+{
+   enum class ConsoleAnimationType
+   {
+      PlayerThwipOut = 0,
+      PlayerThwipIn,
+      StageStarted,
+      PlayerExploded
+   };
+}

--- a/MegaManLofi/ConsoleBuffer.cpp
+++ b/MegaManLofi/ConsoleBuffer.cpp
@@ -5,7 +5,7 @@
 
 #include "ConsoleBuffer.h"
 #include "ConsoleRenderConfig.h"
-#include "ConsoleSprite.h"
+#include "IConsoleSprite.h"
 
 namespace MegaManLofi
 {
@@ -194,7 +194,7 @@ void ConsoleBuffer::Draw( short left, short top, const ConsoleImage& image )
    }
 }
 
-void ConsoleBuffer::Draw( short left, short top, const std::shared_ptr<ConsoleSprite> sprite )
+void ConsoleBuffer::Draw( short left, short top, const std::shared_ptr<IConsoleSprite> sprite )
 {
    Draw( left, top, sprite->GetCurrentImage() );
 }

--- a/MegaManLofi/ConsoleBuffer.h
+++ b/MegaManLofi/ConsoleBuffer.h
@@ -28,7 +28,7 @@ namespace MegaManLofi
       void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor ) override;
       void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
       void Draw( short left, short top, const ConsoleImage& image ) override;
-      void Draw( short left, short top, const std::shared_ptr<ConsoleSprite> sprite ) override;
+      void Draw( short left, short top, const std::shared_ptr<IConsoleSprite> sprite ) override;
 
       void Flip() override;
 

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -61,6 +61,7 @@ namespace MegaManLofi
       std::shared_ptr<IConsoleSprite> PlayerThwipInTransitionSprite;
       std::shared_ptr<IConsoleSprite> PlayerThwipOutTransitionSprite;
       long long PlayerThwipVelocity = 0;
+      double PlayerPostThwipDelaySeconds = 0;
 
       short TitleTextLeftChars = 0;
       short TitleTextTopChars = 0;
@@ -77,7 +78,6 @@ namespace MegaManLofi
       int TitleStarCount = 0;
       long long MinTitleStarVelocity = 0;
       long long MaxTitleStarVelocity = 0;
-      double TitlePostThwipDelaySeconds = 0;
 
       std::shared_ptr<IConsoleSprite> GetReadySprite;
       double GetReadyAnimationSeconds = 0;

--- a/MegaManLofi/ConsoleRenderConfig.h
+++ b/MegaManLofi/ConsoleRenderConfig.h
@@ -5,11 +5,13 @@
 #include <vector>
 
 #include "IGameRenderConfig.h"
-#include "ConsoleSprite.h"
 #include "Direction.h"
+#include "ConsoleImage.h"
 
 namespace MegaManLofi
 {
+   class IConsoleSprite;
+
    class ConsoleRenderConfig : public IGameRenderConfig
    {
    public:
@@ -32,7 +34,7 @@ namespace MegaManLofi
       double PitfallAnimationSeconds = 0;
 
       double PlayerExplosionAnimationSeconds = 0;
-      std::shared_ptr<ConsoleSprite> PlayerExplosionParticleSprite;
+      std::shared_ptr<IConsoleSprite> PlayerExplosionParticleSprite;
       long long PlayerExplosionParticleVelocity = 0;
 
       ConsoleColor DefaultForegroundColor = (ConsoleColor)0;
@@ -55,9 +57,9 @@ namespace MegaManLofi
       ConsoleImage TitleStartMessageImage;
       ConsoleImage TitleStarImage;
 
-      std::shared_ptr<ConsoleSprite> PlayerThwipSprite;
-      std::shared_ptr<ConsoleSprite> PlayerThwipInTransitionSprite;
-      std::shared_ptr<ConsoleSprite> PlayerThwipOutTransitionSprite;
+      std::shared_ptr<IConsoleSprite> PlayerThwipSprite;
+      std::shared_ptr<IConsoleSprite> PlayerThwipInTransitionSprite;
+      std::shared_ptr<IConsoleSprite> PlayerThwipOutTransitionSprite;
       long long PlayerThwipVelocity = 0;
 
       short TitleTextLeftChars = 0;
@@ -77,15 +79,15 @@ namespace MegaManLofi
       long long MaxTitleStarVelocity = 0;
       double TitlePostThwipDelaySeconds = 0;
 
-      std::shared_ptr<ConsoleSprite> GetReadySprite;
+      std::shared_ptr<IConsoleSprite> GetReadySprite;
       double GetReadyAnimationSeconds = 0;
 
       ConsoleImage PauseOverlayImage;
       ConsoleImage GameOverImage;
 
-      std::map<Direction, std::shared_ptr<ConsoleSprite>> PlayerStandingSpriteMap;
-      std::map<Direction, std::shared_ptr<ConsoleSprite>> PlayerWalkingSpriteMap;
-      std::map<Direction, std::shared_ptr<ConsoleSprite>> PlayerFallingSpriteMap;
+      std::map<Direction, std::shared_ptr<IConsoleSprite>> PlayerStandingSpriteMap;
+      std::map<Direction, std::shared_ptr<IConsoleSprite>> PlayerWalkingSpriteMap;
+      std::map<Direction, std::shared_ptr<IConsoleSprite>> PlayerFallingSpriteMap;
 
       std::map<int, ConsoleImage> ArenaImageMap;
       std::vector<int> ArenaTiles;

--- a/MegaManLofi/ConsoleSprite.cpp
+++ b/MegaManLofi/ConsoleSprite.cpp
@@ -1,9 +1,12 @@
 #include "ConsoleSprite.h"
+#include "IFrameRateProvider.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-ConsoleSprite::ConsoleSprite( double imageTraversalSeconds ) :
+ConsoleSprite::ConsoleSprite( const shared_ptr<IFrameRateProvider> frameRateProvider,
+                              double imageTraversalSeconds ) :
+   _frameRateProvider( frameRateProvider ),
    _currentImageIndex( 0 ),
    _imageTraversalSeconds( imageTraversalSeconds ),
    _totalSpriteSeconds( 0 ),
@@ -17,7 +20,7 @@ void ConsoleSprite::AddImage( ConsoleImage image )
    _totalSpriteSeconds = _images.size() * _imageTraversalSeconds;
 }
 
-void ConsoleSprite::Tick( int framesPerSecond )
+void ConsoleSprite::Tick()
 {
    if ( _images.size() == 1 )
    {
@@ -25,7 +28,7 @@ void ConsoleSprite::Tick( int framesPerSecond )
    }
    else if ( _totalSpriteSeconds > 0 )
    {
-      _spriteElapsedSeconds += ( 1 / (double)framesPerSecond );
+      _spriteElapsedSeconds += _frameRateProvider->GetFrameScalar();
 
       while ( _spriteElapsedSeconds > _totalSpriteSeconds )
       {

--- a/MegaManLofi/ConsoleSprite.cpp
+++ b/MegaManLofi/ConsoleSprite.cpp
@@ -45,6 +45,12 @@ void ConsoleSprite::Tick( int framesPerSecond )
    }
 }
 
+void ConsoleSprite::Reset()
+{
+   _currentImageIndex = 0;
+   _spriteElapsedSeconds = 0;
+}
+
 short ConsoleSprite::GetWidth() const
 {
    return _images[_currentImageIndex].Width;

--- a/MegaManLofi/ConsoleSprite.h
+++ b/MegaManLofi/ConsoleSprite.h
@@ -1,18 +1,22 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "IConsoleSprite.h"
 
 namespace MegaManLofi
 {
+   class IFrameRateProvider;
+
    class ConsoleSprite : public IConsoleSprite
    {
    public:
-      ConsoleSprite( double imageTraversalSeconds );
+      ConsoleSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                     double imageTraversalSeconds );
 
       void AddImage( ConsoleImage image ) override;
-      void Tick( int framesPerSecond ) override;
+      void Tick() override;
       void Reset() override;
 
       short GetWidth() const override;
@@ -21,6 +25,8 @@ namespace MegaManLofi
       const ConsoleImage& GetCurrentImage() const override;
 
    private:
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+
       std::vector<ConsoleImage> _images;
       int _currentImageIndex;
       double _imageTraversalSeconds;

--- a/MegaManLofi/ConsoleSprite.h
+++ b/MegaManLofi/ConsoleSprite.h
@@ -2,22 +2,23 @@
 
 #include <vector>
 
-#include "ConsoleImage.h"
+#include "IConsoleSprite.h"
 
 namespace MegaManLofi
 {
-   class ConsoleSprite
+   class ConsoleSprite : public IConsoleSprite
    {
    public:
       ConsoleSprite( double imageTraversalSeconds );
 
-      void AddImage( ConsoleImage image );
-      void Tick( int framesPerSecond );
+      void AddImage( ConsoleImage image ) override;
+      void Tick( int framesPerSecond ) override;
+      void Reset() override;
 
-      short GetWidth() const;
-      short GetHeight() const;
-      double GetTotalTraversalSeconds() const { return _totalSpriteSeconds; }
-      const ConsoleImage& GetCurrentImage() const;
+      short GetWidth() const override;
+      short GetHeight() const override;
+      double GetTotalTraversalSeconds() const override { return _totalSpriteSeconds; }
+      const ConsoleImage& GetCurrentImage() const override;
 
    private:
       std::vector<ConsoleImage> _images;

--- a/MegaManLofi/GameClock.cpp
+++ b/MegaManLofi/GameClock.cpp
@@ -14,7 +14,8 @@ GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock
    _totalFrameCount( 0 ),
    _lagFrameCount( 0 ),
    _frameStartTimeNano(),
-   _nanoSecondsPerFrame( 1'000'000'000ll / framesPerSecond )
+   _nanoSecondsPerFrame( 1'000'000'000ll / framesPerSecond ),
+   _frameScalar( 1 / (double)framesPerSecond )
 {
 }
 

--- a/MegaManLofi/GameClock.h
+++ b/MegaManLofi/GameClock.h
@@ -24,6 +24,7 @@ namespace MegaManLofi
       long long GetLagFrameCount() const override { return _lagFrameCount; }
 
       long long GetCurrentFrame() const override { return _totalFrameCount; }
+      double GetFrameScalar() const override { return _frameScalar; }
 
    private:
       const std::shared_ptr<IHighResolutionClock> _highResolutionClock;
@@ -34,5 +35,6 @@ namespace MegaManLofi
       long long _lagFrameCount;
       long long _frameStartTimeNano;
       long long _nanoSecondsPerFrame;
+      double _frameScalar;
    };
 }

--- a/MegaManLofi/IConsoleAnimation.h
+++ b/MegaManLofi/IConsoleAnimation.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Coordinate.h"
+
+namespace MegaManLofi
+{
+   class __declspec( novtable ) IConsoleAnimation
+   {
+   public:
+      virtual void Start( Coordinate<short> startCoordinate, Coordinate<short> endCoordinate ) = 0;
+      virtual bool IsRunning() const = 0;
+      virtual void Draw() = 0;
+      virtual void Tick( int framesPerSecond ) = 0;
+   };
+}

--- a/MegaManLofi/IConsoleAnimation.h
+++ b/MegaManLofi/IConsoleAnimation.h
@@ -7,7 +7,7 @@ namespace MegaManLofi
    class __declspec( novtable ) IConsoleAnimation
    {
    public:
-      virtual void Start( Coordinate<short> startCoordinate, Coordinate<short> endCoordinate ) = 0;
+      virtual void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) = 0;
       virtual bool IsRunning() const = 0;
       virtual void Draw() = 0;
       virtual void Tick( int framesPerSecond ) = 0;

--- a/MegaManLofi/IConsoleAnimation.h
+++ b/MegaManLofi/IConsoleAnimation.h
@@ -10,6 +10,6 @@ namespace MegaManLofi
       virtual void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) = 0;
       virtual bool IsRunning() const = 0;
       virtual void Draw() = 0;
-      virtual void Tick( int framesPerSecond ) = 0;
+      virtual void Tick() = 0;
    };
 }

--- a/MegaManLofi/IConsoleAnimationProvider.h
+++ b/MegaManLofi/IConsoleAnimationProvider.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+
+#include "ConsoleAnimationType.h"
+
+namespace MegaManLofi
+{
+   class IConsoleAnimation;
+
+   class __declspec( novtable ) IConsoleAnimationProvider
+   {
+   public:
+      virtual const std::shared_ptr<IConsoleAnimation> GetAnimation( ConsoleAnimationType type ) const = 0;
+   };
+}

--- a/MegaManLofi/IConsoleBuffer.h
+++ b/MegaManLofi/IConsoleBuffer.h
@@ -8,7 +8,7 @@
 
 namespace MegaManLofi
 {
-   class ConsoleSprite;
+   class IConsoleSprite;
 
    class __declspec( novtable ) IConsoleBuffer : public IScreenBuffer
    {
@@ -27,7 +27,7 @@ namespace MegaManLofi
       virtual void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor ) = 0;
       virtual void Draw( short left, short top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
       virtual void Draw( short left, short top, const ConsoleImage& image ) = 0;
-      virtual void Draw( short left, short top, const std::shared_ptr<ConsoleSprite> sprite ) = 0;
+      virtual void Draw( short left, short top, const std::shared_ptr<IConsoleSprite> sprite ) = 0;
 
       virtual void Flip() override = 0;
    };

--- a/MegaManLofi/IConsoleSprite.h
+++ b/MegaManLofi/IConsoleSprite.h
@@ -8,7 +8,7 @@ namespace MegaManLofi
    {
    public:
       virtual void AddImage( ConsoleImage image ) = 0;
-      virtual void Tick( int framesPerSecond ) = 0;
+      virtual void Tick() = 0;
       virtual void Reset() = 0;
 
       virtual short GetWidth() const = 0;

--- a/MegaManLofi/IConsoleSprite.h
+++ b/MegaManLofi/IConsoleSprite.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ConsoleImage.h"
+
+namespace MegaManLofi
+{
+   class __declspec( novtable ) IConsoleSprite
+   {
+   public:
+      virtual void AddImage( ConsoleImage image ) = 0;
+      virtual void Tick( int framesPerSecond ) = 0;
+      virtual void Reset() = 0;
+
+      virtual short GetWidth() const = 0;
+      virtual short GetHeight() const = 0;
+      virtual double GetTotalTraversalSeconds() const = 0;
+      virtual const ConsoleImage& GetCurrentImage() const = 0;;
+   };
+}

--- a/MegaManLofi/IFrameRateProvider.h
+++ b/MegaManLofi/IFrameRateProvider.h
@@ -7,5 +7,6 @@ namespace MegaManLofi
    public:
       virtual int GetFramesPerSecond() const = 0;
       virtual long long GetCurrentFrame() const = 0;
+      virtual double GetFrameScalar() const = 0;
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -28,6 +28,7 @@
 #include "ArenaPhysics.h"
 #include "Game.h"
 #include "PlayerThwipOutConsoleAnimation.h"
+#include "StageStartedConsoleAnimation.h"
 #include "PlayerThwipInConsoleAnimation.h"
 #include "ConsoleAnimationRepository.h"
 #include "DiagnosticsConsoleRenderer.h"
@@ -143,9 +144,11 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // animations
    auto playerThwipOutAnimation = shared_ptr<PlayerThwipOutConsoleAnimation>( new PlayerThwipOutConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
+   auto stageStartedAnimation = shared_ptr<StageStartedConsoleAnimation>( new StageStartedConsoleAnimation() );
    auto playerThwipInAnimation = shared_ptr<PlayerThwipInConsoleAnimation>( new PlayerThwipInConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
    auto animationRepository = make_shared<ConsoleAnimationRepository>();
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipOut, playerThwipOutAnimation );
+   animationRepository->AddAnimation( ConsoleAnimationType::StageStarted, stageStartedAnimation );
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipIn, playerThwipInAnimation );
 
    // rendering objects

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -148,7 +148,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
    auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, eventAggregator, consoleRenderConfig, keyboardInputConfig, animationRepository ) );
-   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game, player, arena, eventAggregator, clock ) );
+   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game, player, arena, eventAggregator, clock, animationRepository ) );
    auto gameOverStateConsoleRenderer = shared_ptr<GameOverStateConsoleRenderer>( new GameOverStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Title, titleStateConsoleRenderer );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -27,6 +27,8 @@
 #include "PlayerPhysics.h"
 #include "ArenaPhysics.h"
 #include "Game.h"
+#include "PlayerThwipOutConsoleAnimation.h"
+#include "ConsoleAnimationRepository.h"
 #include "DiagnosticsConsoleRenderer.h"
 #include "TitleStateInputHandler.h"
 #include "PlayingStateInputHandler.h"
@@ -129,9 +131,14 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    inputHandler->AddInputHandlerForGameState( GameState::Playing, playingStateInputHandler );
    inputHandler->AddInputHandlerForGameState( GameState::GameOver, gameOverStateInputHandler );
 
+   // animations
+   auto playerThwipOutAnimation = shared_ptr<PlayerThwipOutConsoleAnimation>( new PlayerThwipOutConsoleAnimation( consoleBuffer, consoleRenderConfig ) );
+   auto animationRepository = make_shared<ConsoleAnimationRepository>();
+   animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipOut, playerThwipOutAnimation );
+
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
-   auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, eventAggregator, consoleRenderConfig, keyboardInputConfig ) );
+   auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, eventAggregator, consoleRenderConfig, keyboardInputConfig, animationRepository ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game, player, arena, eventAggregator, clock ) );
    auto gameOverStateConsoleRenderer = shared_ptr<GameOverStateConsoleRenderer>( new GameOverStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -144,7 +144,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // animations
    auto playerThwipOutAnimation = shared_ptr<PlayerThwipOutConsoleAnimation>( new PlayerThwipOutConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
-   auto stageStartedAnimation = shared_ptr<StageStartedConsoleAnimation>( new StageStartedConsoleAnimation() );
+   auto stageStartedAnimation = shared_ptr<StageStartedConsoleAnimation>( new StageStartedConsoleAnimation( consoleBuffer, clock, consoleRenderConfig ) );
    auto playerThwipInAnimation = shared_ptr<PlayerThwipInConsoleAnimation>( new PlayerThwipInConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
    auto animationRepository = make_shared<ConsoleAnimationRepository>();
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipOut, playerThwipOutAnimation );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -28,6 +28,7 @@
 #include "ArenaPhysics.h"
 #include "Game.h"
 #include "PlayerThwipOutConsoleAnimation.h"
+#include "PlayerThwipInConsoleAnimation.h"
 #include "ConsoleAnimationRepository.h"
 #include "DiagnosticsConsoleRenderer.h"
 #include "TitleStateInputHandler.h"
@@ -142,8 +143,10 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // animations
    auto playerThwipOutAnimation = shared_ptr<PlayerThwipOutConsoleAnimation>( new PlayerThwipOutConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
+   auto playerThwipInAnimation = shared_ptr<PlayerThwipInConsoleAnimation>( new PlayerThwipInConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
    auto animationRepository = make_shared<ConsoleAnimationRepository>();
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipOut, playerThwipOutAnimation );
+   animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipIn, playerThwipInAnimation );
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -203,6 +203,7 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->PlayerThwipInTransitionSprite = PlayerSpriteGenerator::GenerateThwipInTransitionSprite();
    renderConfig->PlayerThwipOutTransitionSprite = PlayerSpriteGenerator::GenerateThwipOutTransitionSprite();
    renderConfig->PlayerThwipVelocity = 5'000;
+   renderConfig->PlayerPostThwipDelaySeconds = 1;
 
    renderConfig->TitleTextLeftChars = 6;
    renderConfig->TitleTextTopChars = 1;
@@ -219,7 +220,6 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
    renderConfig->TitleStarCount = 20;
    renderConfig->MinTitleStarVelocity = 200;
    renderConfig->MaxTitleStarVelocity = 2'000;
-   renderConfig->TitlePostThwipDelaySeconds = 1;
 
    renderConfig->GetReadySprite = ArenaSpriteGenerator::GenerateGetReadySprite();
    renderConfig->GetReadyAnimationSeconds = 2;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -30,6 +30,7 @@
 #include "PlayerThwipOutConsoleAnimation.h"
 #include "StageStartedConsoleAnimation.h"
 #include "PlayerThwipInConsoleAnimation.h"
+#include "PlayerExplodedConsoleAnimation.h"
 #include "ConsoleAnimationRepository.h"
 #include "DiagnosticsConsoleRenderer.h"
 #include "TitleStateInputHandler.h"
@@ -146,10 +147,12 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    auto playerThwipOutAnimation = shared_ptr<PlayerThwipOutConsoleAnimation>( new PlayerThwipOutConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
    auto stageStartedAnimation = shared_ptr<StageStartedConsoleAnimation>( new StageStartedConsoleAnimation( consoleBuffer, clock, consoleRenderConfig ) );
    auto playerThwipInAnimation = shared_ptr<PlayerThwipInConsoleAnimation>( new PlayerThwipInConsoleAnimation( consoleBuffer, consoleRenderConfig, clock ) );
+   auto playerExplodedAnimation = shared_ptr<PlayerExplodedConsoleAnimation>( new PlayerExplodedConsoleAnimation( consoleBuffer, clock, consoleRenderConfig ) );
    auto animationRepository = make_shared<ConsoleAnimationRepository>();
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipOut, playerThwipOutAnimation );
    animationRepository->AddAnimation( ConsoleAnimationType::StageStarted, stageStartedAnimation );
    animationRepository->AddAnimation( ConsoleAnimationType::PlayerThwipIn, playerThwipInAnimation );
+   animationRepository->AddAnimation( ConsoleAnimationType::PlayerExploded, playerExplodedAnimation );
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -41,7 +41,7 @@
 #include "GameState.h"
 #include "Direction.h"
 #include "ArenaTile.h"
-#include "ConsoleSprite.h"
+#include "IConsoleSprite.h"
 #include "PlayerSpriteGenerator.h"
 #include "ArenaTileGenerator.h"
 #include "ArenaSpriteGenerator.h"

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -219,6 +219,7 @@
     <ClInclude Include="IArenaInfoProvider.h" />
     <ClInclude Include="IArenaPhysics.h" />
     <ClInclude Include="IConsoleAnimation.h" />
+    <ClInclude Include="IConsoleAnimationProvider.h" />
     <ClInclude Include="IConsoleSprite.h" />
     <ClInclude Include="IFrameActionRegistry.h" />
     <ClInclude Include="IFrameRateProvider.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -190,6 +190,7 @@
     <ClInclude Include="ArenaTileGenerator.h" />
     <ClInclude Include="ArenaPhysics.h" />
     <ClInclude Include="ArenaTile.h" />
+    <ClInclude Include="ConsoleAnimationType.h" />
     <ClInclude Include="ConsoleColor.h" />
     <ClInclude Include="ConsoleBuffer.h" />
     <ClInclude Include="ConsoleImage.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="PlayerPhysics.cpp" />
     <ClCompile Include="Player.cpp" />
     <ClCompile Include="PlayerSpriteGenerator.cpp" />
+    <ClCompile Include="PlayerThwipInConsoleAnimation.cpp" />
     <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp" />
     <ClCompile Include="PlayingStateConsoleRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
@@ -255,6 +256,7 @@
     <ClInclude Include="PlayerPhysics.h" />
     <ClInclude Include="PlayerPhysicsConfig.h" />
     <ClInclude Include="PlayerSpriteGenerator.h" />
+    <ClInclude Include="PlayerThwipInConsoleAnimation.h" />
     <ClInclude Include="PlayerThwipOutConsoleAnimation.h" />
     <ClInclude Include="PointPlayerCommandArgs.h" />
     <ClInclude Include="PushPlayerCommandArgs.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="ArenaSpriteGenerator.cpp" />
     <ClCompile Include="ArenaTileGenerator.cpp" />
     <ClCompile Include="ArenaPhysics.cpp" />
+    <ClCompile Include="ConsoleAnimationRepository.cpp" />
     <ClCompile Include="ConsoleBuffer.cpp" />
     <ClCompile Include="ConsoleSprite.cpp" />
     <ClCompile Include="FrameActionRegistry.cpp" />
@@ -191,6 +192,7 @@
     <ClInclude Include="ArenaTileGenerator.h" />
     <ClInclude Include="ArenaPhysics.h" />
     <ClInclude Include="ArenaTile.h" />
+    <ClInclude Include="ConsoleAnimationRepository.h" />
     <ClInclude Include="ConsoleAnimationType.h" />
     <ClInclude Include="ConsoleColor.h" />
     <ClInclude Include="ConsoleBuffer.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="RandomWrapper.cpp" />
     <ClCompile Include="RectangleUtilities.cpp" />
     <ClCompile Include="SleeperWrapper.cpp" />
+    <ClCompile Include="StageStartedConsoleAnimation.cpp" />
     <ClCompile Include="TitleStateConsoleRenderer.cpp" />
     <ClCompile Include="TitleStateInputHandler.cpp" />
     <ClCompile Include="ThreadWrapper.cpp" />
@@ -269,6 +270,7 @@
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
     <ClInclude Include="SleeperWrapper.h" />
+    <ClInclude Include="StageStartedConsoleAnimation.h" />
     <ClInclude Include="TitleStateInputHandler.h" />
     <ClInclude Include="TitleStateConsoleRenderer.h" />
     <ClInclude Include="ThreadWrapper.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -216,6 +216,7 @@
     <ClInclude Include="IArena.h" />
     <ClInclude Include="IArenaInfoProvider.h" />
     <ClInclude Include="IArenaPhysics.h" />
+    <ClInclude Include="IConsoleAnimation.h" />
     <ClInclude Include="IFrameActionRegistry.h" />
     <ClInclude Include="IFrameRateProvider.h" />
     <ClInclude Include="IGame.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="PlayerPhysics.cpp" />
     <ClCompile Include="Player.cpp" />
     <ClCompile Include="PlayerSpriteGenerator.cpp" />
+    <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp" />
     <ClCompile Include="PlayingStateConsoleRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
     <ClCompile Include="RandomWrapper.cpp" />
@@ -218,6 +219,7 @@
     <ClInclude Include="IArenaInfoProvider.h" />
     <ClInclude Include="IArenaPhysics.h" />
     <ClInclude Include="IConsoleAnimation.h" />
+    <ClInclude Include="IConsoleSprite.h" />
     <ClInclude Include="IFrameActionRegistry.h" />
     <ClInclude Include="IFrameRateProvider.h" />
     <ClInclude Include="IGame.h" />
@@ -250,6 +252,7 @@
     <ClInclude Include="PlayerPhysics.h" />
     <ClInclude Include="PlayerPhysicsConfig.h" />
     <ClInclude Include="PlayerSpriteGenerator.h" />
+    <ClInclude Include="PlayerThwipOutConsoleAnimation.h" />
     <ClInclude Include="PointPlayerCommandArgs.h" />
     <ClInclude Include="PushPlayerCommandArgs.h" />
     <ClInclude Include="ConsolePixel.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="HighResolutionClockWrapper.cpp" />
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="KeyboardWrapper.cpp" />
+    <ClCompile Include="PlayerExplodedConsoleAnimation.cpp" />
     <ClCompile Include="PlayerPhysics.cpp" />
     <ClCompile Include="Player.cpp" />
     <ClCompile Include="PlayerSpriteGenerator.cpp" />
@@ -254,6 +255,7 @@
     <ClInclude Include="ISleeper.h" />
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
+    <ClInclude Include="PlayerExplodedConsoleAnimation.h" />
     <ClInclude Include="PlayerPhysics.h" />
     <ClInclude Include="PlayerPhysicsConfig.h" />
     <ClInclude Include="PlayerSpriteGenerator.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClCompile Include="StageStartedConsoleAnimation.cpp">
       <Filter>Source Files\Render\Animations</Filter>
     </ClCompile>
+    <ClCompile Include="PlayerExplodedConsoleAnimation.cpp">
+      <Filter>Source Files\Render\Animations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -444,6 +447,9 @@
       <Filter>Header Files\Render\Animations</Filter>
     </ClInclude>
     <ClInclude Include="StageStartedConsoleAnimation.h">
+      <Filter>Header Files\Render\Animations</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerExplodedConsoleAnimation.h">
       <Filter>Header Files\Render\Animations</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -162,6 +162,9 @@
     <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
+    <ClCompile Include="ConsoleAnimationRepository.cpp">
+      <Filter>Source Files\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -421,6 +424,9 @@
     </ClInclude>
     <ClInclude Include="IConsoleAnimationProvider.h">
       <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
+    <ClInclude Include="ConsoleAnimationRepository.h">
+      <Filter>Header Files\Render</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClCompile Include="PlayerThwipInConsoleAnimation.cpp">
       <Filter>Source Files\Render\Animations</Filter>
     </ClCompile>
+    <ClCompile Include="StageStartedConsoleAnimation.cpp">
+      <Filter>Source Files\Render\Animations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -438,6 +441,9 @@
       <Filter>Header Files\Render\Animations</Filter>
     </ClInclude>
     <ClInclude Include="PlayerThwipInConsoleAnimation.h">
+      <Filter>Header Files\Render\Animations</Filter>
+    </ClInclude>
+    <ClInclude Include="StageStartedConsoleAnimation.h">
       <Filter>Header Files\Render\Animations</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -419,5 +419,8 @@
     <ClInclude Include="IConsoleSprite.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
+    <ClInclude Include="IConsoleAnimationProvider.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -407,5 +407,8 @@
     <ClInclude Include="IConsoleAnimation.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
+    <ClInclude Include="ConsoleAnimationType.h">
+      <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -61,6 +61,12 @@
     <Filter Include="Source Files\ConfigGenerators">
       <UniqueIdentifier>{bada5787-7047-4f37-88c2-c3ec93573a4a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Render\Animations">
+      <UniqueIdentifier>{2199efa5-6cd1-4f52-8822-d28273f8fe00}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Render\Animations">
+      <UniqueIdentifier>{b32e0e61-a47e-46a8-9109-f87854115a73}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MegaManLofi.cpp">
@@ -159,11 +165,14 @@
     <ClCompile Include="ConsoleSprite.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
-    <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp">
-      <Filter>Source Files\Render</Filter>
-    </ClCompile>
     <ClCompile Include="ConsoleAnimationRepository.cpp">
-      <Filter>Source Files\Render</Filter>
+      <Filter>Source Files\Render\Animations</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp">
+      <Filter>Source Files\Render\Animations</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerThwipInConsoleAnimation.cpp">
+      <Filter>Source Files\Render\Animations</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -416,9 +425,6 @@
     <ClInclude Include="ConsoleAnimationType.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
-    <ClInclude Include="PlayerThwipOutConsoleAnimation.h">
-      <Filter>Header Files\Render</Filter>
-    </ClInclude>
     <ClInclude Include="IConsoleSprite.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
@@ -426,7 +432,13 @@
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="ConsoleAnimationRepository.h">
-      <Filter>Header Files\Render</Filter>
+      <Filter>Header Files\Render\Animations</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerThwipOutConsoleAnimation.h">
+      <Filter>Header Files\Render\Animations</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerThwipInConsoleAnimation.h">
+      <Filter>Header Files\Render\Animations</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClCompile Include="ConsoleSprite.cpp">
       <Filter>Source Files\Render</Filter>
     </ClCompile>
+    <ClCompile Include="PlayerThwipOutConsoleAnimation.cpp">
+      <Filter>Source Files\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -409,6 +412,12 @@
     </ClInclude>
     <ClInclude Include="ConsoleAnimationType.h">
       <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerThwipOutConsoleAnimation.h">
+      <Filter>Header Files\Render</Filter>
+    </ClInclude>
+    <ClInclude Include="IConsoleSprite.h">
+      <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -404,5 +404,8 @@
     <ClInclude Include="ConsoleSprite.h">
       <Filter>Header Files\Render</Filter>
     </ClInclude>
+    <ClInclude Include="IConsoleAnimation.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
@@ -1,0 +1,32 @@
+#include "PlayerExplodedConsoleAnimation.h"
+#include "IConsoleBuffer.h"
+#include "IFrameRateProvider.h"
+#include "ConsoleRenderConfig.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+PlayerExplodedConsoleAnimation::PlayerExplodedConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                                const shared_ptr<IFrameRateProvider> frameRateProvider,
+                                                                const shared_ptr<ConsoleRenderConfig> renderConfig ) :
+   _consoleBuffer( consoleBuffer ),
+   _frameRateProvider( frameRateProvider ),
+   _renderConfig( renderConfig ),
+   _isRunning( false )
+{
+}
+
+void PlayerExplodedConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+{
+   _isRunning = true;
+}
+
+void PlayerExplodedConsoleAnimation::Draw()
+{
+
+}
+
+void PlayerExplodedConsoleAnimation::Tick()
+{
+
+}

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
@@ -2,6 +2,7 @@
 #include "IConsoleBuffer.h"
 #include "IFrameRateProvider.h"
 #include "ConsoleRenderConfig.h"
+#include "IConsoleSprite.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -12,21 +13,65 @@ PlayerExplodedConsoleAnimation::PlayerExplodedConsoleAnimation( const shared_ptr
    _consoleBuffer( consoleBuffer ),
    _frameRateProvider( frameRateProvider ),
    _renderConfig( renderConfig ),
-   _isRunning( false )
+   _isRunning( false ),
+   _elapsedSeconds( 0 ),
+   _explosionStartFrame( 0 ),
+   _startPositionChars( { 0, 0 } )
 {
 }
 
 void PlayerExplodedConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
 {
    _isRunning = true;
+   _elapsedSeconds = 0;
+   _explosionStartFrame = _frameRateProvider->GetCurrentFrame();
+   _startPositionChars = startPositionChars;
+
+   _renderConfig->PlayerExplosionParticleSprite->Reset();
 }
 
 void PlayerExplodedConsoleAnimation::Draw()
 {
+   auto elapsedFrames = _frameRateProvider->GetCurrentFrame() - _explosionStartFrame;
+   auto particleIncrement = ( _renderConfig->PlayerExplosionParticleVelocity * _frameRateProvider->GetFrameScalar() );
+   auto particleDeltaXChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharWidth );
+   auto particleDeltaYChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharHeight );
 
+   auto particleSprite = _renderConfig->PlayerExplosionParticleSprite;
+
+   // horizontal and vertical particles
+   _consoleBuffer->Draw( _startPositionChars.Left + particleDeltaXChars, _startPositionChars.Top, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left + ( particleDeltaXChars / 2 ), _startPositionChars.Top, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - particleDeltaXChars, _startPositionChars.Top, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - ( particleDeltaXChars / 2 ), _startPositionChars.Top, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left, _startPositionChars.Top + particleDeltaYChars, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left, _startPositionChars.Top + ( particleDeltaYChars / 2 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left, _startPositionChars.Top - particleDeltaYChars, particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left, _startPositionChars.Top - ( particleDeltaYChars / 2 ), particleSprite );
+
+   // diagonal particles
+   _consoleBuffer->Draw( _startPositionChars.Left + (short)( particleDeltaXChars / 1.5 ), _startPositionChars.Top + (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left + (short)( particleDeltaXChars / 3 ), _startPositionChars.Top + (short)( particleDeltaYChars / 3 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - (short)( particleDeltaXChars / 1.5 ), _startPositionChars.Top + (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - (short)( particleDeltaXChars / 3 ), _startPositionChars.Top + (short)( particleDeltaYChars / 3 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left + (short)( particleDeltaXChars / 1.5 ), _startPositionChars.Top - (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left + (short)( particleDeltaXChars / 3 ), _startPositionChars.Top - (short)( particleDeltaYChars / 3 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - (short)( particleDeltaXChars / 1.5 ), _startPositionChars.Top - (short)( particleDeltaYChars / 1.5 ), particleSprite );
+   _consoleBuffer->Draw( _startPositionChars.Left - (short)( particleDeltaXChars / 3 ), _startPositionChars.Top - (short)( particleDeltaYChars / 3 ), particleSprite );
 }
 
 void PlayerExplodedConsoleAnimation::Tick()
 {
+   if ( !_isRunning )
+   {
+      return;
+   }
 
+   _elapsedSeconds += _frameRateProvider->GetFrameScalar();
+   _renderConfig->PlayerExplosionParticleSprite->Tick();
+
+   if ( _elapsedSeconds >= _renderConfig->PlayerExplosionAnimationSeconds )
+   {
+      _isRunning = false;
+   }
 }

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.h
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+
+#include "IConsoleAnimation.h"
+
+namespace MegaManLofi
+{
+   class IConsoleBuffer;
+   class IFrameRateProvider;
+   class ConsoleRenderConfig;
+
+   class PlayerExplodedConsoleAnimation : public IConsoleAnimation
+   {
+   public:
+      PlayerExplodedConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                      const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                                      const std::shared_ptr<ConsoleRenderConfig> renderConfig );
+
+      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      bool IsRunning() const override { return _isRunning; }
+      void Draw() override;
+      void Tick() override;
+
+   private:
+      const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+      bool _isRunning;
+   };
+}

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.h
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "IConsoleAnimation.h"
+#include "Coordinate.h"
 
 namespace MegaManLofi
 {
@@ -27,6 +28,9 @@ namespace MegaManLofi
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
 
+      Coordinate<short> _startPositionChars;
       bool _isRunning;
+      double _elapsedSeconds;
+      long long _explosionStartFrame;
    };
 }

--- a/MegaManLofi/PlayerPhysics.cpp
+++ b/MegaManLofi/PlayerPhysics.cpp
@@ -139,7 +139,7 @@ void PlayerPhysics::ExtendJump()
    else
    {
       _lastExtendJumpFrame = currentFrame;
-      _elapsedJumpExtensionSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+      _elapsedJumpExtensionSeconds += _frameRateProvider->GetFrameScalar();
       _player->SetVelocityY( -( _config->JumpAccelerationPerSecond ) );
       _frameActionRegistry->FlagAction( FrameAction::PlayerJumping );
    }

--- a/MegaManLofi/PlayerSpriteGenerator.cpp
+++ b/MegaManLofi/PlayerSpriteGenerator.cpp
@@ -7,9 +7,9 @@
 using namespace std;
 using namespace MegaManLofi;
 
-shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
-   auto thwipSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
+   auto thwipSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .05 ) );
 
    ConsoleImage image0 = { 1, 3 };
    image0.Pixels.push_back( { '#', true, ConsoleColor::Blue, ConsoleColor::Black } );
@@ -26,9 +26,9 @@ shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite()
    return thwipSprite;
 }
 
-shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
+   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .05 ) );
 
    string chars0 =
       "    " \
@@ -48,9 +48,9 @@ shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprit
    return sprite;
 }
 
-shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
+   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .05 ) );
 
    string chars0 =
       "    " \
@@ -70,9 +70,9 @@ shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSpri
    return sprite;
 }
 
-shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
-   auto particleSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .25 ) );
+   auto particleSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .25 ) );
 
    ConsoleImage image0 = { 1, 1 };
    image0.Pixels.push_back( { 'O', true, ConsoleColor::Blue, ConsoleColor::Black } );
@@ -85,12 +85,12 @@ shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprit
    return particleSprite;
 }
 
-map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandingSpriteMap( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
    auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
-   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string leftChars =
       "  O " \
       "o-|\\" \
@@ -103,7 +103,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandi
    spriteMap[Direction::DownLeft] = leftSprite;
 
    // facing right
-   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string rightChars =
       " O  " \
       "/|-o" \
@@ -116,7 +116,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandi
    spriteMap[Direction::DownRight] = rightSprite;
 
    // facing up or down
-   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string verticalChars =
       " O  " \
       "/|\\ " \
@@ -130,12 +130,12 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandi
    return spriteMap;
 }
 
-map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkingSpriteMap( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
    auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
-   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .15 ) );
+   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .15 ) );
    string leftChars0 =
       "  O " \
       "o-|\\" \
@@ -155,7 +155,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkin
    spriteMap[Direction::DownLeft] = leftSprite;
 
    // facing right
-   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .15 ) );
+   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .15 ) );
    string rightChars0 =
       " O  " \
       "/|-o" \
@@ -175,7 +175,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkin
    spriteMap[Direction::DownRight] = rightSprite;
 
    // facing up or down (this will probably very rarely happen)
-   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string verticalChars =
       " O  " \
       "/|\\ " \
@@ -189,12 +189,12 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkin
    return spriteMap;
 }
 
-map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateFallingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateFallingSpriteMap( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
    auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
-   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string leftChars =
       "  O/" \
       "o-| " \
@@ -207,7 +207,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateFallin
    spriteMap[Direction::DownLeft] = leftSprite;
 
    // facing right
-   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string rightChars =
       "\\O  " \
       " |-o" \
@@ -220,7 +220,7 @@ map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateFallin
    spriteMap[Direction::DownRight] = rightSprite;
 
    // facing up or down
-   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
+   auto verticalSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0 ) );
    string verticalChars =
       "\\O/ " \
       " |  " \

--- a/MegaManLofi/PlayerSpriteGenerator.cpp
+++ b/MegaManLofi/PlayerSpriteGenerator.cpp
@@ -1,12 +1,13 @@
 #include <string>
 
 #include "PlayerSpriteGenerator.h"
+#include "ConsoleSprite.h"
 #include "Direction.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite()
 {
    auto thwipSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
 
@@ -25,7 +26,7 @@ shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipSprite()
    return thwipSprite;
 }
 
-shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprite()
 {
    auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
 
@@ -47,7 +48,7 @@ shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipInTransitionSprite
    return sprite;
 }
 
-shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSprite()
 {
    auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .05 ) );
 
@@ -69,7 +70,7 @@ shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateThwipOutTransitionSprit
    return sprite;
 }
 
-shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprite()
+shared_ptr<IConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprite()
 {
    auto particleSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .25 ) );
 
@@ -84,9 +85,9 @@ shared_ptr<ConsoleSprite> PlayerSpriteGenerator::GenerateExplosionParticleSprite
    return particleSprite;
 }
 
-map<Direction, shared_ptr<ConsoleSprite>> PlayerSpriteGenerator::GenerateStandingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateStandingSpriteMap()
 {
-   auto spriteMap = map<Direction, shared_ptr<ConsoleSprite>>();
+   auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
    auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
@@ -129,9 +130,9 @@ map<Direction, shared_ptr<ConsoleSprite>> PlayerSpriteGenerator::GenerateStandin
    return spriteMap;
 }
 
-map<Direction, shared_ptr<ConsoleSprite>> PlayerSpriteGenerator::GenerateWalkingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateWalkingSpriteMap()
 {
-   auto spriteMap = map<Direction, shared_ptr<ConsoleSprite>>();
+   auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
    auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( .15 ) );
@@ -188,9 +189,9 @@ map<Direction, shared_ptr<ConsoleSprite>> PlayerSpriteGenerator::GenerateWalking
    return spriteMap;
 }
 
-map<Direction, shared_ptr<ConsoleSprite>> PlayerSpriteGenerator::GenerateFallingSpriteMap()
+map<Direction, shared_ptr<IConsoleSprite>> PlayerSpriteGenerator::GenerateFallingSpriteMap()
 {
-   auto spriteMap = map<Direction, shared_ptr<ConsoleSprite>>();
+   auto spriteMap = map<Direction, shared_ptr<IConsoleSprite>>();
 
    // facing left
    auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );

--- a/MegaManLofi/PlayerSpriteGenerator.h
+++ b/MegaManLofi/PlayerSpriteGenerator.h
@@ -6,18 +6,19 @@
 namespace MegaManLofi
 {
    class IConsoleSprite;
+   class IFrameRateProvider;
    enum class Direction;
 
    class PlayerSpriteGenerator
    {
    public:
-      static std::shared_ptr<IConsoleSprite> GenerateThwipSprite();
-      static std::shared_ptr<IConsoleSprite> GenerateThwipInTransitionSprite();
-      static std::shared_ptr<IConsoleSprite> GenerateThwipOutTransitionSprite();
-      static std::shared_ptr<IConsoleSprite> GenerateExplosionParticleSprite();
+      static std::shared_ptr<IConsoleSprite> GenerateThwipSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::shared_ptr<IConsoleSprite> GenerateThwipInTransitionSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::shared_ptr<IConsoleSprite> GenerateThwipOutTransitionSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::shared_ptr<IConsoleSprite> GenerateExplosionParticleSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
-      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateStandingSpriteMap();
-      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateWalkingSpriteMap();
-      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateFallingSpriteMap();
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateStandingSpriteMap( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateWalkingSpriteMap( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateFallingSpriteMap( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
    };
 }

--- a/MegaManLofi/PlayerSpriteGenerator.h
+++ b/MegaManLofi/PlayerSpriteGenerator.h
@@ -3,22 +3,21 @@
 #include <memory>
 #include <map>
 
-#include "ConsoleSprite.h"
-
 namespace MegaManLofi
 {
+   class IConsoleSprite;
    enum class Direction;
 
    class PlayerSpriteGenerator
    {
    public:
-      static std::shared_ptr<ConsoleSprite> GenerateThwipSprite();
-      static std::shared_ptr<ConsoleSprite> GenerateThwipInTransitionSprite();
-      static std::shared_ptr<ConsoleSprite> GenerateThwipOutTransitionSprite();
-      static std::shared_ptr<ConsoleSprite> GenerateExplosionParticleSprite();
+      static std::shared_ptr<IConsoleSprite> GenerateThwipSprite();
+      static std::shared_ptr<IConsoleSprite> GenerateThwipInTransitionSprite();
+      static std::shared_ptr<IConsoleSprite> GenerateThwipOutTransitionSprite();
+      static std::shared_ptr<IConsoleSprite> GenerateExplosionParticleSprite();
 
-      static std::map<Direction, std::shared_ptr<ConsoleSprite>> GenerateStandingSpriteMap();
-      static std::map<Direction, std::shared_ptr<ConsoleSprite>> GenerateWalkingSpriteMap();
-      static std::map<Direction, std::shared_ptr<ConsoleSprite>> GenerateFallingSpriteMap();
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateStandingSpriteMap();
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateWalkingSpriteMap();
+      static std::map<Direction, std::shared_ptr<IConsoleSprite>> GenerateFallingSpriteMap();
    };
 }

--- a/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
@@ -1,0 +1,98 @@
+#include "PlayerThwipInConsoleAnimation.h"
+#include "IConsoleBuffer.h"
+#include "ConsoleRenderConfig.h"
+#include "IFrameRateProvider.h"
+#include "IConsoleSprite.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+PlayerThwipInConsoleAnimation::PlayerThwipInConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                                const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                                const shared_ptr<IFrameRateProvider> frameRateProvider ) :
+   _consoleBuffer( consoleBuffer ),
+   _renderConfig( renderConfig ),
+   _frameRateProvider( frameRateProvider ),
+   _isRunning( false ),
+   _startPositionChars( {0, 0} ),
+   _endPositionChars( {0, 0} ),
+   _currentTopPositionUnits( 0 ),
+   _endTopPositionUnits( 0 ),
+   _postThwipping( false ),
+   _elapsedSeconds( 0 )
+{
+}
+
+void PlayerThwipInConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+{
+   _isRunning = true;
+   _startPositionChars = startPositionChars;
+   _endPositionChars = endPositionChars;
+   _currentTopPositionUnits = startPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _endTopPositionUnits = endPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _postThwipping = false;
+   _elapsedSeconds = 0;
+
+   _renderConfig->PlayerThwipInTransitionSprite->Reset();
+   _renderConfig->PlayerThwipSprite->Reset();
+}
+
+void PlayerThwipInConsoleAnimation::Draw()
+{
+   if ( _postThwipping )
+   {
+      _consoleBuffer->Draw( _startPositionChars.Left, _endPositionChars.Top, _renderConfig->PlayerThwipInTransitionSprite );
+   }
+   else
+   {
+      auto leftOffset = short( ( _renderConfig->PlayerThwipInTransitionSprite->GetWidth() - _renderConfig->PlayerThwipSprite->GetWidth() ) / 2 );
+      _consoleBuffer->Draw( _startPositionChars.Left + leftOffset,
+                            (short)( _currentTopPositionUnits / _renderConfig->ArenaCharHeight ),
+                            _renderConfig->PlayerThwipSprite );
+   }
+}
+
+void PlayerThwipInConsoleAnimation::Tick()
+{
+   if ( !_isRunning )
+   {
+      return;
+   }
+
+   _elapsedSeconds += _frameRateProvider->GetFrameScalar();
+
+   if ( _postThwipping )
+   {
+      _renderConfig->PlayerThwipInTransitionSprite->Tick();
+
+      auto test = _renderConfig->PlayerThwipInTransitionSprite->GetTotalTraversalSeconds();
+      if ( _elapsedSeconds >= _renderConfig->PlayerThwipInTransitionSprite->GetTotalTraversalSeconds() )
+      {
+         _isRunning = false;
+      }
+   }
+   else
+   {
+      _renderConfig->PlayerThwipSprite->Tick();
+      auto topDelta = (long long)( _renderConfig->PlayerThwipVelocity * _frameRateProvider->GetFrameScalar() );
+
+      if ( _endPositionChars.Top < _startPositionChars.Top )
+      {
+         _currentTopPositionUnits -= topDelta;
+         if ( _currentTopPositionUnits <= _endTopPositionUnits )
+         {
+            _postThwipping = true;
+            _elapsedSeconds = 0;
+         }
+      }
+      else
+      {
+         _currentTopPositionUnits += topDelta;
+         if ( _currentTopPositionUnits >= _endTopPositionUnits )
+         {
+            _postThwipping = true;
+            _elapsedSeconds = 0;
+         }
+      }
+   }
+}

--- a/MegaManLofi/PlayerThwipInConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipInConsoleAnimation.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+
+#include "IConsoleAnimation.h"
+
+namespace MegaManLofi
+{
+   class IConsoleBuffer;
+   class ConsoleRenderConfig;
+   class IFrameRateProvider;
+
+   class PlayerThwipInConsoleAnimation : public IConsoleAnimation
+   {
+   public:
+      PlayerThwipInConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                     const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                     const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+
+      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      bool IsRunning() const override { return _isRunning; }
+      void Draw() override;
+      void Tick() override;
+
+   private:
+      const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+
+      bool _isRunning;
+      Coordinate<short> _startPositionChars;
+      Coordinate<short> _endPositionChars;
+      long long _currentTopPositionUnits;
+      long long _endTopPositionUnits;
+      bool _postThwipping;
+      double _elapsedSeconds;
+   };
+}

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -1,15 +1,18 @@
 #include "PlayerThwipOutConsoleAnimation.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderConfig.h"
+#include "IFrameRateProvider.h"
 #include "IConsoleSprite.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
 PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                                const shared_ptr<ConsoleRenderConfig> renderConfig ) :
+                                                                const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                                const shared_ptr<IFrameRateProvider> frameRateProvider ) :
    _consoleBuffer( consoleBuffer ),
    _renderConfig( renderConfig ),
+   _frameRateProvider( frameRateProvider ),
    _isRunning( false ),
    _startPositionChars( {0, 0} ),
    _endPositionChars( {0, 0} ),
@@ -51,19 +54,18 @@ void PlayerThwipOutConsoleAnimation::Draw()
    }
 }
 
-void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
+void PlayerThwipOutConsoleAnimation::Tick()
 {
    if ( !_isRunning )
    {
       return;
    }
 
-   auto frameRateScalar = 1 / (double)framesPerSecond;
-   _elapsedSeconds += frameRateScalar;
+   _elapsedSeconds += _frameRateProvider->GetFrameScalar();
 
    if ( _preThwipping )
    {
-      _renderConfig->PlayerThwipOutTransitionSprite->Tick( framesPerSecond );
+      _renderConfig->PlayerThwipOutTransitionSprite->Tick();
 
       if ( _elapsedSeconds >= _renderConfig->PlayerThwipOutTransitionSprite->GetTotalTraversalSeconds() )
       {
@@ -80,8 +82,8 @@ void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
    }
    else
    {
-      _renderConfig->PlayerThwipSprite->Tick( framesPerSecond );
-      auto topDelta = (long long)( _renderConfig->PlayerThwipVelocity * frameRateScalar );
+      _renderConfig->PlayerThwipSprite->Tick();
+      auto topDelta = (long long)( _renderConfig->PlayerThwipVelocity * _frameRateProvider->GetFrameScalar() );
 
       if ( _endPositionChars.Top < _startPositionChars.Top )
       {

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -16,6 +16,7 @@ PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr
    _currentTopPositionUnits( 0 ),
    _endTopPositionUnits( 0 ),
    _preThwipping( false ),
+   _postThwipping( false ),
    _elapsedSeconds( 0 )
 {
 }
@@ -28,6 +29,7 @@ void PlayerThwipOutConsoleAnimation::Start( Coordinate<short> startPositionChars
    _currentTopPositionUnits = startPositionChars.Top * _renderConfig->ArenaCharHeight;
    _endTopPositionUnits = endPositionChars.Top * _renderConfig->ArenaCharHeight;
    _preThwipping = true;
+   _postThwipping = false;
    _elapsedSeconds = 0;
 
    _renderConfig->PlayerThwipOutTransitionSprite->Reset();
@@ -40,7 +42,7 @@ void PlayerThwipOutConsoleAnimation::Draw()
    {
       _consoleBuffer->Draw( _startPositionChars.Left, _startPositionChars.Top, _renderConfig->PlayerThwipOutTransitionSprite );
    }
-   else
+   else if ( !_postThwipping )
    {
       auto leftOffset = short( ( _renderConfig->PlayerThwipOutTransitionSprite->GetWidth() - _renderConfig->PlayerThwipSprite->GetWidth() ) / 2 );
       _consoleBuffer->Draw( _startPositionChars.Left + leftOffset,
@@ -69,6 +71,13 @@ void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
          _elapsedSeconds = 0;
       }
    }
+   else if ( _postThwipping )
+   {
+      if ( _elapsedSeconds >= _renderConfig->PlayerPostThwipDelaySeconds )
+      {
+         _isRunning = false;
+      }
+   }
    else
    {
       _renderConfig->PlayerThwipSprite->Tick( framesPerSecond );
@@ -79,7 +88,8 @@ void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
          _currentTopPositionUnits -= topDelta;
          if ( _currentTopPositionUnits <= _endTopPositionUnits )
          {
-            _isRunning = false;
+            _postThwipping = true;
+            _elapsedSeconds = 0;
          }
       }
       else
@@ -87,7 +97,8 @@ void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
          _currentTopPositionUnits += topDelta;
          if ( _currentTopPositionUnits >= _endTopPositionUnits )
          {
-            _isRunning = false;
+            _postThwipping = true;
+            _elapsedSeconds = 0;
          }
       }
    }

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -1,0 +1,55 @@
+#include "PlayerThwipOutConsoleAnimation.h"
+#include "IConsoleBuffer.h"
+#include "ConsoleRenderConfig.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                                const shared_ptr<ConsoleRenderConfig> renderConfig ) :
+   _consoleBuffer( consoleBuffer ),
+   _renderConfig( renderConfig ),
+   _isRunning( false ),
+   _startCoordinate( {0, 0} ),
+   _endCoordinate( {0, 0} ),
+   _preThwipping( false ),
+   _elapsedSeconds( 0 )
+{
+}
+
+void PlayerThwipOutConsoleAnimation::Start( Coordinate<short> startCoordinate, Coordinate<short> endCoordinate )
+{
+   _startCoordinate = startCoordinate;
+   _endCoordinate = endCoordinate;
+   _preThwipping = true;
+   _elapsedSeconds = 0;
+
+   // MUFFINS: reset the thwip and transition sprites
+}
+
+void PlayerThwipOutConsoleAnimation::Draw()
+{
+   if ( _preThwipping )
+   {
+      _consoleBuffer->Draw( _startCoordinate.Left, _startCoordinate.Top, _renderConfig->PlayerThwipOutTransitionSprite );
+   }
+   else
+   {
+      // MUFFINS: draw the twhip sprite wherever it needs to be based on velocity and _elapsedSeconds
+   }
+}
+
+void PlayerThwipOutConsoleAnimation::Tick( int framesPerSecond )
+{
+   _elapsedSeconds += 1 / (double)framesPerSecond;
+
+   if ( _preThwipping )
+   {
+      // MUFFINS: tick the sprite and check if it's finished
+      // if it is finished, reset _elapsedSeconds and set _preThwipping to false
+   }
+   else
+   {
+      // MUFFINS: just tick the sprite
+   }
+}

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -6,7 +6,6 @@
 using namespace std;
 using namespace MegaManLofi;
 
-// MUFFINS: test this whole class
 PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                                 const shared_ptr<ConsoleRenderConfig> renderConfig ) :
    _consoleBuffer( consoleBuffer ),
@@ -43,7 +42,8 @@ void PlayerThwipOutConsoleAnimation::Draw()
    }
    else
    {
-      _consoleBuffer->Draw( _startPositionChars.Left,
+      auto leftOffset = short( ( _renderConfig->PlayerThwipOutTransitionSprite->GetWidth() - _renderConfig->PlayerThwipSprite->GetWidth() ) / 2 );
+      _consoleBuffer->Draw( _startPositionChars.Left + leftOffset,
                             (short)( _currentTopPositionUnits / _renderConfig->ArenaCharHeight ),
                             _renderConfig->PlayerThwipSprite );
    }

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.h
@@ -8,21 +8,24 @@ namespace MegaManLofi
 {
    class IConsoleBuffer;
    class ConsoleRenderConfig;
+   class IFrameRateProvider;
 
    class PlayerThwipOutConsoleAnimation : public IConsoleAnimation
    {
    public:
       PlayerThwipOutConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
-                                      const std::shared_ptr<ConsoleRenderConfig> renderConfig );
+                                      const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                      const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
       void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
-      void Tick( int framesPerSecond ) override;
+      void Tick() override;
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
 
       bool _isRunning;
       Coordinate<short> _startPositionChars;

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.h
@@ -15,7 +15,7 @@ namespace MegaManLofi
       PlayerThwipOutConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                       const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
-      void Start( Coordinate<short> startCoordinate, Coordinate<short> endCoordinate ) override;
+      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
       void Tick( int framesPerSecond ) override;
@@ -25,8 +25,10 @@ namespace MegaManLofi
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
 
       bool _isRunning;
-      Coordinate<short> _startCoordinate;
-      Coordinate<short> _endCoordinate;
+      Coordinate<short> _startPositionChars;
+      Coordinate<short> _endPositionChars;
+      long long _currentTopPositionUnits;
+      long long _endTopPositionUnits;
       bool _preThwipping;
       double _elapsedSeconds;
    };

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+
+#include "IConsoleAnimation.h"
+
+namespace MegaManLofi
+{
+   class IConsoleBuffer;
+   class ConsoleRenderConfig;
+
+   class PlayerThwipOutConsoleAnimation : public IConsoleAnimation
+   {
+   public:
+      PlayerThwipOutConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                      const std::shared_ptr<ConsoleRenderConfig> renderConfig );
+
+      void Start( Coordinate<short> startCoordinate, Coordinate<short> endCoordinate ) override;
+      bool IsRunning() const override { return _isRunning; }
+      void Draw() override;
+      void Tick( int framesPerSecond ) override;
+
+   private:
+      const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+      bool _isRunning;
+      Coordinate<short> _startCoordinate;
+      Coordinate<short> _endCoordinate;
+      bool _preThwipping;
+      double _elapsedSeconds;
+   };
+}

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.h
@@ -30,6 +30,7 @@ namespace MegaManLofi
       long long _currentTopPositionUnits;
       long long _endTopPositionUnits;
       bool _preThwipping;
+      bool _postThwipping;
       double _elapsedSeconds;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -8,6 +8,7 @@
 #include "IArenaInfoProvider.h"
 #include "IGameEventAggregator.h"
 #include "IFrameRateProvider.h"
+#include "IConsoleAnimationProvider.h"
 #include "Direction.h"
 #include "GameEvent.h"
 #include "IConsoleSprite.h"
@@ -21,7 +22,8 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
                                                           const shared_ptr<IPlayerInfoProvider> playerInfoProvider,
                                                           const shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                                           const shared_ptr<IGameEventAggregator> eventAggregator,
-                                                          const shared_ptr<IFrameRateProvider> frameRateProvider ) :
+                                                          const shared_ptr<IFrameRateProvider> frameRateProvider,
+                                                          const shared_ptr<IConsoleAnimationProvider> animationProvider ) :
    _consoleBuffer( consoleBuffer ),
    _renderConfig( renderConfig ),
    _gameInfoProvider( gameInfoProvider ),
@@ -29,6 +31,7 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _arenaInfoProvider( arenaInfoProvider ),
    _eventAggregator( eventAggregator ),
    _frameRateProvider( frameRateProvider ),
+   _animationProvider( animationProvider ),
    _viewportQuadUnits( { 0, 0, 0, 0 } ),
    _viewportRectChars( { 0, 0, 0, 0 } ),
    _viewportOffsetChars( { 0, 0 } ),

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -156,8 +156,8 @@ void PlayingStateConsoleRenderer::UpdateCaches()
 
 void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 {
-   _stageStartAnimationElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
-   _renderConfig->GetReadySprite->Tick( _frameRateProvider->GetFramesPerSecond() );
+   _stageStartAnimationElapsedSeconds += _frameRateProvider->GetFrameScalar();
+   _renderConfig->GetReadySprite->Tick();
 
    auto image = _renderConfig->GetReadySprite->GetCurrentImage();
    auto left = ( _viewportRectChars.Width / 2 ) - ( image.Width / 2 ) + _viewportOffsetChars.Left;
@@ -175,7 +175,7 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
 void PlayingStateConsoleRenderer::DrawPlayerThwipInAnimation()
 {
-   auto thwipDeltaUnits = ( _renderConfig->PlayerThwipVelocity / _frameRateProvider->GetFramesPerSecond() );
+   auto thwipDeltaUnits = _renderConfig->PlayerThwipVelocity * _frameRateProvider->GetFrameScalar();
    _playerThwipBottom += thwipDeltaUnits;
 
    auto playerSprite = GetPlayerSprite();
@@ -194,12 +194,12 @@ void PlayingStateConsoleRenderer::DrawPlayerThwipInAnimation()
    _consoleBuffer->Draw( _playerViewportChars.Left + thwipSpriteLeftOffsetChars + _viewportOffsetChars.Left,
                          ( playerThwipBottomViewportChars - _renderConfig->PlayerThwipSprite->GetHeight() ) + _viewportOffsetChars.Top,
                          _renderConfig->PlayerThwipSprite );
-   _renderConfig->PlayerThwipSprite->Tick( _frameRateProvider->GetFramesPerSecond() );
+   _renderConfig->PlayerThwipSprite->Tick();
 }
 
 void PlayingStateConsoleRenderer::DrawPlayerThwipInTransitionAnimation()
 {
-   _playerThwipTransitionElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+   _playerThwipTransitionElapsedSeconds += _frameRateProvider->GetFrameScalar();
 
    auto sprite = _renderConfig->PlayerThwipInTransitionSprite;
    _consoleBuffer->Draw( _playerViewportChars.Left + _viewportOffsetChars.Left, _playerViewportChars.Top + _viewportOffsetChars.Top, sprite );
@@ -210,13 +210,13 @@ void PlayingStateConsoleRenderer::DrawPlayerThwipInTransitionAnimation()
    }
    else
    {
-      sprite->Tick( _frameRateProvider->GetFramesPerSecond() );
+      sprite->Tick();
    }
 }
 
 void PlayingStateConsoleRenderer::DrawPitfallAnimation()
 {
-   _pitfallAnimationElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
+   _pitfallAnimationElapsedSeconds += _frameRateProvider->GetFrameScalar();
 
    if ( _pitfallAnimationElapsedSeconds >= _renderConfig->PitfallAnimationSeconds )
    {
@@ -226,15 +226,14 @@ void PlayingStateConsoleRenderer::DrawPitfallAnimation()
 
 void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
 {
-   auto frameRateScalar = ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
-   _playerExplosionAnimationElapsedSeconds += frameRateScalar;
+   _playerExplosionAnimationElapsedSeconds += _frameRateProvider->GetFrameScalar();
 
    const auto& hitBox = _playerInfoProvider->GetHitBox();
    auto particleStartLeftChars = _playerViewportChars.Left + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _viewportOffsetChars.Left;
    auto particleStartTopChars = _playerViewportChars.Top + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _viewportOffsetChars.Top;
    
    auto elapsedFrames = _frameRateProvider->GetCurrentFrame() - _playerExplosionStartFrame;
-   auto particleIncrement = ( _renderConfig->PlayerExplosionParticleVelocity * frameRateScalar );
+   auto particleIncrement = ( _renderConfig->PlayerExplosionParticleVelocity * _frameRateProvider->GetFrameScalar() );
    auto particleDeltaXChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharWidth );
    auto particleDeltaYChars = (short)( ( particleIncrement * elapsedFrames ) / _renderConfig->ArenaCharHeight );
 
@@ -266,7 +265,7 @@ void PlayingStateConsoleRenderer::DrawPlayerExplosionAnimation()
    }
    else
    {
-      particleSprite->Tick( _frameRateProvider->GetFramesPerSecond() );
+      particleSprite->Tick();
    }
 }
 
@@ -293,7 +292,7 @@ void PlayingStateConsoleRenderer::DrawPlayer()
 {
    auto sprite = GetPlayerSprite();
    _consoleBuffer->Draw( _playerViewportChars.Left + _viewportOffsetChars.Left, _playerViewportChars.Top + _viewportOffsetChars.Top, sprite );
-   sprite->Tick( _frameRateProvider->GetFramesPerSecond() );
+   sprite->Tick();
 }
 
 void PlayingStateConsoleRenderer::DrawStatusBar()

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -151,8 +151,26 @@ void PlayingStateConsoleRenderer::UpdateCaches()
 
 void PlayingStateConsoleRenderer::DrawStageStartAnimation()
 {
-   _animationProvider->GetAnimation( ConsoleAnimationType::StageStarted )->Draw();
-   _animationProvider->GetAnimation( ConsoleAnimationType::StageStarted )->Tick();
+   const auto& animation = _animationProvider->GetAnimation( ConsoleAnimationType::StageStarted );
+
+   animation->Draw();
+   animation->Tick();
+
+   if ( !animation->IsRunning() )
+   {
+      Coordinate<short> thwipStartPosition =
+      {
+         _viewportOffsetChars.Left + _playerViewportChars.Left,
+         _viewportOffsetChars.Top - _renderConfig->PlayerThwipInTransitionSprite->GetHeight()
+      };
+      Coordinate<short> thwipEndPosition =
+      {
+         thwipStartPosition.Left,
+         _viewportOffsetChars.Top + _playerViewportChars.Top
+      };
+
+      _animationProvider->GetAnimation( ConsoleAnimationType::PlayerThwipIn )->Start( thwipStartPosition, thwipEndPosition );
+   }
 }
 
 void PlayingStateConsoleRenderer::DrawPlayerThwipInAnimation()

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -10,7 +10,7 @@
 #include "IFrameRateProvider.h"
 #include "Direction.h"
 #include "GameEvent.h"
-#include "ConsoleSprite.h"
+#include "IConsoleSprite.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -309,7 +309,7 @@ void PlayingStateConsoleRenderer::DrawPauseOverlay()
    _consoleBuffer->Draw( left + _viewportOffsetChars.Left, top + _viewportOffsetChars.Top, _renderConfig->PauseOverlayImage );
 }
 
-const shared_ptr<ConsoleSprite> PlayingStateConsoleRenderer::GetPlayerSprite() const
+const shared_ptr<IConsoleSprite> PlayingStateConsoleRenderer::GetPlayerSprite() const
 {
    auto direction = _playerInfoProvider->GetDirection();
 

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -175,7 +175,7 @@ void PlayingStateConsoleRenderer::DrawGameStartAnimation()
 
 void PlayingStateConsoleRenderer::DrawPlayerThwipInAnimation()
 {
-   auto thwipDeltaUnits = _renderConfig->PlayerThwipVelocity * _frameRateProvider->GetFrameScalar();
+   auto thwipDeltaUnits = (long long)( _renderConfig->PlayerThwipVelocity * _frameRateProvider->GetFrameScalar() );
    _playerThwipBottom += thwipDeltaUnits;
 
    auto playerSprite = GetPlayerSprite();

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -43,7 +43,6 @@ namespace MegaManLofi
 
       void DrawGameStartAnimation();
       void DrawPlayerThwipInAnimation();
-      void DrawPlayerThwipInTransitionAnimation();
       void DrawPitfallAnimation();
       void DrawPlayerExplosionAnimation();
       void DrawArenaSprites();
@@ -69,17 +68,13 @@ namespace MegaManLofi
       Coordinate<short> _playerViewportChars;
 
       bool _isAnimatingStageStart;
-      bool _isAnimatingPlayerThwipIn;
-      bool _isAnimatingPlayerThwipTransition;
       bool _isAnimatingPitfall;
       bool _isAnimatingPlayerExplosion;
 
       double _stageStartAnimationElapsedSeconds;
-      double _playerThwipTransitionElapsedSeconds;
       double _pitfallAnimationElapsedSeconds;
       double _playerExplosionAnimationElapsedSeconds;
 
-      long long _playerThwipBottom;
       long long _playerExplosionStartFrame;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -16,6 +16,7 @@ namespace MegaManLofi
    class IArenaInfoProvider;
    class IGameEventAggregator;
    class IFrameRateProvider;
+   class IConsoleAnimationProvider;
    class IConsoleSprite;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
@@ -27,7 +28,8 @@ namespace MegaManLofi
                                    const std::shared_ptr<IPlayerInfoProvider> playerInfoProvider,
                                    const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                    const std::shared_ptr<IGameEventAggregator> eventAggregator,
-                                   const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+                                   const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                                   const std::shared_ptr<IConsoleAnimationProvider> animationProvider );
 
       void Render() override;
       bool HasFocus() const override;
@@ -59,6 +61,7 @@ namespace MegaManLofi
       const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+      const std::shared_ptr<IConsoleAnimationProvider> _animationProvider;
 
       Quad<long long> _viewportQuadUnits;
       Rectangle<short> _viewportRectChars;

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -16,7 +16,7 @@ namespace MegaManLofi
    class IArenaInfoProvider;
    class IGameEventAggregator;
    class IFrameRateProvider;
-   class ConsoleSprite;
+   class IConsoleSprite;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
@@ -49,7 +49,7 @@ namespace MegaManLofi
       void DrawStatusBar();
       void DrawPauseOverlay();
 
-      const std::shared_ptr<ConsoleSprite> GetPlayerSprite() const;
+      const std::shared_ptr<IConsoleSprite> GetPlayerSprite() const;
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -68,11 +68,6 @@ namespace MegaManLofi
       Coordinate<short> _playerViewportChars;
 
       bool _isAnimatingPitfall;
-      bool _isAnimatingPlayerExplosion;
-
       double _pitfallAnimationElapsedSeconds;
-      double _playerExplosionAnimationElapsedSeconds;
-
-      long long _playerExplosionStartFrame;
    };
 }

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -41,7 +41,7 @@ namespace MegaManLofi
 
       void UpdateCaches();
 
-      void DrawGameStartAnimation();
+      void DrawStageStartAnimation();
       void DrawPlayerThwipInAnimation();
       void DrawPitfallAnimation();
       void DrawPlayerExplosionAnimation();
@@ -67,11 +67,9 @@ namespace MegaManLofi
       Coordinate<short> _viewportOffsetChars;
       Coordinate<short> _playerViewportChars;
 
-      bool _isAnimatingStageStart;
       bool _isAnimatingPitfall;
       bool _isAnimatingPlayerExplosion;
 
-      double _stageStartAnimationElapsedSeconds;
       double _pitfallAnimationElapsedSeconds;
       double _playerExplosionAnimationElapsedSeconds;
 

--- a/MegaManLofi/StageStartedConsoleAnimation.cpp
+++ b/MegaManLofi/StageStartedConsoleAnimation.cpp
@@ -1,9 +1,48 @@
 #include "StageStartedConsoleAnimation.h"
+#include "IConsoleBuffer.h"
+#include "IFrameRateProvider.h"
+#include "ConsoleRenderConfig.h"
+#include "IConsoleSprite.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-StageStartedConsoleAnimation::StageStartedConsoleAnimation() :
-   _isRunning( false )
+StageStartedConsoleAnimation::StageStartedConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
+                                                            const shared_ptr<IFrameRateProvider> frameRateProvider,
+                                                            const shared_ptr<ConsoleRenderConfig> renderConfig ) :
+   _consoleBuffer( consoleBuffer ),
+   _frameRateProvider( frameRateProvider ),
+   _renderConfig( renderConfig ),
+   _isRunning( false ),
+   _elapsedSeconds( 0 ),
+   _positionChars( { 0, 0 } )
 {
+}
+
+void StageStartedConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+{
+   _isRunning = true;
+   _elapsedSeconds = 0;
+   _positionChars = startPositionChars;
+
+   _renderConfig->GetReadySprite->Reset();
+}
+
+void StageStartedConsoleAnimation::Draw()
+{
+   _consoleBuffer->Draw( _positionChars.Left, _positionChars.Top, _renderConfig->GetReadySprite );
+}
+
+void StageStartedConsoleAnimation::Tick()
+{
+   if ( _isRunning )
+   {
+      _elapsedSeconds += _frameRateProvider->GetFrameScalar();
+      _renderConfig->GetReadySprite->Tick();
+
+      if ( _elapsedSeconds >= _renderConfig->GetReadyAnimationSeconds )
+      {
+         _isRunning = false;
+      }
+   }
 }

--- a/MegaManLofi/StageStartedConsoleAnimation.cpp
+++ b/MegaManLofi/StageStartedConsoleAnimation.cpp
@@ -1,0 +1,9 @@
+#include "StageStartedConsoleAnimation.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+StageStartedConsoleAnimation::StageStartedConsoleAnimation() :
+   _isRunning( false )
+{
+}

--- a/MegaManLofi/StageStartedConsoleAnimation.cpp
+++ b/MegaManLofi/StageStartedConsoleAnimation.cpp
@@ -30,7 +30,9 @@ void StageStartedConsoleAnimation::Start( Coordinate<short> startPositionChars, 
 
 void StageStartedConsoleAnimation::Draw()
 {
-   _consoleBuffer->Draw( _positionChars.Left, _positionChars.Top, _renderConfig->GetReadySprite );
+   auto leftOffset = (short)( _renderConfig->GetReadySprite->GetWidth() / 2 );
+   auto topOffset = (short)( _renderConfig->GetReadySprite->GetHeight() / 2 );
+   _consoleBuffer->Draw( _positionChars.Left - leftOffset, _positionChars.Top - topOffset, _renderConfig->GetReadySprite );
 }
 
 void StageStartedConsoleAnimation::Tick()

--- a/MegaManLofi/StageStartedConsoleAnimation.h
+++ b/MegaManLofi/StageStartedConsoleAnimation.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "IConsoleAnimation.h"
+
+namespace MegaManLofi
+{
+   class StageStartedConsoleAnimation : public IConsoleAnimation
+   {
+   public:
+      StageStartedConsoleAnimation();
+
+      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      bool IsRunning() const override { return _isRunning; }
+      void Draw() override;
+      void Tick() override;
+
+   private:
+      bool _isRunning;
+   };
+}

--- a/MegaManLofi/StageStartedConsoleAnimation.h
+++ b/MegaManLofi/StageStartedConsoleAnimation.h
@@ -1,13 +1,21 @@
 #pragma once
 
+#include <memory>
+
 #include "IConsoleAnimation.h"
 
 namespace MegaManLofi
 {
+   class IConsoleBuffer;
+   class IFrameRateProvider;
+   class ConsoleRenderConfig;
+
    class StageStartedConsoleAnimation : public IConsoleAnimation
    {
    public:
-      StageStartedConsoleAnimation();
+      StageStartedConsoleAnimation( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
+                                    const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+                                    const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
       void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
@@ -15,6 +23,12 @@ namespace MegaManLofi
       void Tick() override;
 
    private:
+      const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+
       bool _isRunning;
+      double _elapsedSeconds;
+      Coordinate<short> _positionChars;
    };
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -66,7 +66,7 @@ void TitleStateConsoleRenderer::Render()
    if ( _thwipOutAnimation->IsRunning() )
    {
       _thwipOutAnimation->Draw();
-      _thwipOutAnimation->Tick( _frameRateProvider->GetFramesPerSecond() );
+      _thwipOutAnimation->Tick();
    }
    else
    {

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -31,13 +31,7 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
    _renderConfig( renderConfig ),
    _inputConfig( inputConfig ),
    _animationProvider( animationProvider ),
-   _thwipOutAnimation( animationProvider->GetAnimation( ConsoleAnimationType::PlayerThwipOut ) ),
-   _isAnimatingPlayerThwipOutTransition( false ),
-   _isAnimatingPlayerThwipOut( false ),
-   _isAnimatingPostThwipDelay( false ),
-   _playerThwipBottomUnits( 0 ),
-   _preThwipElapsedSeconds( 0 ),
-   _postThwipElapsedSeconds( 0 )
+   _thwipOutAnimation( animationProvider->GetAnimation( ConsoleAnimationType::PlayerThwipOut ) )
 {
    for ( int i = 0; i < renderConfig->TitleStarCount; i++ )
    {
@@ -71,11 +65,8 @@ void TitleStateConsoleRenderer::Render()
 
    if ( _thwipOutAnimation->IsRunning() )
    {
-      DrawPlayerThwipOutAnimation();
-   }
-   else if ( _isAnimatingPostThwipDelay )
-   {
-      DrawPostThwipDelayAnimation();
+      _thwipOutAnimation->Draw();
+      _thwipOutAnimation->Tick( _frameRateProvider->GetFramesPerSecond() );
    }
    else
    {
@@ -87,7 +78,7 @@ void TitleStateConsoleRenderer::Render()
 
 bool TitleStateConsoleRenderer::HasFocus() const
 {
-   return _thwipOutAnimation->IsRunning() || _isAnimatingPostThwipDelay;
+   return _thwipOutAnimation->IsRunning();
 }
 
 void TitleStateConsoleRenderer::DrawStars()
@@ -122,26 +113,5 @@ void TitleStateConsoleRenderer::DrawKeyBindings() const
       _consoleBuffer->Draw( leftOfMiddleX - (int)keyString.length() - 2, top, format( "{0} -> {1}", keyString, buttonString ), _renderConfig->TitleKeyBindingsForegroundColor );
 
       top++;
-   }
-}
-
-void TitleStateConsoleRenderer::DrawPlayerThwipOutAnimation()
-{
-   _thwipOutAnimation->Draw();
-   _thwipOutAnimation->Tick( _frameRateProvider->GetFramesPerSecond() );
-
-   if ( !_thwipOutAnimation->IsRunning() )
-   {
-      _isAnimatingPostThwipDelay = true;
-   }
-}
-
-void TitleStateConsoleRenderer::DrawPostThwipDelayAnimation()
-{
-   _postThwipElapsedSeconds += ( 1 / (double)_frameRateProvider->GetFramesPerSecond() );
-
-   if ( _postThwipElapsedSeconds >= _renderConfig->TitlePostThwipDelaySeconds )
-   {
-      _isAnimatingPostThwipDelay = false;
    }
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -8,6 +8,7 @@
 #include "IGameEventAggregator.h"
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"
+#include "IConsoleSprite.h"
 #include "ConsoleColor.h"
 #include "GameEvent.h"
 

--- a/MegaManLofi/TitleStateConsoleRenderer.cpp
+++ b/MegaManLofi/TitleStateConsoleRenderer.cpp
@@ -8,6 +8,7 @@
 #include "IGameEventAggregator.h"
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"
+#include "IConsoleAnimationProvider.h"
 #include "IConsoleSprite.h"
 #include "ConsoleColor.h"
 #include "GameEvent.h"
@@ -20,13 +21,15 @@ TitleStateConsoleRenderer::TitleStateConsoleRenderer( const shared_ptr<IConsoleB
                                                       const shared_ptr<IFrameRateProvider> frameRateProvider,
                                                       const shared_ptr<IGameEventAggregator> eventAggregator,
                                                       const shared_ptr<ConsoleRenderConfig> renderConfig,
-                                                      const shared_ptr<KeyboardInputConfig> inputConfig ) :
+                                                      const shared_ptr<KeyboardInputConfig> inputConfig,
+                                                      const shared_ptr<IConsoleAnimationProvider> animationProvider ) :
    _consoleBuffer( consoleBuffer ),
    _random( random ),
    _frameRateProvider( frameRateProvider ),
    _eventAggregator( eventAggregator ),
    _renderConfig( renderConfig ),
    _inputConfig( inputConfig ),
+   _animationProvider( animationProvider ),
    _isAnimatingPlayerThwipOutTransition( false ),
    _isAnimatingPlayerThwipOut( false ),
    _isAnimatingPostThwipDelay( false ),

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -15,6 +15,7 @@ namespace MegaManLofi
    class ConsoleRenderConfig;
    class KeyboardInputConfig;
    class IConsoleAnimationProvider;
+   class IConsoleAnimation;
 
    class TitleStateConsoleRenderer : public IGameRenderer
    {
@@ -34,7 +35,6 @@ namespace MegaManLofi
    private:
       void DrawStars();
       void DrawKeyBindings() const;
-      void DrawPlayerThwipOutTransitionAnimation();
       void DrawPlayerThwipOutAnimation();
       void DrawPostThwipDelayAnimation();
 
@@ -46,6 +46,8 @@ namespace MegaManLofi
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<KeyboardInputConfig> _inputConfig;
       const std::shared_ptr<IConsoleAnimationProvider> _animationProvider;
+
+      const std::shared_ptr<IConsoleAnimation> _thwipOutAnimation;
 
       std::vector<Coordinate<long long>> _starCoordinates;
       std::vector<long long> _starVelocities;

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -35,8 +35,6 @@ namespace MegaManLofi
    private:
       void DrawStars();
       void DrawKeyBindings() const;
-      void DrawPlayerThwipOutAnimation();
-      void DrawPostThwipDelayAnimation();
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
@@ -51,12 +49,5 @@ namespace MegaManLofi
 
       std::vector<Coordinate<long long>> _starCoordinates;
       std::vector<long long> _starVelocities;
-
-      bool _isAnimatingPlayerThwipOutTransition;
-      bool _isAnimatingPlayerThwipOut;
-      bool _isAnimatingPostThwipDelay;
-      long long _playerThwipBottomUnits;
-      double _preThwipElapsedSeconds;
-      double _postThwipElapsedSeconds;
    };
 }

--- a/MegaManLofi/TitleStateConsoleRenderer.h
+++ b/MegaManLofi/TitleStateConsoleRenderer.h
@@ -14,6 +14,7 @@ namespace MegaManLofi
    class IGameEventAggregator;
    class ConsoleRenderConfig;
    class KeyboardInputConfig;
+   class IConsoleAnimationProvider;
 
    class TitleStateConsoleRenderer : public IGameRenderer
    {
@@ -23,7 +24,8 @@ namespace MegaManLofi
                                  const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                                  const std::shared_ptr<IGameEventAggregator> eventAggregator,
                                  const std::shared_ptr<ConsoleRenderConfig> renderConfig,
-                                 const std::shared_ptr<KeyboardInputConfig> inputConfig );
+                                 const std::shared_ptr<KeyboardInputConfig> inputConfig,
+                                 const std::shared_ptr<IConsoleAnimationProvider> animationProvider );
 
       void HandleGameStartedEvent();
       void Render() override;
@@ -43,6 +45,7 @@ namespace MegaManLofi
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<KeyboardInputConfig> _inputConfig;
+      const std::shared_ptr<IConsoleAnimationProvider> _animationProvider;
 
       std::vector<Coordinate<long long>> _starCoordinates;
       std::vector<long long> _starVelocities;

--- a/MegaManLofiTests/ConsoleAnimationRepositoryTests.cpp
+++ b/MegaManLofiTests/ConsoleAnimationRepositoryTests.cpp
@@ -1,0 +1,36 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/ConsoleAnimationRepository.h>
+
+#include "mock_ConsoleAnimation.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class ConsoleAnimationRepositoryTests : public Test { };
+
+TEST_F( ConsoleAnimationRepositoryTests, AddAnimation_Always_AddsAnimationToMap )
+{
+   ConsoleAnimationRepository repository;
+
+   auto animationMock = shared_ptr<mock_ConsoleAnimation>( new NiceMock<mock_ConsoleAnimation> );
+   repository.AddAnimation( ConsoleAnimationType::StageStarted, animationMock );
+
+   EXPECT_EQ( repository.GetAnimation( ConsoleAnimationType::StageStarted ), animationMock );
+}
+
+TEST_F( ConsoleAnimationRepositoryTests, GetAnimation_Always_ReturnsCorrectAnimation )
+{
+   ConsoleAnimationRepository repository;
+
+   auto animationMock1 = shared_ptr<mock_ConsoleAnimation>( new NiceMock<mock_ConsoleAnimation> );
+   auto animationMock2 = shared_ptr<mock_ConsoleAnimation>( new NiceMock<mock_ConsoleAnimation> );
+   repository.AddAnimation( ConsoleAnimationType::StageStarted, animationMock1 );
+   repository.AddAnimation( ConsoleAnimationType::PlayerExploded, animationMock2 );
+
+   EXPECT_EQ( repository.GetAnimation( ConsoleAnimationType::StageStarted ), animationMock1 );
+   EXPECT_EQ( repository.GetAnimation( ConsoleAnimationType::PlayerExploded ), animationMock2 );
+}

--- a/MegaManLofiTests/ConsoleSpriteTests.cpp
+++ b/MegaManLofiTests/ConsoleSpriteTests.cpp
@@ -10,101 +10,131 @@ using namespace std;
 using namespace testing;
 using namespace MegaManLofi;
 
-class ConsoleSpriteTests : public Test { };
+class ConsoleSpriteTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
+
+      ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 ) );
+
+      _imageTraversalSeconds = 1;
+   }
+
+   void BuildSprite()
+   {
+      _sprite.reset( new ConsoleSprite( _frameRateProviderMock, _imageTraversalSeconds ) );
+   }
+
+protected:
+   shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
+
+   double _imageTraversalSeconds;
+
+   shared_ptr<ConsoleSprite> _sprite;
+};
 
 TEST_F( ConsoleSpriteTests, Reset_Always_ResetsToFirstImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.75 ) );
-   sprite->AddImage( { 0, 0 } );
-   sprite->AddImage( { 1, 1 } );
-   sprite->AddImage( { 2, 2 } );
+   _imageTraversalSeconds = .75;
+   BuildSprite();
+   _sprite->AddImage( { 0, 0 } );
+   _sprite->AddImage( { 1, 1 } );
+   _sprite->AddImage( { 2, 2 } );
 
-   sprite->Tick( 1 ); // 1 second has passed, should be on the second image
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 1 );
+   _sprite->Tick(); // 1 second has passed, should be on the second image
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 1 );
 
-   sprite->Reset(); // back to first image
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 0 );
+   _sprite->Reset(); // back to first image
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 0 );
 
-   sprite->Tick( 1 ); // 1 second has passed, should be on the second image again
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 1 );
+   _sprite->Tick(); // 1 second has passed, should be on the second image again
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 1 );
 }
 
 TEST_F( ConsoleSpriteTests, GetCurrentImage_ElapsedTimeMatchesTotalSpriteTime_ReturnsFirstImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.25 ) );
-   sprite->AddImage( { 0, 0 } );
-   sprite->AddImage( { 1, 1 } );
-   sprite->AddImage( { 2, 2 } );
-   sprite->AddImage( { 3, 3 } );
+   _imageTraversalSeconds = .25;
+   BuildSprite();
+   _sprite->AddImage( { 0, 0 } );
+   _sprite->AddImage( { 1, 1 } );
+   _sprite->AddImage( { 2, 2 } );
+   _sprite->AddImage( { 3, 3 } );
 
-   sprite->Tick( 1 ); // 1 second has passed, should be back on the first image
+   _sprite->Tick(); // 1 second has passed, should be back on the first image
 
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 0 );
-   EXPECT_EQ( sprite->GetCurrentImage().Height, 0 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 0 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Height, 0 );
 }
 
 TEST_F( ConsoleSpriteTests, GetCurrentImage_ElapsedTimeLandsOnImageBoundary_ReturnsCorrectImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.25 ) );
-   sprite->AddImage( { 0, 0 } );
-   sprite->AddImage( { 1, 1 } );
-   sprite->AddImage( { 2, 2 } );
-   sprite->AddImage( { 3, 3 } );
+   ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( .25 ) );
+   _imageTraversalSeconds = .25;
+   BuildSprite();
+   _sprite->AddImage( { 0, 0 } );
+   _sprite->AddImage( { 1, 1 } );
+   _sprite->AddImage( { 2, 2 } );
+   _sprite->AddImage( { 3, 3 } );
 
-   sprite->Tick( 4 ); // 0.25 seconds have passed, should be on second image
+   _sprite->Tick(); // 0.25 seconds have passed, should be on second image
 
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 1 );
-   EXPECT_EQ( sprite->GetCurrentImage().Height, 1 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 1 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Height, 1 );
 }
 
 TEST_F( ConsoleSpriteTests, GetWidth_Always_ReturnsWidthOfCurrentImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.75 ) );
-   sprite->AddImage( { 0, 1 } );
-   sprite->AddImage( { 2, 3 } );
-   sprite->AddImage( { 4, 5 } );
-   sprite->AddImage( { 6, 7 } );
+   _imageTraversalSeconds = .75;
+   BuildSprite();
+   _sprite->AddImage( { 0, 1 } );
+   _sprite->AddImage( { 2, 3 } );
+   _sprite->AddImage( { 4, 5 } );
+   _sprite->AddImage( { 6, 7 } );
 
-   sprite->Tick( 1 ); // 1 second has passed, should be on second image
+   _sprite->Tick(); // 1 second has passed, should be on second image
 
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 2 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 2 );
 }
 
 TEST_F( ConsoleSpriteTests, GetHeight_Always_ReturnsHeightOfCurrentImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.75 ) );
-   sprite->AddImage( { 0, 1 } );
-   sprite->AddImage( { 2, 3 } );
-   sprite->AddImage( { 4, 5 } );
-   sprite->AddImage( { 6, 7 } );
+   _imageTraversalSeconds = .75;
+   BuildSprite();
+   _sprite->AddImage( { 0, 1 } );
+   _sprite->AddImage( { 2, 3 } );
+   _sprite->AddImage( { 4, 5 } );
+   _sprite->AddImage( { 6, 7 } );
 
-   sprite->Tick( 1 ); // 1 second has passed, should be on second image
-   sprite->Tick( 1 ); // 2 seconds have passed, should be on third image
+   _sprite->Tick(); // 1 second has passed, should be on second image
+   _sprite->Tick(); // 2 seconds have passed, should be on third image
 
-   EXPECT_EQ( sprite->GetCurrentImage().Height, 5 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Height, 5 );
 }
 
 TEST_F( ConsoleSpriteTests, GetTotalTraversalSeconds_Always_ReturnsTotalTraversalSeconds )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 1 ) );
-   sprite->AddImage( { 0, 1 } );
-   sprite->AddImage( { 2, 3 } );
-   sprite->AddImage( { 4, 5 } );
+   BuildSprite();
+   _sprite->AddImage( { 0, 1 } );
+   _sprite->AddImage( { 2, 3 } );
+   _sprite->AddImage( { 4, 5 } );
 
-   EXPECT_EQ( sprite->GetTotalTraversalSeconds(), 3 );
+   EXPECT_EQ( _sprite->GetTotalTraversalSeconds(), 3 );
 }
 
 TEST_F( ConsoleSpriteTests, Tick_ImageTraversalIsZeroSeconds_MovesDirectlyToTheNextImage )
 {
-   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0 ) );
-   sprite->AddImage( { 0, 1 } );
-   sprite->AddImage( { 2, 3 } );
-   sprite->AddImage( { 4, 5 } );
-   sprite->AddImage( { 6, 7 } );
+   _imageTraversalSeconds = 0;
+   BuildSprite();
+   _sprite->AddImage( { 0, 1 } );
+   _sprite->AddImage( { 2, 3 } );
+   _sprite->AddImage( { 4, 5 } );
+   _sprite->AddImage( { 6, 7 } );
 
-   sprite->Tick( 1 ); // should be on second image
-   sprite->Tick( 1 ); // should be on third image
-   sprite->Tick( 1 ); // should be on fourth image
+   _sprite->Tick(); // should be on second image
+   _sprite->Tick(); // should be on third image
+   _sprite->Tick(); // should be on fourth image
 
-   EXPECT_EQ( sprite->GetCurrentImage().Width, 6 );
+   EXPECT_EQ( _sprite->GetCurrentImage().Width, 6 );
 }

--- a/MegaManLofiTests/ConsoleSpriteTests.cpp
+++ b/MegaManLofiTests/ConsoleSpriteTests.cpp
@@ -12,6 +12,23 @@ using namespace MegaManLofi;
 
 class ConsoleSpriteTests : public Test { };
 
+TEST_F( ConsoleSpriteTests, Reset_Always_ResetsToFirstImage )
+{
+   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.75 ) );
+   sprite->AddImage( { 0, 0 } );
+   sprite->AddImage( { 1, 1 } );
+   sprite->AddImage( { 2, 2 } );
+
+   sprite->Tick( 1 ); // 1 second has passed, should be on the second image
+   EXPECT_EQ( sprite->GetCurrentImage().Width, 1 );
+
+   sprite->Reset(); // back to first image
+   EXPECT_EQ( sprite->GetCurrentImage().Width, 0 );
+
+   sprite->Tick( 1 ); // 1 second has passed, should be on the second image again
+   EXPECT_EQ( sprite->GetCurrentImage().Width, 1 );
+}
+
 TEST_F( ConsoleSpriteTests, GetCurrentImage_ElapsedTimeMatchesTotalSpriteTime_ReturnsFirstImage )
 {
    auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( 0.25 ) );

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -39,6 +39,7 @@
     <ClInclude Include="mock_Arena.h" />
     <ClInclude Include="mock_ArenaPhysics.h" />
     <ClInclude Include="mock_ConsoleAnimation.h" />
+    <ClInclude Include="mock_ConsoleAnimationProvider.h" />
     <ClInclude Include="mock_ConsoleSprite.h" />
     <ClInclude Include="mock_FrameActionRegistry.h" />
     <ClInclude Include="mock_FrameRateProvider.h" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <ClCompile Include="ArenaPhysicsTests.cpp" />
     <ClCompile Include="ArenaTests.cpp" />
+    <ClCompile Include="ConsoleAnimationRepositoryTests.cpp" />
     <ClCompile Include="ConsoleSpriteTests.cpp" />
     <ClCompile Include="FrameActionRegistryTests.cpp" />
     <ClCompile Include="GameClockTests.cpp" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ClInclude Include="mock_Arena.h" />
     <ClInclude Include="mock_ArenaPhysics.h" />
+    <ClInclude Include="mock_ConsoleAnimation.h" />
     <ClInclude Include="mock_FrameActionRegistry.h" />
     <ClInclude Include="mock_FrameRateProvider.h" />
     <ClInclude Include="mock_Game.h" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
     <ClCompile Include="RectangleUtilitiesTests.cpp" />
+    <ClCompile Include="StageStartedConsoleAnimationTests.cpp" />
     <ClCompile Include="TitleStateInputHandlerTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -39,6 +39,7 @@
     <ClInclude Include="mock_Arena.h" />
     <ClInclude Include="mock_ArenaPhysics.h" />
     <ClInclude Include="mock_ConsoleAnimation.h" />
+    <ClInclude Include="mock_ConsoleSprite.h" />
     <ClInclude Include="mock_FrameActionRegistry.h" />
     <ClInclude Include="mock_FrameRateProvider.h" />
     <ClInclude Include="mock_Game.h" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
     <ClCompile Include="PlayerPhysicsTests.cpp" />
     <ClCompile Include="PlayerTests.cpp" />
+    <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
     <ClCompile Include="RectangleUtilitiesTests.cpp" />
     <ClCompile Include="TitleStateInputHandlerTests.cpp" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="GameRunnerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
+    <ClCompile Include="PlayerExplodedConsoleAnimationTests.cpp" />
     <ClCompile Include="PlayerPhysicsTests.cpp" />
     <ClCompile Include="PlayerTests.cpp" />
     <ClCompile Include="PlayerThwipInConsoleAnimationTests.cpp" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -76,6 +76,7 @@
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
     <ClCompile Include="PlayerPhysicsTests.cpp" />
     <ClCompile Include="PlayerTests.cpp" />
+    <ClCompile Include="PlayerThwipInConsoleAnimationTests.cpp" />
     <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
     <ClCompile Include="RectangleUtilitiesTests.cpp" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -125,6 +125,9 @@
     <ClInclude Include="mock_ConsoleSprite.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_ConsoleAnimationProvider.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClInclude Include="mock_ConsoleAnimation.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_ConsoleSprite.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp">
       <Filter>Tests\Render</Filter>
     </ClCompile>
+    <ClCompile Include="ConsoleAnimationRepositoryTests.cpp">
+      <Filter>Tests\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="PlayerThwipInConsoleAnimationTests.cpp">
       <Filter>Tests\Render\Animations</Filter>
     </ClCompile>
+    <ClCompile Include="StageStartedConsoleAnimationTests.cpp">
+      <Filter>Tests\Render\Animations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -54,11 +54,14 @@
     <ClCompile Include="ConsoleSpriteTests.cpp">
       <Filter>Tests\Render</Filter>
     </ClCompile>
-    <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp">
-      <Filter>Tests\Render</Filter>
-    </ClCompile>
     <ClCompile Include="ConsoleAnimationRepositoryTests.cpp">
-      <Filter>Tests\Render</Filter>
+      <Filter>Tests\Render\Animations</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp">
+      <Filter>Tests\Render\Animations</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerThwipInConsoleAnimationTests.cpp">
+      <Filter>Tests\Render\Animations</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -150,6 +153,9 @@
     </Filter>
     <Filter Include="Tests\GameObjects">
       <UniqueIdentifier>{02651954-e96a-4c40-9549-39d3547a04bf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Render\Animations">
+      <UniqueIdentifier>{da0cac45-9def-420d-9060-6a4218471f8b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="ConsoleSpriteTests.cpp">
       <Filter>Tests\Render</Filter>
     </ClCompile>
+    <ClCompile Include="PlayerThwipOutConsoleAnimationTests.cpp">
+      <Filter>Tests\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="StageStartedConsoleAnimationTests.cpp">
       <Filter>Tests\Render\Animations</Filter>
     </ClCompile>
+    <ClCompile Include="PlayerExplodedConsoleAnimationTests.cpp">
+      <Filter>Tests\Render\Animations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClInclude Include="mock_ArenaPhysics.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_ConsoleAnimation.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
@@ -1,0 +1,55 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/PlayerExplodedConsoleAnimation.h>
+#include <MegaManLofi/ConsoleRenderConfig.h>
+
+#include "mock_ConsoleBuffer.h"
+#include "mock_FrameRateProvider.h"
+#include "mock_ConsoleSprite.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class PlayerExplodedConsoleAnimationTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _consoleBufferMock.reset( new NiceMock<mock_ConsoleBuffer> );
+      _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
+      _renderConfig.reset( new ConsoleRenderConfig );
+
+      ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 ) );
+   }
+
+   void BuildAnimation()
+   {
+      _animation.reset( new PlayerExplodedConsoleAnimation( _consoleBufferMock, _frameRateProviderMock, _renderConfig ) );
+   }
+
+protected:
+   shared_ptr<mock_ConsoleBuffer> _consoleBufferMock;
+   shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
+   shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+   shared_ptr<PlayerExplodedConsoleAnimation> _animation;
+};
+
+TEST_F( PlayerExplodedConsoleAnimationTests, Constructor_Always_InitializesIsRunningToFalse )
+{
+   BuildAnimation();
+
+   EXPECT_FALSE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
+{
+   BuildAnimation();
+
+   _animation->Start( { 0, 0 }, { 0,0 } );
+
+   EXPECT_TRUE( _animation->IsRunning() );
+}

--- a/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
@@ -21,6 +21,12 @@ public:
       _consoleBufferMock.reset( new NiceMock<mock_ConsoleBuffer> );
       _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
       _renderConfig.reset( new ConsoleRenderConfig );
+      _particleSpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+
+      _renderConfig->PlayerExplosionParticleSprite = _particleSpriteMock;
+      _renderConfig->PlayerExplosionParticleVelocity = 2;
+      _renderConfig->ArenaCharWidth = 1;
+      _renderConfig->ArenaCharHeight = 1;
 
       ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 ) );
    }
@@ -34,6 +40,8 @@ protected:
    shared_ptr<mock_ConsoleBuffer> _consoleBufferMock;
    shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
    shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+   shared_ptr<mock_ConsoleSprite> _particleSpriteMock;
 
    shared_ptr<PlayerExplodedConsoleAnimation> _animation;
 };
@@ -49,7 +57,66 @@ TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();
 
-   _animation->Start( { 0, 0 }, { 0,0 } );
+   _animation->Start( { 0, 0 }, { 0, 0 } );
 
    EXPECT_TRUE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_ResetsExplosionSprite )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_particleSpriteMock, Reset() );
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+
+   EXPECT_TRUE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerExplodedConsoleAnimationTests, Draw_Always_DrawsAllParticlesInCorrectPositions )
+{
+   ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 / (double)30 ) );
+   BuildAnimation();
+
+   EXPECT_CALL( *_frameRateProviderMock, GetCurrentFrame() )
+      .WillOnce( Return( 0 ) )   // in Start()
+      .WillOnce( Return( 0 ) )   // first call to Draw()
+      .WillOnce( Return( 90 ) ); // second call to Draw()
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 30, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) ).Times( 16 );
+
+   _animation->Start( { 30, 30 }, { 0, 0 } );
+   _animation->Draw();
+
+   // horizontal and vertical particles
+   EXPECT_CALL( *_consoleBufferMock, Draw( 36, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 33, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 27, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 24, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 30, 36, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 30, 33, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 30, 27, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 30, 24, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+
+   // diagonal particles
+   EXPECT_CALL( *_consoleBufferMock, Draw( 26, 26, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 28, 28, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 26, 34, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 28, 32, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 34, 26, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 32, 28, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 34, 34, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+   EXPECT_CALL( *_consoleBufferMock, Draw( 32, 32, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) );
+
+   _animation->Tick();
+   _animation->Draw();
+}
+
+TEST_F( PlayerExplodedConsoleAnimationTests, Tick_NotRunning_DoesNotTickParticleSprite )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_particleSpriteMock, Tick() ).Times( 0 );
+
+   _animation->Tick();
 }

--- a/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
@@ -1,0 +1,153 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/PlayerThwipInConsoleAnimation.h>
+#include <MegaManLofi/ConsoleRenderConfig.h>
+
+#include "mock_ConsoleBuffer.h"
+#include "mock_FrameRateProvider.h"
+#include "mock_ConsoleSprite.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class PlayerThwipInConsoleAnimationTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _renderConfig.reset( new ConsoleRenderConfig );
+      _consoleBufferMock.reset( new NiceMock<mock_ConsoleBuffer> );
+      _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
+      _transitionSpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+      _thwipSpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+
+      _renderConfig->ArenaCharWidth = 1;
+      _renderConfig->ArenaCharHeight = 1;
+      _renderConfig->PlayerThwipVelocity = 1;
+
+      ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 ) );
+      ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 10 ) );
+
+      _renderConfig->PlayerThwipSprite = _thwipSpriteMock;
+      _renderConfig->PlayerThwipInTransitionSprite = _transitionSpriteMock;
+   }
+
+   void BuildAnimation()
+   {
+      _animation.reset( new PlayerThwipInConsoleAnimation( _consoleBufferMock, _renderConfig, _frameRateProviderMock ) );
+   }
+
+protected:
+   shared_ptr<mock_ConsoleBuffer> _consoleBufferMock;
+   shared_ptr<ConsoleRenderConfig> _renderConfig;
+   shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
+
+   shared_ptr<mock_ConsoleSprite> _thwipSpriteMock;
+   shared_ptr<mock_ConsoleSprite> _transitionSpriteMock;
+
+   shared_ptr<PlayerThwipInConsoleAnimation> _animation;
+};
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Constructor_Always_InitializesIsRunningToFalse )
+{
+   BuildAnimation();
+
+   EXPECT_FALSE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
+{
+   BuildAnimation();
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+
+   EXPECT_TRUE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Start_Always_ResetsSprites )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_transitionSpriteMock, Reset() );
+   EXPECT_CALL( *_thwipSpriteMock, Reset() );
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Draw_PostThwipping_DrawsSpriteInEndPosition )
+{
+   BuildAnimation();
+   _animation->Start( { 0, 0 }, { 10, 10 } );
+
+   for ( int i = 0; i < 10; i++ )
+   {
+      _animation->Tick(); // 10 seconds later, should be post-thwipping
+   }
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 10, static_pointer_cast<IConsoleSprite>( _transitionSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Draw_ThwippingDownward_DrawsSpriteInCorrectTopPosition )
+{
+   ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
+   BuildAnimation();
+   _animation->Start( { 0, 0 }, { 10, 10 } );
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+
+   for( int i = 0; i < 3; i++ ) _animation->Tick(); // 3 seconds, should be 3 chars down
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 3, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Draw_ThwippingUpward_DrawsSpriteInCorrectTopPosition )
+{
+   ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
+   BuildAnimation();
+   _animation->Start( { 10, 10 }, { 0, 0 } );
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 10, 10, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+
+   for( int i = 0; i < 3; i++ ) _animation->Tick(); // 3 seconds, should be 3 chars up
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 10, 7, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Tick_NotRunning_DoesNotTickAnySprites )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_thwipSpriteMock, Tick() ).Times( 0 );
+   EXPECT_CALL( *_transitionSpriteMock, Tick() ).Times( 0 );
+
+   _animation->Tick();
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Tick_ThwipAnimationHasFinished_StopsRunning )
+{
+   BuildAnimation();
+   _animation->Start( { 10, 10 }, { 8, 8 } );
+
+   _animation->Tick(); // thwip sprite moves to 1 char up
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick(); // thwip sprite moves to 2 chars up, should switch to post-thwipping
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   for ( int i = 0; i < 9; i++ )
+   {
+      _animation->Tick(); // after 9 seconds, should be on last frame
+      EXPECT_TRUE( _animation->IsRunning() );
+   }
+
+   _animation->Tick(); // 10 seconds post-thwip, finished
+   EXPECT_FALSE( _animation->IsRunning() );
+}

--- a/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
@@ -1,0 +1,153 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/PlayerThwipOutConsoleAnimation.h>
+#include <MegaManLofi/ConsoleRenderConfig.h>
+
+#include "mock_ConsoleBuffer.h"
+#include "mock_ConsoleSprite.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class PlayerThwipOutConsoleAnimationTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _renderConfig.reset( new ConsoleRenderConfig );
+      _consoleBufferMock.reset( new NiceMock<mock_ConsoleBuffer> );
+      _transitionSpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+      _thwipSpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+
+      _renderConfig->ArenaCharWidth = 1;
+      _renderConfig->ArenaCharHeight = 1;
+      _renderConfig->PlayerThwipVelocity = 1;
+
+      _framesPerSecond = 1;
+
+      ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 10 ) );
+
+      _renderConfig->PlayerThwipOutTransitionSprite = _transitionSpriteMock;
+      _renderConfig->PlayerThwipSprite = _thwipSpriteMock;
+   }
+
+   void BuildAnimation()
+   {
+      _animation.reset( new PlayerThwipOutConsoleAnimation( _consoleBufferMock, _renderConfig ) );
+   }
+
+protected:
+   shared_ptr<mock_ConsoleBuffer> _consoleBufferMock;
+   shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+   shared_ptr<mock_ConsoleSprite> _transitionSpriteMock;
+   shared_ptr<mock_ConsoleSprite> _thwipSpriteMock;
+
+   int _framesPerSecond;
+
+   shared_ptr<PlayerThwipOutConsoleAnimation> _animation;
+};
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Constructor_Always_InitializesIsRunningToFalse )
+{
+   BuildAnimation();
+
+   EXPECT_FALSE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
+{
+   BuildAnimation();
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+
+   EXPECT_TRUE( _animation->IsRunning() );
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Start_Always_ResetsSprites )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_transitionSpriteMock, Reset() );
+   EXPECT_CALL( *_thwipSpriteMock, Reset() );
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_PreThwipping_DrawsSpriteInStartPosition )
+{
+   BuildAnimation();
+   _animation->Start( { 0, 0 }, { 10, 10 } );
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _transitionSpriteMock ) ) );
+   _animation->Draw();
+
+   EXPECT_CALL( *_transitionSpriteMock, Tick( _framesPerSecond ) );
+   _animation->Tick( _framesPerSecond );
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _transitionSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_ThwippingDownward_DrawsSpriteInCorrectTopPosition )
+{
+   ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
+   BuildAnimation();
+   _animation->Start( { 0, 0 }, { 10, 10 } );
+
+   _animation->Tick( _framesPerSecond ); // should switch from pre-thwipping to thwipping
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+
+   for( int i = 0; i < 3; i++ ) _animation->Tick( _framesPerSecond ); // 3 seconds, should be 3 chars down
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 0, 3, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_ThwippingUpward_DrawsSpriteInCorrectTopPosition )
+{
+   ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
+   BuildAnimation();
+   _animation->Start( { 10, 10 }, { 0, 0 } );
+
+   _animation->Tick( _framesPerSecond ); // should switch from pre-thwipping to thwipping
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 10, 10, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+
+   for( int i = 0; i < 3; i++ ) _animation->Tick( _framesPerSecond ); // 3 seconds, should be 3 chars up
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 10, 7, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
+   _animation->Draw();
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Tick_NotRunning_DoesNotTickAnySprites )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_transitionSpriteMock, Tick( _ ) ).Times( 0 );
+   EXPECT_CALL( *_thwipSpriteMock, Tick( _ ) ).Times( 0 );
+
+   _animation->Tick( _framesPerSecond );
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Tick_ThwipAnimationHasFinished_StopsRunning )
+{
+   ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
+   BuildAnimation();
+   _animation->Start( { 10, 10 }, { 8, 8 } );
+
+   _animation->Tick( _framesPerSecond ); // should switch from pre-thwipping to thwipping
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick( _framesPerSecond ); // thwip sprite moves to 1 char up
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick( _framesPerSecond ); // thwip sprite moves to 2 chars up, finished
+   EXPECT_FALSE( _animation->IsRunning() );
+}

--- a/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
@@ -25,6 +25,7 @@ public:
       _renderConfig->ArenaCharWidth = 1;
       _renderConfig->ArenaCharHeight = 1;
       _renderConfig->PlayerThwipVelocity = 1;
+      _renderConfig->PlayerPostThwipDelaySeconds = 2;
 
       _framesPerSecond = 1;
 
@@ -148,6 +149,12 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Tick_ThwipAnimationHasFinished_Stop
    _animation->Tick( _framesPerSecond ); // thwip sprite moves to 1 char up
    EXPECT_TRUE( _animation->IsRunning() );
 
-   _animation->Tick( _framesPerSecond ); // thwip sprite moves to 2 chars up, finished
+   _animation->Tick( _framesPerSecond ); // thwip sprite moves to 2 chars up, should switch to post-thwipping
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick( _framesPerSecond ); // post-thwip delay first second
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick( _framesPerSecond ); // post-thwip delay second second, finished
    EXPECT_FALSE( _animation->IsRunning() );
 }

--- a/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
@@ -1,0 +1,112 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <MegaManLofi/StageStartedConsoleAnimation.h>
+#include <MegaManLofi/ConsoleRenderConfig.h>
+
+#include "mock_ConsoleBuffer.h"
+#include "mock_FrameRateProvider.h"
+#include "mock_ConsoleSprite.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class StageStartedConsoleAnimationTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _consoleBufferMock.reset( new NiceMock<mock_ConsoleBuffer> );
+      _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
+      _renderConfig.reset( new ConsoleRenderConfig );
+      _getReadySpriteMock.reset( new NiceMock<mock_ConsoleSprite> );
+
+      _renderConfig->GetReadySprite = _getReadySpriteMock;
+
+      ON_CALL( *_frameRateProviderMock, GetFrameScalar() ).WillByDefault( Return( 1 ) );
+   }
+
+   void BuildAnimation()
+   {
+      _animation.reset( new StageStartedConsoleAnimation( _consoleBufferMock, _frameRateProviderMock, _renderConfig ) );
+   }
+
+protected:
+   shared_ptr<mock_ConsoleBuffer> _consoleBufferMock;
+   shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
+   shared_ptr<ConsoleRenderConfig> _renderConfig;
+
+   shared_ptr<mock_ConsoleSprite> _getReadySpriteMock;
+
+   shared_ptr<StageStartedConsoleAnimation> _animation;
+};
+
+TEST_F( StageStartedConsoleAnimationTests, Constructor_Always_InitializesIsRunningToFalse )
+{
+   BuildAnimation();
+
+   EXPECT_FALSE( _animation->IsRunning() );
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
+{
+   BuildAnimation();
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+
+   EXPECT_TRUE( _animation->IsRunning() );
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Start_Always_ResetsGetReadySprite )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_getReadySpriteMock, Reset() );
+
+   _animation->Start( { 0, 0 }, { 0, 0 } );
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Draw_Always_DrawsStartPosition )
+{
+   BuildAnimation();
+   _animation->Start( { 1, 2 }, { 0, 0 } );
+
+   EXPECT_CALL( *_consoleBufferMock, Draw( 1, 2, static_pointer_cast<IConsoleSprite>( _getReadySpriteMock ) ) );
+   _animation->Tick();
+
+   _animation->Draw();
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Tick_IsNotRunning_DoesNotTickGetReadySprite )
+{
+   BuildAnimation();
+
+   EXPECT_CALL( *_getReadySpriteMock, Tick() ).Times( 0 );
+
+   _animation->Tick();
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Tick_IsRunning_TicksGetReadySprite )
+{
+   BuildAnimation();
+   _animation->Start( { 1, 2 }, { 0, 0 } );
+
+   EXPECT_CALL( *_getReadySpriteMock, Tick() );
+
+   _animation->Tick();
+}
+
+TEST_F( StageStartedConsoleAnimationTests, Tick_FinishedRunning_SetsIsRunningToFalse )
+{
+   _renderConfig->GetReadyAnimationSeconds = 2;
+   BuildAnimation();
+   _animation->Start( { 1, 2 }, { 0, 0 } );
+
+   _animation->Tick(); // 1 second has passed, still running
+   EXPECT_TRUE( _animation->IsRunning() );
+
+   _animation->Tick(); // 2 seconds have passed, should be finished
+   EXPECT_FALSE( _animation->IsRunning() );
+}

--- a/MegaManLofiTests/mock_ConsoleAnimation.h
+++ b/MegaManLofiTests/mock_ConsoleAnimation.h
@@ -8,7 +8,7 @@ class mock_ConsoleAnimation : public MegaManLofi::IConsoleAnimation
 {
 public:
    MOCK_METHOD( void, Start, ( MegaManLofi::Coordinate<short>, MegaManLofi::Coordinate<short> ), ( override ) );
-   MOCK_METHOD( bool, IsRunning, ( ), ( const override ) );
+   MOCK_METHOD( bool, IsRunning, ( ), ( const, override ) );
    MOCK_METHOD( void, Draw, ( ), ( override ) );
    MOCK_METHOD( void, Tick, ( int ), ( override ) );
 };

--- a/MegaManLofiTests/mock_ConsoleAnimation.h
+++ b/MegaManLofiTests/mock_ConsoleAnimation.h
@@ -10,5 +10,5 @@ public:
    MOCK_METHOD( void, Start, ( MegaManLofi::Coordinate<short>, MegaManLofi::Coordinate<short> ), ( override ) );
    MOCK_METHOD( bool, IsRunning, ( ), ( const, override ) );
    MOCK_METHOD( void, Draw, ( ), ( override ) );
-   MOCK_METHOD( void, Tick, ( int ), ( override ) );
+   MOCK_METHOD( void, Tick, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_ConsoleAnimation.h
+++ b/MegaManLofiTests/mock_ConsoleAnimation.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <MegaManLofi/IConsoleAnimation.h>
+
+class mock_ConsoleAnimation : public MegaManLofi::IConsoleAnimation
+{
+public:
+   MOCK_METHOD( void, Start, ( MegaManLofi::Coordinate<short>, MegaManLofi::Coordinate<short> ), ( override ) );
+   MOCK_METHOD( bool, IsRunning, ( ), ( const override ) );
+   MOCK_METHOD( void, Draw, ( ), ( override ) );
+   MOCK_METHOD( void, Tick, ( int ), ( override ) );
+};

--- a/MegaManLofiTests/mock_ConsoleAnimationProvider.h
+++ b/MegaManLofiTests/mock_ConsoleAnimationProvider.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <MegaManLofi/IConsoleAnimationProvider.h>
+
+class mock_ConsoleAnimationProvider : public MegaManLofi::IConsoleAnimationProvider
+{
+public:
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::IConsoleAnimation>, GetAnimation, ( MegaManLofi::ConsoleAnimationType ), ( const, override ) );
+};

--- a/MegaManLofiTests/mock_ConsoleBuffer.h
+++ b/MegaManLofiTests/mock_ConsoleBuffer.h
@@ -21,7 +21,7 @@ public:
    MOCK_METHOD( void, Draw, ( short, short, const std::string&, MegaManLofi::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, Draw, ( short, short, const std::string&, MegaManLofi::ConsoleColor, MegaManLofi::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, Draw, ( short, short, const MegaManLofi::ConsoleImage& ), ( override ) );
-   MOCK_METHOD( void, Draw, ( short, short, const std::shared_ptr<MegaManLofi::ConsoleSprite> ), ( override ) );
+   MOCK_METHOD( void, Draw, ( short, short, const std::shared_ptr<MegaManLofi::IConsoleSprite> ), ( override ) );
 
    MOCK_METHOD( void, Flip, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_ConsoleSprite.h
+++ b/MegaManLofiTests/mock_ConsoleSprite.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <MegaManLofi/IConsoleSprite.h>
+
+class mock_ConsoleSprite : public MegaManLofi::IConsoleSprite
+{
+public:
+   MOCK_METHOD( void, AddImage, ( MegaManLofi::ConsoleImage ), ( override ) );
+   MOCK_METHOD( void, Tick, ( int ), ( override ) );
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
+   MOCK_METHOD( short, GetWidth, ( ), ( const, override ) );
+   MOCK_METHOD( short, GetHeight, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetTotalTraversalSeconds, ( ), ( const, override ) );
+   MOCK_METHOD( const MegaManLofi::ConsoleImage&, GetCurrentImage, ( ), ( const, override ) );
+};

--- a/MegaManLofiTests/mock_ConsoleSprite.h
+++ b/MegaManLofiTests/mock_ConsoleSprite.h
@@ -8,7 +8,7 @@ class mock_ConsoleSprite : public MegaManLofi::IConsoleSprite
 {
 public:
    MOCK_METHOD( void, AddImage, ( MegaManLofi::ConsoleImage ), ( override ) );
-   MOCK_METHOD( void, Tick, ( int ), ( override ) );
+   MOCK_METHOD( void, Tick, ( ), ( override ) );
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( short, GetWidth, ( ), ( const, override ) );
    MOCK_METHOD( short, GetHeight, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_FrameRateProvider.h
+++ b/MegaManLofiTests/mock_FrameRateProvider.h
@@ -9,4 +9,5 @@ class mock_FrameRateProvider : public MegaManLofi::IFrameRateProvider
 public:
    MOCK_METHOD( int, GetFramesPerSecond, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetFrameScalar, ( ), ( const, override ) );
 };

--- a/MegaManLofiTests/mock_GameClock.h
+++ b/MegaManLofiTests/mock_GameClock.h
@@ -10,10 +10,9 @@ class mock_GameClock : public MegaManLofi::IGameClock
 public:
    MOCK_METHOD( void, StartFrame, ( ), ( override ) );
    MOCK_METHOD( void, WaitForNextFrame, ( ), ( override ) );
-
    MOCK_METHOD( int, GetFramesPerSecond, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetTotalFrameCount, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetLagFrameCount, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
-
+   MOCK_METHOD( double, GetFrameScalar, ( ), ( const, override ) );
 };


### PR DESCRIPTION
`PlayingStateConsoleRenderer` was getting a little out of hand, so I figured it'd be easier on everyone if I moved animations into their own classes. This introduces `IConsoleAnimation`, as well as an `IConsoleAnimationProvider` that retrieves an animation based on the `ConsoleAnimationType` enum. You just have to give the animation a start and end position (sometimes these are optional, such as the end position in the explosion animation), call `Start()`, and then `Tick()` each frame until `IsRunning()` is false.

I thought about using `std::optional` for the start/end position, still might do that at some point.