### PR TITLE
Entity Sprites should have an instance of an entity

### DIFF
--- a/MegaManLofi/DiagnosticsConsoleRenderer.cpp
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.cpp
@@ -4,6 +4,9 @@
 #include "IConsoleBuffer.h"
 #include "IGameClock.h"
 #include "ConsoleRenderDefs.h"
+#include "IArenaInfoProvider.h"
+#include "IEntityConsoleSpriteRepository.h"
+#include "IReadOnlyArena.h"
 #include "ConsoleColor.h"
 
 #define DIAGNOSTICS_WIDTH 35
@@ -13,10 +16,14 @@ using namespace MegaManLofi;
 
 DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                         const shared_ptr<IGameClock> clock,
-                                                        const shared_ptr<ConsoleRenderDefs> renderDefs ) :
+                                                        const shared_ptr<ConsoleRenderDefs> renderDefs,
+                                                        const shared_ptr<IArenaInfoProvider> arenaInfoProvider,
+                                                        const shared_ptr<IEntityConsoleSpriteRepository> spriteRepository ) :
    _consoleBuffer( consoleBuffer ),
    _clock( clock ),
-   _renderDefs( renderDefs )
+   _renderDefs( renderDefs ),
+   _arenaInfoProvider( arenaInfoProvider ),
+   _spriteRepository( spriteRepository )
 {
 }
 
@@ -27,12 +34,18 @@ void DiagnosticsConsoleRenderer::Render()
    auto elapsedSecondsString = format( " Elapsed Seconds:    {0} ", _clock->GetElapsedNanoseconds() / 1'000'000'000 );
    auto totalFramesString = format( " Total frames:       {0} ", _clock->GetCurrentFrame() );
    auto framesPerSecondString = format( " Average frame rate: {0} ", _clock->GetAverageFrameRate() );
+   auto arenaEntitiesString = format( " Arena entities:     {0} ", _arenaInfoProvider->GetArena()->GetEntityCount() );
+   auto activeSpritesString = format( " Active sprites:     {0} ", _spriteRepository->GetSpriteCount() );
 
    while ( elapsedSecondsString.length() < DIAGNOSTICS_WIDTH ) { elapsedSecondsString += ' '; }
    while ( totalFramesString.length() < DIAGNOSTICS_WIDTH ) { totalFramesString += ' '; }
    while ( framesPerSecondString.length() < DIAGNOSTICS_WIDTH ) { framesPerSecondString += ' '; }
+   while ( arenaEntitiesString.length() < DIAGNOSTICS_WIDTH ) { arenaEntitiesString += ' '; }
+   while ( activeSpritesString.length() < DIAGNOSTICS_WIDTH ) { activeSpritesString += ' '; }
 
    _consoleBuffer->Draw( left, 0, elapsedSecondsString, ConsoleColor::DarkGrey, ConsoleColor::Black );
    _consoleBuffer->Draw( left, 1, totalFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
    _consoleBuffer->Draw( left, 2, framesPerSecondString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   _consoleBuffer->Draw( left, 3, arenaEntitiesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   _consoleBuffer->Draw( left, 4, activeSpritesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
 }

--- a/MegaManLofi/DiagnosticsConsoleRenderer.h
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.h
@@ -9,13 +9,17 @@ namespace MegaManLofi
    class IConsoleBuffer;
    class IGameClock;
    class ConsoleRenderDefs;
+   class IArenaInfoProvider;
+   class IEntityConsoleSpriteRepository;
 
    class DiagnosticsConsoleRenderer : public IGameRenderer
    {
    public:
       DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                   const std::shared_ptr<IGameClock> clock,
-                                  const std::shared_ptr<ConsoleRenderDefs> renderDefs );
+                                  const std::shared_ptr<ConsoleRenderDefs> renderDefs,
+                                  const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
+                                  const std::shared_ptr<IEntityConsoleSpriteRepository> spriteRepository );
 
       void Render() override;
       bool HasFocus() const override { return false; }
@@ -24,5 +28,7 @@ namespace MegaManLofi
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
       const std::shared_ptr<IGameClock> _clock;
       const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
+      const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
+      const std::shared_ptr<IEntityConsoleSpriteRepository> _spriteRepository;
    };
 }

--- a/MegaManLofi/EntityConsoleSprite.cpp
+++ b/MegaManLofi/EntityConsoleSprite.cpp
@@ -1,18 +1,17 @@
 #include "EntityConsoleSprite.h"
 #include "ConsoleSprite.h"
+#include "IReadOnlyEntity.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
 EntityConsoleSprite::EntityConsoleSprite() :
-   _currentMovementType( (MovementType)0 ),
-   _currentDirection( (Direction)0 )
+   _entity( nullptr )
 {
 }
 
 EntityConsoleSprite::EntityConsoleSprite( EntityConsoleSprite& ecs ) :
-   _currentMovementType( ecs._currentMovementType ),
-   _currentDirection( ecs._currentDirection )
+   _entity( ecs._entity )
 {
    for ( auto [movementType, directionSpriteMap] : ecs._movementSpriteMaps )
    {
@@ -24,6 +23,12 @@ EntityConsoleSprite::EntityConsoleSprite( EntityConsoleSprite& ecs ) :
    }
 }
 
+void EntityConsoleSprite::AssignTo( const shared_ptr<IReadOnlyEntity> entity )
+{
+   _entity = entity;
+   Reset();
+}
+
 void EntityConsoleSprite::AddSprite( MovementType movementType,
                                      Direction direction,
                                      const std::shared_ptr<IConsoleSprite> sprite )
@@ -33,7 +38,7 @@ void EntityConsoleSprite::AddSprite( MovementType movementType,
 
 void EntityConsoleSprite::Tick()
 {
-   _movementSpriteMaps[_currentMovementType][_currentDirection]->Tick();
+   _movementSpriteMaps[_entity->GetMovementType()][_entity->GetDirection()]->Tick();
 }
 
 void EntityConsoleSprite::Reset()
@@ -49,20 +54,20 @@ void EntityConsoleSprite::Reset()
 
 short EntityConsoleSprite::GetWidth() const
 {
-   return _movementSpriteMaps.at( _currentMovementType ).at( _currentDirection )->GetWidth();
+   return _movementSpriteMaps.at( _entity->GetMovementType() ).at( _entity->GetDirection() )->GetWidth();
 }
 
 short EntityConsoleSprite::GetHeight() const
 {
-   return _movementSpriteMaps.at( _currentMovementType ).at( _currentDirection )->GetHeight();
+   return _movementSpriteMaps.at( _entity->GetMovementType() ).at( _entity->GetDirection() )->GetHeight();
 }
 
 double EntityConsoleSprite::GetTotalTraversalSeconds() const
 {
-   return _movementSpriteMaps.at( _currentMovementType ).at( _currentDirection )->GetTotalTraversalSeconds();
+   return _movementSpriteMaps.at( _entity->GetMovementType() ).at( _entity->GetDirection() )->GetTotalTraversalSeconds();
 }
 
 const ConsoleImage& EntityConsoleSprite::GetCurrentImage() const
 {
-   return _movementSpriteMaps.at( _currentMovementType ).at( _currentDirection )->GetCurrentImage();
+   return _movementSpriteMaps.at( _entity->GetMovementType() ).at( _entity->GetDirection() )->GetCurrentImage();
 }

--- a/MegaManLofi/EntityConsoleSprite.h
+++ b/MegaManLofi/EntityConsoleSprite.h
@@ -12,6 +12,7 @@ namespace MegaManLofi
       EntityConsoleSprite();
       EntityConsoleSprite( EntityConsoleSprite& ecs );
 
+      void AssignTo( const std::shared_ptr<IReadOnlyEntity> entity ) override;
       void AddSprite( MovementType movementType,
                       Direction direction,
                       const std::shared_ptr<IConsoleSprite> sprite ) override;
@@ -23,13 +24,9 @@ namespace MegaManLofi
       double GetTotalTraversalSeconds() const override;
       const ConsoleImage& GetCurrentImage() const override;
 
-      void SetMovementType( MovementType type ) override { _currentMovementType = type; }
-      void SetDirection( Direction direction ) override { _currentDirection = direction; }
-
    private:
       std::map<MovementType, std::map<Direction, std::shared_ptr<IConsoleSprite>>> _movementSpriteMaps;
 
-      MovementType _currentMovementType;
-      Direction _currentDirection;
+      std::shared_ptr<IReadOnlyEntity> _entity;
    };
 }

--- a/MegaManLofi/EntityConsoleSpriteRepository.cpp
+++ b/MegaManLofi/EntityConsoleSpriteRepository.cpp
@@ -6,6 +6,7 @@
 #include "IEntityConsoleSpriteCopier.h"
 #include "ConsoleSpriteDefs.h"
 #include "IReadOnlyEntity.h"
+#include "IEntityConsoleSprite.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -38,7 +39,10 @@ void EntityConsoleSpriteRepository::HandleEntitySpawned()
       if ( _spriteMap.count( uniqueId ) == 0 )
       {
          auto sprite = _spriteDefs->EntitySpriteMap[entity->GetEntityMetaId()];
-         _spriteMap[uniqueId] = _spriteCopier->MakeCopy( sprite );
+         auto spriteCopy = _spriteCopier->MakeCopy( sprite );
+         spriteCopy->AssignTo( entity );
+
+         _spriteMap[uniqueId] = spriteCopy;
       }
    }
 }

--- a/MegaManLofi/EntityConsoleSpriteRepository.h
+++ b/MegaManLofi/EntityConsoleSpriteRepository.h
@@ -20,6 +20,7 @@ namespace MegaManLofi
                                      const std::shared_ptr<ConsoleSpriteDefs> spriteDefs );
 
       const std::shared_ptr<IEntityConsoleSprite> GetSprite( int uniqueId ) const override;
+      int GetSpriteCount() const override { return (int)_spriteMap.size(); }
 
    private:
       void HandleEntitySpawned();

--- a/MegaManLofi/IEntityConsoleSprite.h
+++ b/MegaManLofi/IEntityConsoleSprite.h
@@ -9,10 +9,12 @@
 namespace MegaManLofi
 {
    class IConsoleSprite;
+   class IReadOnlyEntity;
 
    class __declspec( novtable ) IEntityConsoleSprite
    {
    public:
+      virtual void AssignTo( const std::shared_ptr<IReadOnlyEntity> entity );
       virtual void AddSprite( MovementType movementType,
                               Direction direction,
                               const std::shared_ptr<IConsoleSprite> sprite ) = 0;
@@ -23,8 +25,5 @@ namespace MegaManLofi
       virtual short GetHeight() const = 0;
       virtual double GetTotalTraversalSeconds() const = 0;
       virtual const ConsoleImage& GetCurrentImage() const = 0;
-
-      virtual void SetMovementType( MovementType type ) = 0;
-      virtual void SetDirection( Direction direction ) = 0;
    };
 }

--- a/MegaManLofi/IEntityConsoleSpriteRepository.h
+++ b/MegaManLofi/IEntityConsoleSpriteRepository.h
@@ -10,5 +10,6 @@ namespace MegaManLofi
    {
    public:
       virtual const std::shared_ptr<IEntityConsoleSprite> GetSprite( int uniqueId ) const = 0;
+      virtual int GetSpriteCount() const = 0;
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -148,7 +148,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, arena, spriteCopier, consoleRenderDefs->SpriteDefs ) );
 
    // renderers objects
-   auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs ) );
+   auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs, game, spriteRepository ) );
    auto titleStateConsoleRenderer = shared_ptr<TitleStateConsoleRenderer>( new TitleStateConsoleRenderer( consoleBuffer, random, clock, eventAggregator, consoleRenderDefs, keyboardInputDefs, animationRepository ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderDefs, game, game, game, eventAggregator, clock, animationRepository, spriteRepository ) );
    auto playingMenuStateConsoleRenderer = shared_ptr<PlayingMenuStateConsoleRenderer>( new PlayingMenuStateConsoleRenderer( consoleBuffer, consoleRenderDefs, menuRepository ) );

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -250,8 +250,6 @@ void PlayingStateConsoleRenderer::DrawNonPlayerEntities()
 void PlayingStateConsoleRenderer::DrawEntity( const shared_ptr<IReadOnlyEntity> entity )
 {
    auto sprite = _spriteRepository->GetSprite( entity->GetUniqueId() );
-   sprite->SetDirection( entity->GetDirection() );
-   sprite->SetMovementType( entity->GetMovementType() );
    auto left = (short)( ( entity->GetArenaPositionLeft() - _viewportQuadUnits.Left ) / _renderDefs->ArenaCharWidth ) + _viewportOffsetChars.Left;
    auto top = (short)( ( entity->GetArenaPositionTop() - _viewportQuadUnits.Top ) / _renderDefs->ArenaCharHeight ) + _viewportOffsetChars.Top;
 

--- a/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
+++ b/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
@@ -80,6 +80,7 @@ TEST_F( EntityConsoleSpriteRepositoryTests, EntitySpawned_DoNotAlreadyHaveEntity
    ON_CALL( *_arenaMock, GetEntity( 0 ) ).WillByDefault( Return( _entityMock1 ) );
 
    EXPECT_CALL( *_spriteCopier, MakeCopy( static_pointer_cast<IEntityConsoleSprite>( _spriteMock1 ) ) );
+   EXPECT_CALL( *_spriteCopyMock1, AssignTo( static_pointer_cast<IReadOnlyEntity>( _entityMock1 ) ) );
 
    _eventAggregator->RaiseEvent( GameEvent::ArenaEntitySpawned );
 

--- a/MegaManLofiTests/EntityConsoleSpriteTests.cpp
+++ b/MegaManLofiTests/EntityConsoleSpriteTests.cpp
@@ -5,6 +5,7 @@
 #include <MegaManLofi/EntityConsoleSprite.h>
 
 #include "mock_ConsoleSprite.h"
+#include "mock_ReadOnlyEntity.h"
 
 using namespace std;
 using namespace testing;
@@ -15,12 +16,33 @@ class EntityConsoleSpriteTests : public Test
 public:
    void SetUp() override
    {
+      _entityMock.reset( new NiceMock<mock_ReadOnlyEntity> );
+      
+      ON_CALL( *_entityMock, GetMovementType() ).WillByDefault( Return( MovementType::Standing ) );
+      ON_CALL( *_entityMock, GetDirection() ).WillByDefault( Return( Direction::Left ) );
+
       _entitySprite.reset( new EntityConsoleSprite );
+      _entitySprite->AssignTo( _entityMock );
    }
 
 protected:
+   shared_ptr<mock_ReadOnlyEntity> _entityMock;
+
    shared_ptr<EntityConsoleSprite> _entitySprite;
 };
+
+TEST_F( EntityConsoleSpriteTests, AssignTo_Always_ResetsSprites )
+{
+   auto spriteMock1 = shared_ptr<mock_ConsoleSprite>( new NiceMock<mock_ConsoleSprite> );
+   auto spriteMock2 = shared_ptr<mock_ConsoleSprite>( new NiceMock<mock_ConsoleSprite> );
+   _entitySprite->AddSprite( MovementType::Standing, Direction::Left, spriteMock1 );
+   _entitySprite->AddSprite( MovementType::Walking, Direction::Right, spriteMock2 );
+
+   EXPECT_CALL( *spriteMock1, Reset() );
+   EXPECT_CALL( *spriteMock2, Reset() );
+
+   _entitySprite->AssignTo( _entityMock );
+}
 
 TEST_F( EntityConsoleSpriteTests, Tick_Always_TicksCurrentSprite )
 {
@@ -28,9 +50,6 @@ TEST_F( EntityConsoleSpriteTests, Tick_Always_TicksCurrentSprite )
    auto spriteMock2 = shared_ptr<mock_ConsoleSprite>( new NiceMock<mock_ConsoleSprite> );
    _entitySprite->AddSprite( MovementType::Standing, Direction::Left, spriteMock1 );
    _entitySprite->AddSprite( MovementType::Walking, Direction::Right, spriteMock2 );
-
-   _entitySprite->SetMovementType( MovementType::Standing );
-   _entitySprite->SetDirection( Direction::Left );
 
    EXPECT_CALL( *spriteMock1, Tick() );
 
@@ -62,8 +81,8 @@ TEST_F( EntityConsoleSpriteTests, GetWidth_Always_ReturnsCurrentSpriteWidth )
 
    EXPECT_CALL( *spriteMock2, GetWidth() ).WillOnce( Return( 3 ) );
 
-   _entitySprite->SetMovementType( MovementType::Walking );
-   _entitySprite->SetDirection( Direction::Right );
+   ON_CALL( *_entityMock, GetMovementType() ).WillByDefault( Return( MovementType::Walking ) );
+   ON_CALL( *_entityMock, GetDirection() ).WillByDefault( Return( Direction::Right ) );
 
    EXPECT_EQ( _entitySprite->GetWidth(), 3 );
 }
@@ -76,10 +95,6 @@ TEST_F( EntityConsoleSpriteTests, GetHeight_Always_ReturnsCurrentSpriteHeight )
    _entitySprite->AddSprite( MovementType::Walking, Direction::Right, spriteMock2 );
 
    EXPECT_CALL( *spriteMock1, GetHeight() ).WillOnce( Return( 7 ) );
-
-   _entitySprite->SetMovementType( MovementType::Standing );
-   _entitySprite->SetDirection( Direction::Left );
-
    EXPECT_EQ( _entitySprite->GetHeight(), 7 );
 }
 
@@ -92,8 +107,8 @@ TEST_F( EntityConsoleSpriteTests, GetTotalTraversalSeconds_Always_ReturnsCurrent
 
    EXPECT_CALL( *spriteMock2, GetTotalTraversalSeconds() ).WillOnce( Return( 8.2 ) );
 
-   _entitySprite->SetMovementType( MovementType::Walking );
-   _entitySprite->SetDirection( Direction::Right );
+   ON_CALL( *_entityMock, GetMovementType() ).WillByDefault( Return( MovementType::Walking ) );
+   ON_CALL( *_entityMock, GetDirection() ).WillByDefault( Return( Direction::Right ) );
 
    EXPECT_EQ( _entitySprite->GetTotalTraversalSeconds(), 8.2 );
 }
@@ -108,9 +123,5 @@ TEST_F( EntityConsoleSpriteTests, GetCurrentImage_Always_ReturnsCurrentSpriteCur
    image.Width = 1000;
 
    EXPECT_CALL( *spriteMock1, GetCurrentImage() ).WillOnce( ReturnRef( image ) );
-
-   _entitySprite->SetMovementType( MovementType::Standing );
-   _entitySprite->SetDirection( Direction::Left );
-
    EXPECT_EQ( _entitySprite->GetCurrentImage().Width, 1000 );
 }

--- a/MegaManLofiTests/mock_EntityConsoleSprite.h
+++ b/MegaManLofiTests/mock_EntityConsoleSprite.h
@@ -7,6 +7,7 @@
 class mock_EntityConsoleSprite : public MegaManLofi::IEntityConsoleSprite
 {
 public:
+   MOCK_METHOD( void, AssignTo, ( const std::shared_ptr<MegaManLofi::IReadOnlyEntity> ), ( override ) );
    MOCK_METHOD( void, AddSprite, ( MegaManLofi::MovementType, MegaManLofi::Direction, const std::shared_ptr<MegaManLofi::IConsoleSprite> ), ( override ) );
    MOCK_METHOD( void, Tick, ( ), ( override ) );
    MOCK_METHOD( void, Reset, ( ), ( override ) );
@@ -14,6 +15,4 @@ public:
    MOCK_METHOD( short, GetHeight, ( ), ( const, override ) );
    MOCK_METHOD( double, GetTotalTraversalSeconds, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::ConsoleImage&, GetCurrentImage, ( ), ( const, override ) );
-   MOCK_METHOD( void, SetMovementType, ( MegaManLofi::MovementType ), ( override ) );
-   MOCK_METHOD( void, SetDirection, ( MegaManLofi::Direction ), ( override ) );
 };

--- a/MegaManLofiTests/mock_EntityConsoleSpriteRepository.h
+++ b/MegaManLofiTests/mock_EntityConsoleSpriteRepository.h
@@ -8,4 +8,5 @@ class mock_EntityConsoleSpriteRepository : public MegaManLofi::IEntityConsoleSpr
 {
 public:
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::IEntityConsoleSprite>, GetSprite, ( int ), ( const, override ) );
+   MOCK_METHOD( int, GetSpriteCount, ( ), ( const, override ) );
 };


### PR DESCRIPTION
This makes it a lot easier to tell which direction/movement the sprite should have.

BONUS: I added the total entity count for the arena and the total "active" entity sprite count to the diagnostics renderer, and it seems we're not actually removing sprites. Maybe I should've finished the unit tests for the sprites repository..... anyway, fix is incoming.

LESS OF A BONUS: I also found a crash bug with pitfalls. Not totally sure what's going on there yet, but will look into it further.