### PR TITLE
Light cleanup in ArenaPhysics

### DIFF
--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -1,6 +1,5 @@
 #include "ArenaPhysics.h"
 #include "IFrameRateProvider.h"
-#include "IFrameActionRegistry.h"
 #include "IGameEventAggregator.h"
 #include "ArenaDefs.h"
 #include "IPlayer.h"
@@ -12,11 +11,9 @@ using namespace std;
 using namespace MegaManLofi;
 
 ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
-                            const shared_ptr<IFrameActionRegistry> frameActionRegistry,
                             const shared_ptr<IGameEventAggregator> eventAggregator,
                             const shared_ptr<ArenaDefs> arenaDefs ) :
    _frameRateProvider( frameRateProvider ),
-   _frameActionRegistry( frameActionRegistry ),
    _eventAggregator( eventAggregator ),
    _arenaDefs( arenaDefs ),
    _arena( nullptr )

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -79,27 +79,12 @@ void ArenaPhysics::MoveEntities()
 
 void ArenaPhysics::MoveEntity( const shared_ptr<IEntity> entity )
 {
-   auto currentPositionLeft = entity->GetArenaPositionLeft();
-   auto currentPositionTop = entity->GetArenaPositionTop();
-   auto newPositionLeft = (long long)( currentPositionLeft + ( entity->GetVelocityX() * _frameRateProvider->GetFrameSeconds() ) );
-   auto newPositionTop = (long long)( currentPositionTop + ( entity->GetVelocityY() * _frameRateProvider->GetFrameSeconds() ) );
+   auto newPositionLeft = (long long)( entity->GetArenaPositionLeft() + ( entity->GetVelocityX() * _frameRateProvider->GetFrameSeconds() ) );
+   auto newPositionTop = (long long)( entity->GetArenaPositionTop() + ( entity->GetVelocityY() * _frameRateProvider->GetFrameSeconds() ) );
    DetectEntityTileCollisionX( entity, newPositionLeft );
    DetectEntityTileCollisionY( entity, newPositionTop );
 
    entity->SetArenaPosition( { newPositionLeft, newPositionTop } );
-
-   auto player = _arena->GetMutablePlayer();
-   if ( entity == player )
-   {
-      if ( currentPositionLeft != newPositionLeft )
-      {
-         _frameActionRegistry->FlagAction( FrameAction::PlayerMovedHorizontal );
-      }
-      if ( currentPositionTop != newPositionTop )
-      {
-         _frameActionRegistry->FlagAction( FrameAction::PlayerMovedVertical );
-      }
-   }
 }
 
 void ArenaPhysics::DetectEntityTileCollisionX( const std::shared_ptr<IEntity> entity, long long& newPositionLeft )

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -24,7 +24,7 @@ namespace MegaManLofi
       void Tick() override;
 
    private:
-      void UpdateEntityOccupyingTileIndices( const std::shared_ptr<IEntity> entity );
+      void UpdateEntityTileIndicesCache( const std::shared_ptr<IEntity> entity );
       void MoveEntities();
       void MoveEntity( const std::shared_ptr<IEntity> entity );
       void DetectEntityTileCollisionX( const std::shared_ptr<IEntity> entity, long long& newPositionLeft );
@@ -42,6 +42,6 @@ namespace MegaManLofi
 
       std::shared_ptr<IArena> _arena;
 
-      std::map<std::shared_ptr<IEntity>, Quad<long long>> _entityOccupyingTileIndicesMap;
+      std::map<std::shared_ptr<IEntity>, Quad<long long>> _entityTileIndicesCache;
    };
 }

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -9,7 +9,6 @@
 namespace MegaManLofi
 {
    class IFrameRateProvider;
-   class IFrameActionRegistry;
    class IGameEventAggregator;
    class ArenaDefs;
    class IEntity;
@@ -18,7 +17,6 @@ namespace MegaManLofi
    {
    public:
       ArenaPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
-                    const std::shared_ptr<IFrameActionRegistry> frameActionRegistry,
                     const std::shared_ptr<IGameEventAggregator> eventAggregator,
                     const std::shared_ptr<ArenaDefs> arenaDefs );
 
@@ -39,7 +37,6 @@ namespace MegaManLofi
 
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
-      const std::shared_ptr<IFrameActionRegistry> _frameActionRegistry;
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<ArenaDefs> _arenaDefs;
 

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -43,6 +43,5 @@ namespace MegaManLofi
       std::shared_ptr<IArena> _arena;
 
       std::map<std::shared_ptr<IEntity>, Quad<long long>> _entityOccupyingTileIndicesMap;
-      Quad<long long> _playerOccupyingTileIndices;
    };
 }

--- a/MegaManLofi/FrameAction.h
+++ b/MegaManLofi/FrameAction.h
@@ -5,10 +5,6 @@ namespace MegaManLofi
    enum class FrameAction
    {
       PlayerPushed = 0,
-
-      PlayerMovedHorizontal,
-      PlayerMovedVertical,
-
       PlayerJumping,
 
       FrameActionCount

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -108,7 +108,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // utilities
    auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, gameDefs->PlayerPhysicsDefs ) );
-   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, frameActionRegistry, eventAggregator, gameDefs->ArenaDefs ) );
+   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, eventAggregator, gameDefs->ArenaDefs ) );
 
    // game objects
    auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -80,16 +80,6 @@ protected:
    shared_ptr<ArenaPhysics> _arenaPhysics;
 };
 
-TEST_F( ArenaPhysicsTests, Tick_PlayerDidNotMove_DoesNotFlagMoveActions )
-{
-   BuildArenaPhysics();
-
-   EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedHorizontal ) ).Times( 0 );
-   EXPECT_CALL( *_frameActionRegistryMock, FlagAction( FrameAction::PlayerMovedVertical ) ).Times( 0 );
-
-   _arenaPhysics->Tick();
-}
-
 // TODO: I'd very much like to refactor ArenaPhysics into smaller parts, and in the
 // meantime it seems like a waste of time to fix these tests.
 

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -9,7 +9,6 @@
 #include <MegaManLofi/GameEvent.h>
 
 #include "mock_FrameRateProvider.h"
-#include "mock_FrameActionRegistry.h"
 #include "mock_GameEventAggregator.h"
 #include "mock_Arena.h"
 #include "mock_Player.h"
@@ -24,7 +23,6 @@ public:
    void SetUp() override
    {
       _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
-      _frameActionRegistryMock.reset( new NiceMock<mock_FrameActionRegistry> );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _arenaDefs.reset( new ArenaDefs() );
       _arenaMock.reset( new NiceMock<mock_Arena> );
@@ -61,13 +59,12 @@ public:
       ON_CALL( *_playerMock, GetArenaPositionTop() ).WillByDefault( Return( _playerArenaPosition.Top ) );
       ON_CALL( *_playerMock, GetHitBox() ).WillByDefault( ReturnRef( _playerHitBox ) );
 
-      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _frameActionRegistryMock, _eventAggregatorMock, _arenaDefs ) );
+      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _eventAggregatorMock, _arenaDefs ) );
       _arenaPhysics->AssignTo( _arenaMock );
    }
 
 protected:
    shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
-   shared_ptr<mock_FrameActionRegistry> _frameActionRegistryMock;
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<ArenaDefs> _arenaDefs;
    shared_ptr<mock_Arena> _arenaMock;


### PR DESCRIPTION
This is a little bit of cleanup and re-naming of some things in `ArenaPhysics`. We're not using the `PlayerMovedHorizontal` or `PlayerMovedHorizontal` frame actions anymore, so they can go, meaning `ArenaPhysics` doesn't need a `FrameActionRegistry` anymore either. Also, "EntityOccupyingTileIndices" is a lot to swallow, so those are now "EntityTileIndicesCache".