### PR TITLE
Added Active Region property to Arena

### DIFF
--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -29,6 +29,9 @@ namespace MegaManLofi
       int GetHorizontalTiles() const override { return _horizontalTiles; }
       int GetVerticalTiles() const override { return _verticalTiles; }
 
+      const Quad<long long>& GetActiveRegion() const override { return _activeRegion; }
+      void SetActiveRegion( Quad<long long> region ) override { _activeRegion = region; }
+
       const ArenaTile& GetTile( long long index ) const override { return _tiles[index]; }
 
    private:
@@ -49,5 +52,7 @@ namespace MegaManLofi
 
       int _horizontalTiles;
       int _verticalTiles;
+
+      Quad<long long> _activeRegion;
    };
 }

--- a/MegaManLofi/ArenaDefs.h
+++ b/MegaManLofi/ArenaDefs.h
@@ -16,6 +16,9 @@ namespace MegaManLofi
       int DefaultHorizontalTiles = 0;
       int DefaultVerticalTiles = 0;
 
+      long long ActiveRegionWidth = 0;
+      long long ActiveRegionHeight = 0;
+
       std::vector<ArenaTile> DefaultTiles;
 
       Coordinate<long long> DefaultPlayerPosition = { 0, 0 };

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -18,6 +18,10 @@ shared_ptr<ArenaDefs> ArenaDefsGenerator::GenerateArenaDefs()
 
    arenaDefs->DefaultTiles = ArenaTileGenerator::GenerateArenaTiles();
 
+   // this conveniently matches the console viewport size
+   arenaDefs->ActiveRegionWidth = 120 * arenaDefs->DefaultTileWidth;
+   arenaDefs->ActiveRegionHeight = 30 * arenaDefs->DefaultTileHeight;
+
    arenaDefs->DefaultPlayerPosition = { arenaDefs->DefaultTileWidth * 8, arenaDefs->DefaultTileHeight * 6 };
 
    return arenaDefs;

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -2,6 +2,7 @@
 #include "IFrameRateProvider.h"
 #include "IFrameActionRegistry.h"
 #include "IGameEventAggregator.h"
+#include "ArenaDefs.h"
 #include "IPlayer.h"
 #include "IArena.h"
 #include "FrameAction.h"
@@ -12,10 +13,12 @@ using namespace MegaManLofi;
 
 ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
                             const shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                            const shared_ptr<IGameEventAggregator> eventAggregator ) :
+                            const shared_ptr<IGameEventAggregator> eventAggregator,
+                            const shared_ptr<ArenaDefs> arenaDefs ) :
    _frameRateProvider( frameRateProvider ),
    _frameActionRegistry( frameActionRegistry ),
    _eventAggregator( eventAggregator ),
+   _arenaDefs( arenaDefs ),
    _arena( nullptr )
 {
 }
@@ -47,6 +50,7 @@ void ArenaPhysics::MovePlayer()
    }
 
    UpdatePlayerOccupyingTileIndices();
+   UpdateActiveRegion();
 
    if ( !DetectTileDeath() )
    {
@@ -238,6 +242,15 @@ bool ArenaPhysics::DetectTileDeath() const
    }
 
    return false;
+}
+
+void ArenaPhysics::UpdateActiveRegion()
+{
+   const auto& playerPosition = _arena->GetPlayer()->GetArenaPosition();
+   auto regionLeft = playerPosition.Left - ( _arenaDefs->ActiveRegionWidth / 2 );
+   auto regionTop = playerPosition.Top - ( _arenaDefs->ActiveRegionHeight / 2 );
+
+   _arena->SetActiveRegion( { regionLeft, regionTop, regionLeft + _arenaDefs->ActiveRegionWidth, regionTop + _arenaDefs->ActiveRegionHeight } );
 }
 
 void ArenaPhysics::DetectPlayerStanding()

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -8,13 +8,15 @@ namespace MegaManLofi
    class IFrameRateProvider;
    class IFrameActionRegistry;
    class IGameEventAggregator;
+   class ArenaDefs;
 
    class ArenaPhysics : public IArenaPhysics
    {
    public:
       ArenaPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                     const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
-                    const std::shared_ptr<IGameEventAggregator> eventAggregator );
+                    const std::shared_ptr<IGameEventAggregator> eventAggregator,
+                    const std::shared_ptr<ArenaDefs> arenaDefs );
 
       void AssignTo( const std::shared_ptr<IArena> arena ) override;
       void Tick() override;
@@ -27,12 +29,15 @@ namespace MegaManLofi
       void DetectPlayerTileCollisionX( long long& newPositionLeft );
       void DetectPlayerTileCollisionY( long long& newPositionTop );
       bool DetectTileDeath() const;
+      void UpdateActiveRegion();
       void DetectPlayerStanding();
 
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
+      const std::shared_ptr<ArenaDefs> _arenaDefs;
+
       std::shared_ptr<IArena> _arena;
 
       Quad<long long> _playerOccupyingTileIndices;

--- a/MegaManLofi/IArena.h
+++ b/MegaManLofi/IArena.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "IReadOnlyArena.h"
+#include "Quad.h"
 
 namespace MegaManLofi
 {
@@ -15,5 +16,8 @@ namespace MegaManLofi
 
       virtual const std::shared_ptr<IPlayer> GetPlayer() const = 0;
       virtual void SetPlayer( const std::shared_ptr<IPlayer> player ) = 0;
+
+      virtual const Quad<long long>& GetActiveRegion() const = 0;
+      virtual void SetActiveRegion( Quad<long long> region ) = 0;
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -128,7 +128,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // utilities
    auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, gameDefs->PlayerPhysicsDefs ) );
-   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry, eventAggregator ) );
+   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry, eventAggregator, gameDefs->ArenaDefs ) );
 
    // game objects
    auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -10,6 +10,8 @@ public:
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::IPlayer>, GetPlayer, ( ), ( const, override ) );
    MOCK_METHOD( void, SetPlayer, ( const std::shared_ptr<MegaManLofi::IPlayer> ), ( override ) );
+   MOCK_METHOD( const MegaManLofi::Quad<long long>&, GetActiveRegion, ( ), ( const, override ) );
+   MOCK_METHOD( void, SetActiveRegion, ( MegaManLofi::Quad<long long> ), ( override ) );
    MOCK_METHOD( long long, GetWidth, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetHeight, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetTileWidth, ( ), ( const, override ) );


### PR DESCRIPTION
Another thing Alex had brought up before is how useful an "active region" could be for spawning enemies in an Arena. The idea is you'll be scrolling along, and once a spawn point enters the active region, an enemy appears at that point.

I set it up so the active region exactly matches the viewport, but it doesn't have to. 