### PR TITLE
Fix jumping physics

### DIFF
--- a/MegaManLofi/PlayerPhysics.h
+++ b/MegaManLofi/PlayerPhysics.h
@@ -34,6 +34,5 @@ namespace MegaManLofi
       std::shared_ptr<IPlayer> _player;
 
       long long _lastExtendJumpFrame;
-      double _elapsedJumpExtensionSeconds;
    };
 }

--- a/MegaManLofi/PlayerPhysicsDefsGenerator.cpp
+++ b/MegaManLofi/PlayerPhysicsDefsGenerator.cpp
@@ -13,7 +13,7 @@ shared_ptr<PlayerPhysicsDefs> PlayerPhysicsDefsGenerator::GeneratePlayerPhysicsD
 
    playerPhysicsDefs->PushAccelerationPerSecond = 8'500'000;
    playerPhysicsDefs->FrictionDecelerationPerSecond = 10'000'000;
-   playerPhysicsDefs->JumpAccelerationPerSecond = 2'000'000;
+   playerPhysicsDefs->JumpAccelerationPerSecond = 4'000'000;
    playerPhysicsDefs->GravityAccelerationPerSecond = 10'000'000;
 
    playerPhysicsDefs->MaxJumpExtensionSeconds = 0.25;


### PR DESCRIPTION
Maybe I didn't "completely" fix jumping physics, but it's much better now. This is actually really simple, as long as you're holding down the jump button then normal gravity applies to the player. But as soon as you let go, the player's Y-velocity becomes zero.

Unfortunately this means if the player's y-velocity becomes negative somehow by NOT jumping, then it'll snap to zero on the next frame. I guess we'll have to deal with that if it ever becomes a problem.