### PR TITLE
Animation start/end positions are now optional

### DIFF
--- a/MegaManLofi/IConsoleAnimation.h
+++ b/MegaManLofi/IConsoleAnimation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "Coordinate.h"
 
 namespace MegaManLofi
@@ -7,7 +9,8 @@ namespace MegaManLofi
    class __declspec( novtable ) IConsoleAnimation
    {
    public:
-      virtual void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) = 0;
+      virtual void Start( std::optional<Coordinate<short>> startPositionChars,
+                          std::optional<Coordinate<short>> endPositionChars ) = 0;
       virtual bool IsRunning() const = 0;
       virtual void Draw() = 0;
       virtual void Tick() = 0;

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
@@ -20,12 +20,13 @@ PlayerExplodedConsoleAnimation::PlayerExplodedConsoleAnimation( const shared_ptr
 {
 }
 
-void PlayerExplodedConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+void PlayerExplodedConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
+                                            optional<Coordinate<short>> endPositionChars )
 {
    _isRunning = true;
    _elapsedSeconds = 0;
    _explosionStartFrame = _frameRateProvider->GetCurrentFrame();
-   _startPositionChars = startPositionChars;
+   _startPositionChars = startPositionChars.value();
 
    _renderConfig->PlayerExplosionParticleSprite->Reset();
 }

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "PlayerExplodedConsoleAnimation.h"
 #include "IConsoleBuffer.h"
 #include "IFrameRateProvider.h"
@@ -23,6 +25,11 @@ PlayerExplodedConsoleAnimation::PlayerExplodedConsoleAnimation( const shared_ptr
 void PlayerExplodedConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
                                             optional<Coordinate<short>> endPositionChars )
 {
+   if ( !startPositionChars.has_value() )
+   {
+      throw invalid_argument( "Start position must have a value" );
+   }
+
    _isRunning = true;
    _elapsedSeconds = 0;
    _explosionStartFrame = _frameRateProvider->GetCurrentFrame();

--- a/MegaManLofi/PlayerExplodedConsoleAnimation.h
+++ b/MegaManLofi/PlayerExplodedConsoleAnimation.h
@@ -18,7 +18,8 @@ namespace MegaManLofi
                                       const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                                       const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
-      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      void Start( std::optional<Coordinate<short>> startPositionChars,
+                  std::optional<Coordinate<short>> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
       void Tick() override;

--- a/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
@@ -8,8 +8,8 @@ using namespace std;
 using namespace MegaManLofi;
 
 PlayerThwipInConsoleAnimation::PlayerThwipInConsoleAnimation( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                                const shared_ptr<ConsoleRenderConfig> renderConfig,
-                                                                const shared_ptr<IFrameRateProvider> frameRateProvider ) :
+                                                              const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                              const shared_ptr<IFrameRateProvider> frameRateProvider ) :
    _consoleBuffer( consoleBuffer ),
    _renderConfig( renderConfig ),
    _frameRateProvider( frameRateProvider ),
@@ -23,13 +23,14 @@ PlayerThwipInConsoleAnimation::PlayerThwipInConsoleAnimation( const shared_ptr<I
 {
 }
 
-void PlayerThwipInConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+void PlayerThwipInConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
+                                           optional<Coordinate<short>> endPositionChars )
 {
    _isRunning = true;
-   _startPositionChars = startPositionChars;
-   _endPositionChars = endPositionChars;
-   _currentTopPositionUnits = startPositionChars.Top * _renderConfig->ArenaCharHeight;
-   _endTopPositionUnits = endPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _startPositionChars = startPositionChars.value();
+   _endPositionChars = endPositionChars.value();
+   _currentTopPositionUnits = _startPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _endTopPositionUnits = _endPositionChars.Top * _renderConfig->ArenaCharHeight;
    _postThwipping = false;
    _elapsedSeconds = 0;
 

--- a/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipInConsoleAnimation.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "PlayerThwipInConsoleAnimation.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderConfig.h"
@@ -26,6 +28,15 @@ PlayerThwipInConsoleAnimation::PlayerThwipInConsoleAnimation( const shared_ptr<I
 void PlayerThwipInConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
                                            optional<Coordinate<short>> endPositionChars )
 {
+   if ( !startPositionChars.has_value() )
+   {
+      throw invalid_argument( "Start position must have a value" );
+   }
+   else if ( !endPositionChars.has_value() )
+   {
+      throw invalid_argument( "End position must have a value" );
+   }
+
    _isRunning = true;
    _startPositionChars = startPositionChars.value();
    _endPositionChars = endPositionChars.value();

--- a/MegaManLofi/PlayerThwipInConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipInConsoleAnimation.h
@@ -17,7 +17,8 @@ namespace MegaManLofi
                                      const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                      const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
-      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      void Start( std::optional<Coordinate<short>> startPositionChars,
+                  std::optional<Coordinate<short>> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
       void Tick() override;

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "PlayerThwipOutConsoleAnimation.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderConfig.h"
@@ -27,6 +29,15 @@ PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr
 void PlayerThwipOutConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
                                             optional<Coordinate<short>> endPositionChars )
 {
+   if ( !startPositionChars.has_value() )
+   {
+      throw invalid_argument( "Start position must have a value" );
+   }
+   else if ( !endPositionChars.has_value() )
+   {
+      throw invalid_argument( "End position must have a value" );
+   }
+
    _isRunning = true;
    _startPositionChars = startPositionChars.value();
    _endPositionChars = endPositionChars.value();

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.cpp
@@ -24,13 +24,14 @@ PlayerThwipOutConsoleAnimation::PlayerThwipOutConsoleAnimation( const shared_ptr
 {
 }
 
-void PlayerThwipOutConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+void PlayerThwipOutConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
+                                            optional<Coordinate<short>> endPositionChars )
 {
    _isRunning = true;
-   _startPositionChars = startPositionChars;
-   _endPositionChars = endPositionChars;
-   _currentTopPositionUnits = startPositionChars.Top * _renderConfig->ArenaCharHeight;
-   _endTopPositionUnits = endPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _startPositionChars = startPositionChars.value();
+   _endPositionChars = endPositionChars.value();
+   _currentTopPositionUnits = _startPositionChars.Top * _renderConfig->ArenaCharHeight;
+   _endTopPositionUnits = _endPositionChars.Top * _renderConfig->ArenaCharHeight;
    _preThwipping = true;
    _postThwipping = false;
    _elapsedSeconds = 0;

--- a/MegaManLofi/PlayerThwipOutConsoleAnimation.h
+++ b/MegaManLofi/PlayerThwipOutConsoleAnimation.h
@@ -17,7 +17,8 @@ namespace MegaManLofi
                                       const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                       const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
-      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      void Start( std::optional<Coordinate<short>> startPositionChars,
+                  std::optional<Coordinate<short>> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
       void Tick() override;

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -91,9 +91,9 @@ bool PlayingStateConsoleRenderer::HasFocus() const
 void PlayingStateConsoleRenderer::HandleStageStartedEvent()
 {
    UpdateCaches();
-   Coordinate<short> location = { _viewportOffsetChars.Left + _viewportRectChars.Width / 2,
+   Coordinate<short> position = { _viewportOffsetChars.Left + _viewportRectChars.Width / 2,
                                   _viewportOffsetChars.Top + _viewportRectChars.Height / 2 };
-   _animationProvider->GetAnimation( ConsoleAnimationType::StageStarted )->Start( location, location );
+   _animationProvider->GetAnimation( ConsoleAnimationType::StageStarted )->Start( position, nullopt );
 }
 
 void PlayingStateConsoleRenderer::HandlePitfallEvent()
@@ -107,8 +107,9 @@ void PlayingStateConsoleRenderer::HandleTileDeathEvent()
    const auto& hitBox = _playerInfoProvider->GetHitBox();
    auto particleStartLeftChars = _playerViewportChars.Left + (short)( hitBox.Width / 2 / _renderConfig->ArenaCharWidth ) + _viewportOffsetChars.Left;
    auto particleStartTopChars = _playerViewportChars.Top + (short)( hitBox.Height / 2 / _renderConfig->ArenaCharHeight ) + _viewportOffsetChars.Top;
+   Coordinate<short> startPosition = { (short)particleStartLeftChars, (short)particleStartTopChars };
 
-   _animationProvider->GetAnimation( ConsoleAnimationType::PlayerExploded )->Start( { (short)particleStartLeftChars, (short)particleStartTopChars }, { 0, 0 } );
+   _animationProvider->GetAnimation( ConsoleAnimationType::PlayerExploded )->Start( startPosition, nullopt );
 }
 
 void PlayingStateConsoleRenderer::UpdateCaches()

--- a/MegaManLofi/StageStartedConsoleAnimation.cpp
+++ b/MegaManLofi/StageStartedConsoleAnimation.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "StageStartedConsoleAnimation.h"
 #include "IConsoleBuffer.h"
 #include "IFrameRateProvider.h"
@@ -22,6 +24,11 @@ StageStartedConsoleAnimation::StageStartedConsoleAnimation( const shared_ptr<ICo
 void StageStartedConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
                                           optional<Coordinate<short>> endPositionChars )
 {
+   if ( !startPositionChars.has_value() )
+   {
+      throw invalid_argument( "Start position must have a value" );
+   }
+
    _isRunning = true;
    _elapsedSeconds = 0;
    _positionChars = startPositionChars.value();

--- a/MegaManLofi/StageStartedConsoleAnimation.cpp
+++ b/MegaManLofi/StageStartedConsoleAnimation.cpp
@@ -19,11 +19,12 @@ StageStartedConsoleAnimation::StageStartedConsoleAnimation( const shared_ptr<ICo
 {
 }
 
-void StageStartedConsoleAnimation::Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars )
+void StageStartedConsoleAnimation::Start( optional<Coordinate<short>> startPositionChars,
+                                          optional<Coordinate<short>> endPositionChars )
 {
    _isRunning = true;
    _elapsedSeconds = 0;
-   _positionChars = startPositionChars;
+   _positionChars = startPositionChars.value();
 
    _renderConfig->GetReadySprite->Reset();
 }

--- a/MegaManLofi/StageStartedConsoleAnimation.h
+++ b/MegaManLofi/StageStartedConsoleAnimation.h
@@ -17,7 +17,8 @@ namespace MegaManLofi
                                     const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                                     const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
-      void Start( Coordinate<short> startPositionChars, Coordinate<short> endPositionChars ) override;
+      void Start( std::optional<Coordinate<short>> startPositionChars,
+                  std::optional<Coordinate<short>> endPositionChars ) override;
       bool IsRunning() const override { return _isRunning; }
       void Draw() override;
       void Tick() override;

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -123,6 +123,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <AdditionalIncludeDirectories>$(solutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -166,6 +167,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(solutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
@@ -53,6 +53,23 @@ TEST_F( PlayerExplodedConsoleAnimationTests, Constructor_Always_InitializesIsRun
    EXPECT_FALSE( _animation->IsRunning() );
 }
 
+TEST_F( PlayerExplodedConsoleAnimationTests, Start_StartPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( nullopt, nullopt );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "Start position must have a value" );
+}
+
 TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();

--- a/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerExplodedConsoleAnimationTests.cpp
@@ -57,7 +57,7 @@ TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
 
    EXPECT_TRUE( _animation->IsRunning() );
 }
@@ -68,7 +68,7 @@ TEST_F( PlayerExplodedConsoleAnimationTests, Start_Always_ResetsExplosionSprite 
 
    EXPECT_CALL( *_particleSpriteMock, Reset() );
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
 
    EXPECT_TRUE( _animation->IsRunning() );
 }
@@ -85,7 +85,7 @@ TEST_F( PlayerExplodedConsoleAnimationTests, Draw_Always_DrawsAllParticlesInCorr
 
    EXPECT_CALL( *_consoleBufferMock, Draw( 30, 30, static_pointer_cast<IConsoleSprite>( _particleSpriteMock ) ) ).Times( 16 );
 
-   _animation->Start( { 30, 30 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 30, 30 } ), nullopt );
    _animation->Draw();
 
    // horizontal and vertical particles

--- a/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
@@ -58,6 +58,40 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Constructor_Always_InitializesIsRunn
    EXPECT_FALSE( _animation->IsRunning() );
 }
 
+TEST_F( PlayerThwipInConsoleAnimationTests, Start_StartPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( nullopt, Coordinate<short>( { 0, 0 } ) );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "Start position must have a value" );
+}
+
+TEST_F( PlayerThwipInConsoleAnimationTests, Start_EndPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "End position must have a value" );
+}
+
 TEST_F( PlayerThwipInConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();

--- a/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipInConsoleAnimationTests.cpp
@@ -62,7 +62,7 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 0, 0 } ) );
 
    EXPECT_TRUE( _animation->IsRunning() );
 }
@@ -74,13 +74,13 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Start_Always_ResetsSprites )
    EXPECT_CALL( *_transitionSpriteMock, Reset() );
    EXPECT_CALL( *_thwipSpriteMock, Reset() );
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 0, 0 } ) );
 }
 
 TEST_F( PlayerThwipInConsoleAnimationTests, Draw_PostThwipping_DrawsSpriteInEndPosition )
 {
    BuildAnimation();
-   _animation->Start( { 0, 0 }, { 10, 10 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 10, 10 } ) );
 
    for ( int i = 0; i < 10; i++ )
    {
@@ -95,7 +95,7 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Draw_ThwippingDownward_DrawsSpriteIn
 {
    ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
    BuildAnimation();
-   _animation->Start( { 0, 0 }, { 10, 10 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 10, 10 } ) );
 
    EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
    _animation->Draw();
@@ -110,7 +110,7 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Draw_ThwippingUpward_DrawsSpriteInCo
 {
    ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
    BuildAnimation();
-   _animation->Start( { 10, 10 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 10, 10 } ), Coordinate<short>( { 0, 0 } ) );
 
    EXPECT_CALL( *_consoleBufferMock, Draw( 10, 10, static_pointer_cast<IConsoleSprite>( _thwipSpriteMock ) ) );
    _animation->Draw();
@@ -134,7 +134,7 @@ TEST_F( PlayerThwipInConsoleAnimationTests, Tick_NotRunning_DoesNotTickAnySprite
 TEST_F( PlayerThwipInConsoleAnimationTests, Tick_ThwipAnimationHasFinished_StopsRunning )
 {
    BuildAnimation();
-   _animation->Start( { 10, 10 }, { 8, 8 } );
+   _animation->Start( Coordinate<short>( { 10, 10 } ), Coordinate<short>( { 8, 8 } ) );
 
    _animation->Tick(); // thwip sprite moves to 1 char up
    EXPECT_TRUE( _animation->IsRunning() );

--- a/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
@@ -63,7 +63,7 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 0, 0 } ) );
 
    EXPECT_TRUE( _animation->IsRunning() );
 }
@@ -75,13 +75,13 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Start_Always_ResetsSprites )
    EXPECT_CALL( *_transitionSpriteMock, Reset() );
    EXPECT_CALL( *_thwipSpriteMock, Reset() );
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 0, 0 } ) );
 }
 
 TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_PreThwipping_DrawsSpriteInStartPosition )
 {
    BuildAnimation();
-   _animation->Start( { 0, 0 }, { 10, 10 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 10, 10 } ) );
 
    EXPECT_CALL( *_consoleBufferMock, Draw( 0, 0, static_pointer_cast<IConsoleSprite>( _transitionSpriteMock ) ) );
    _animation->Draw();
@@ -97,7 +97,7 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_ThwippingDownward_DrawsSpriteI
 {
    ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
    BuildAnimation();
-   _animation->Start( { 0, 0 }, { 10, 10 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), Coordinate<short>( { 10, 10 } ) );
 
    _animation->Tick(); // should switch from pre-thwipping to thwipping
 
@@ -114,7 +114,7 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Draw_ThwippingUpward_DrawsSpriteInC
 {
    ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
    BuildAnimation();
-   _animation->Start( { 10, 10 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 10, 10 } ), Coordinate<short>( { 0, 0 } ) );
 
    _animation->Tick(); // should switch from pre-thwipping to thwipping
 
@@ -141,7 +141,7 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Tick_ThwipAnimationHasFinished_Stop
 {
    ON_CALL( *_transitionSpriteMock, GetTotalTraversalSeconds() ).WillByDefault( Return( 1 ) );
    BuildAnimation();
-   _animation->Start( { 10, 10 }, { 8, 8 } );
+   _animation->Start( Coordinate<short>( { 10, 10 } ), Coordinate<short>( { 8, 8 } ) );
 
    _animation->Tick(); // should switch from pre-thwipping to thwipping
    EXPECT_TRUE( _animation->IsRunning() );

--- a/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/PlayerThwipOutConsoleAnimationTests.cpp
@@ -59,6 +59,40 @@ TEST_F( PlayerThwipOutConsoleAnimationTests, Constructor_Always_InitializesIsRun
    EXPECT_FALSE( _animation->IsRunning() );
 }
 
+TEST_F( PlayerThwipOutConsoleAnimationTests, Start_StartPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( nullopt, Coordinate<short>( { 0, 0 } ) );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "Start position must have a value" );
+}
+
+TEST_F( PlayerThwipOutConsoleAnimationTests, Start_EndPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "End position must have a value" );
+}
+
 TEST_F( PlayerThwipOutConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();

--- a/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
@@ -54,7 +54,7 @@ TEST_F( StageStartedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
 
    EXPECT_TRUE( _animation->IsRunning() );
 }
@@ -65,13 +65,13 @@ TEST_F( StageStartedConsoleAnimationTests, Start_Always_ResetsGetReadySprite )
 
    EXPECT_CALL( *_getReadySpriteMock, Reset() );
 
-   _animation->Start( { 0, 0 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 0, 0 } ), nullopt );
 }
 
 TEST_F( StageStartedConsoleAnimationTests, Draw_Always_DrawsStartPosition )
 {
    BuildAnimation();
-   _animation->Start( { 1, 2 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 1, 2 } ), nullopt );
 
    EXPECT_CALL( *_consoleBufferMock, Draw( 1, 2, static_pointer_cast<IConsoleSprite>( _getReadySpriteMock ) ) );
    _animation->Tick();
@@ -91,7 +91,7 @@ TEST_F( StageStartedConsoleAnimationTests, Tick_IsNotRunning_DoesNotTickGetReady
 TEST_F( StageStartedConsoleAnimationTests, Tick_IsRunning_TicksGetReadySprite )
 {
    BuildAnimation();
-   _animation->Start( { 1, 2 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 1, 2 } ), nullopt );
 
    EXPECT_CALL( *_getReadySpriteMock, Tick() );
 
@@ -102,7 +102,7 @@ TEST_F( StageStartedConsoleAnimationTests, Tick_FinishedRunning_SetsIsRunningToF
 {
    _renderConfig->GetReadyAnimationSeconds = 2;
    BuildAnimation();
-   _animation->Start( { 1, 2 }, { 0, 0 } );
+   _animation->Start( Coordinate<short>( { 1, 2 } ), nullopt );
 
    _animation->Tick(); // 1 second has passed, still running
    EXPECT_TRUE( _animation->IsRunning() );

--- a/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
+++ b/MegaManLofiTests/StageStartedConsoleAnimationTests.cpp
@@ -50,6 +50,23 @@ TEST_F( StageStartedConsoleAnimationTests, Constructor_Always_InitializesIsRunni
    EXPECT_FALSE( _animation->IsRunning() );
 }
 
+TEST_F( StageStartedConsoleAnimationTests, Start_StartPositionHasNoValue_ThrowsException )
+{
+   BuildAnimation();
+
+   string message = "";
+   try
+   {
+      _animation->Start( nullopt, Coordinate<short>( { 0, 0 } ) );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "Start position must have a value" );
+}
+
 TEST_F( StageStartedConsoleAnimationTests, Start_Always_SetsIsRunningToTrue )
 {
    BuildAnimation();

--- a/MegaManLofiTests/mock_ConsoleAnimation.h
+++ b/MegaManLofiTests/mock_ConsoleAnimation.h
@@ -7,7 +7,7 @@
 class mock_ConsoleAnimation : public MegaManLofi::IConsoleAnimation
 {
 public:
-   MOCK_METHOD( void, Start, ( MegaManLofi::Coordinate<short>, MegaManLofi::Coordinate<short> ), ( override ) );
+   MOCK_METHOD( void, Start, ( std::optional<MegaManLofi::Coordinate<short>>, std::optional<MegaManLofi::Coordinate<short>> ), ( override ) );
    MOCK_METHOD( bool, IsRunning, ( ), ( const, override ) );
    MOCK_METHOD( void, Draw, ( ), ( override ) );
    MOCK_METHOD( void, Tick, ( ), ( override ) );


### PR DESCRIPTION
Two out of four animations don't even use end positions, so I made both start and end positions into `std::optional`. In the case where the animation NEEDS a position and doesn't get one, an exception is thrown.

(this involved updating the test project to C++ 17 for the use of `nullopt`, but not C++ 20 because everything exploded when I tried that)