### PR TITLE
Bugfix: De-spawn sprites is broken

### DIFF
--- a/MegaManLofi/EntityConsoleSpriteRepository.cpp
+++ b/MegaManLofi/EntityConsoleSpriteRepository.cpp
@@ -20,7 +20,7 @@ EntityConsoleSpriteRepository::EntityConsoleSpriteRepository( const shared_ptr<I
    _spriteDefs( spriteDefs )
 {
    eventAggregator->RegisterEventHandler( GameEvent::ArenaEntitySpawned, std::bind( &EntityConsoleSpriteRepository::HandleEntitySpawned, this ) );
-   eventAggregator->RegisterEventHandler( GameEvent::ArenaEntityDeSpawned, std::bind( &EntityConsoleSpriteRepository::HandleEntitySpawned, this ) );
+   eventAggregator->RegisterEventHandler( GameEvent::ArenaEntityDeSpawned, std::bind( &EntityConsoleSpriteRepository::HandleEntityDeSpawned, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::ArenaEntitiesCleared, std::bind( &EntityConsoleSpriteRepository::HandleEntitiesCleared, this ) );
 }
 


### PR DESCRIPTION
I blame this on being lazy with unit tests. I accidentally bound the "entity de-spawned" event to the "entity spawned" handler. Whoops!