### PR TITLE
Fix issues with low frame rate

### DIFF
--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -84,7 +84,7 @@ void ArenaPhysics::MoveEntity( const shared_ptr<IEntity> entity )
    entity->SetArenaPosition( { newPositionLeft, newPositionTop } );
 }
 
-void ArenaPhysics::DetectEntityTileCollisionX( const std::shared_ptr<IEntity> entity, long long& newPositionLeft )
+void ArenaPhysics::DetectEntityTileCollisionX( const shared_ptr<IEntity> entity, long long& newPositionLeft )
 {
    const auto& hitBox = entity->GetHitBox();
    auto currentPositionLeft = entity->GetArenaPositionLeft();

--- a/MegaManLofi/DiagnosticsConsoleRenderer.cpp
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.cpp
@@ -2,7 +2,7 @@
 
 #include "DiagnosticsConsoleRenderer.h"
 #include "IConsoleBuffer.h"
-#include "IGameClock.h"
+#include "IFrameRateProvider.h"
 #include "ConsoleRenderDefs.h"
 #include "IArenaInfoProvider.h"
 #include "IEntityConsoleSpriteRepository.h"
@@ -15,12 +15,12 @@ using namespace std;
 using namespace MegaManLofi;
 
 DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                        const shared_ptr<IGameClock> clock,
+                                                        const shared_ptr<IFrameRateProvider> frameRateProvider,
                                                         const shared_ptr<ConsoleRenderDefs> renderDefs,
                                                         const shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                                         const shared_ptr<IEntityConsoleSpriteRepository> spriteRepository ) :
    _consoleBuffer( consoleBuffer ),
-   _clock( clock ),
+   _frameRateProvider( frameRateProvider ),
    _renderDefs( renderDefs ),
    _arenaInfoProvider( arenaInfoProvider ),
    _spriteRepository( spriteRepository )
@@ -31,11 +31,11 @@ void DiagnosticsConsoleRenderer::Render()
 {
    auto left = _renderDefs->ConsoleWidthChars - DIAGNOSTICS_WIDTH;
 
-   auto elapsedSecondsString = format( " Elapsed seconds:    {0} ", _clock->GetElapsedNanoseconds() / 1'000'000'000 );
-   auto minFrameRateString = format( " Min frame rate:     {0} ", _clock->GetMinimumFrameRate() );
-   auto totalFramesString = format( " Total frames:       {0} ", _clock->GetCurrentFrame() );
-   auto framesPerSecondString = format( " Average frame rate: {0} ", _clock->GetAverageFrameRate() );
-   auto lagFramesString = format( " Lag frames:         {0} ", _clock->GetLagFrameCount() );
+   auto elapsedSecondsString = format( " Elapsed seconds:    {0} ", _frameRateProvider->GetElapsedNanoseconds() / 1'000'000'000 );
+   auto minFrameRateString = format( " Min frame rate:     {0} ", _frameRateProvider->GetMinimumFrameRate() );
+   auto totalFramesString = format( " Total frames:       {0} ", _frameRateProvider->GetCurrentFrame() );
+   auto framesPerSecondString = format( " Average frame rate: {0} ", _frameRateProvider->GetAverageFrameRate() );
+   auto lagFramesString = format( " Lag frames:         {0} ", _frameRateProvider->GetLagFrameCount() );
    auto arenaEntitiesString = format( " Arena entities:     {0} ", _arenaInfoProvider->GetArena()->GetEntityCount() );
    auto activeSpritesString = format( " Active sprites:     {0} ", _spriteRepository->GetSpriteCount() );
 
@@ -50,13 +50,13 @@ void DiagnosticsConsoleRenderer::Render()
    short top = 0;
 
    _consoleBuffer->Draw( left, top++, elapsedSecondsString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   if ( _clock->HasMinimumFrameRate() )
+   if ( _frameRateProvider->HasMinimumFrameRate() )
    {
       _consoleBuffer->Draw( left, top++, minFrameRateString, ConsoleColor::DarkGrey, ConsoleColor::Black );
    }
    _consoleBuffer->Draw( left, top++, totalFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
    _consoleBuffer->Draw( left, top++, framesPerSecondString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   if ( _clock->HasMinimumFrameRate() )
+   if ( _frameRateProvider->HasMinimumFrameRate() )
    {
       _consoleBuffer->Draw( left, top++, lagFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
    }

--- a/MegaManLofi/DiagnosticsConsoleRenderer.cpp
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.cpp
@@ -31,21 +31,35 @@ void DiagnosticsConsoleRenderer::Render()
 {
    auto left = _renderDefs->ConsoleWidthChars - DIAGNOSTICS_WIDTH;
 
-   auto elapsedSecondsString = format( " Elapsed Seconds:    {0} ", _clock->GetElapsedNanoseconds() / 1'000'000'000 );
+   auto elapsedSecondsString = format( " Elapsed seconds:    {0} ", _clock->GetElapsedNanoseconds() / 1'000'000'000 );
+   auto minFrameRateString = format( " Min frame rate:     {0} ", _clock->GetMinimumFrameRate() );
    auto totalFramesString = format( " Total frames:       {0} ", _clock->GetCurrentFrame() );
    auto framesPerSecondString = format( " Average frame rate: {0} ", _clock->GetAverageFrameRate() );
+   auto lagFramesString = format( " Lag frames:         {0} ", _clock->GetLagFrameCount() );
    auto arenaEntitiesString = format( " Arena entities:     {0} ", _arenaInfoProvider->GetArena()->GetEntityCount() );
    auto activeSpritesString = format( " Active sprites:     {0} ", _spriteRepository->GetSpriteCount() );
 
    while ( elapsedSecondsString.length() < DIAGNOSTICS_WIDTH ) { elapsedSecondsString += ' '; }
+   while ( minFrameRateString.length() < DIAGNOSTICS_WIDTH ) { minFrameRateString += ' '; }
    while ( totalFramesString.length() < DIAGNOSTICS_WIDTH ) { totalFramesString += ' '; }
    while ( framesPerSecondString.length() < DIAGNOSTICS_WIDTH ) { framesPerSecondString += ' '; }
+   while ( lagFramesString.length() < DIAGNOSTICS_WIDTH ) { lagFramesString += ' '; }
    while ( arenaEntitiesString.length() < DIAGNOSTICS_WIDTH ) { arenaEntitiesString += ' '; }
    while ( activeSpritesString.length() < DIAGNOSTICS_WIDTH ) { activeSpritesString += ' '; }
 
-   _consoleBuffer->Draw( left, 0, elapsedSecondsString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   _consoleBuffer->Draw( left, 1, totalFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   _consoleBuffer->Draw( left, 2, framesPerSecondString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   _consoleBuffer->Draw( left, 3, arenaEntitiesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
-   _consoleBuffer->Draw( left, 4, activeSpritesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   short top = 0;
+
+   _consoleBuffer->Draw( left, top++, elapsedSecondsString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   if ( _clock->HasMinimumFrameRate() )
+   {
+      _consoleBuffer->Draw( left, top++, minFrameRateString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   }
+   _consoleBuffer->Draw( left, top++, totalFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   _consoleBuffer->Draw( left, top++, framesPerSecondString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   if ( _clock->HasMinimumFrameRate() )
+   {
+      _consoleBuffer->Draw( left, top++, lagFramesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   }
+   _consoleBuffer->Draw( left, top++, arenaEntitiesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
+   _consoleBuffer->Draw( left, top++, activeSpritesString, ConsoleColor::DarkGrey, ConsoleColor::Black );
 }

--- a/MegaManLofi/DiagnosticsConsoleRenderer.h
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.h
@@ -7,7 +7,7 @@
 namespace MegaManLofi
 {
    class IConsoleBuffer;
-   class IGameClock;
+   class IFrameRateProvider;
    class ConsoleRenderDefs;
    class IArenaInfoProvider;
    class IEntityConsoleSpriteRepository;
@@ -16,7 +16,7 @@ namespace MegaManLofi
    {
    public:
       DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
-                                  const std::shared_ptr<IGameClock> clock,
+                                  const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                                   const std::shared_ptr<ConsoleRenderDefs> renderDefs,
                                   const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                   const std::shared_ptr<IEntityConsoleSpriteRepository> spriteRepository );
@@ -26,7 +26,7 @@ namespace MegaManLofi
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
-      const std::shared_ptr<IGameClock> _clock;
+      const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
       const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
       const std::shared_ptr<IEntityConsoleSpriteRepository> _spriteRepository;

--- a/MegaManLofi/GameClock.cpp
+++ b/MegaManLofi/GameClock.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "GameClock.h"
 #include "IHighResolutionClock.h"
 
@@ -6,6 +8,9 @@ using namespace MegaManLofi;
 
 GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock ) :
    _highResolutionClock( highResolutionClock ),
+   _minimumFrameRate( -1 ),
+   _minSecondsPerFrame( -1 ),
+   _hasMinimumFrameRate( false ),
    _totalFrameCount( 0 ),
    _absoluteStartTimeNano( 0 ),
    _frameStartTimeNano( 0 ),
@@ -13,6 +18,26 @@ GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock
    _totalDurationNano( 0 )
 {
    _absoluteStartTimeNano = _highResolutionClock->Now();
+}
+
+void GameClock::SetMinimumFrameRate( long long frameRate )
+{
+   if ( frameRate == 0 )
+   {
+      throw invalid_argument( "Minimum frame rate cannot be zero" );
+   }
+   else if ( frameRate < 0 )
+   {
+      _minimumFrameRate = -1;
+      _minSecondsPerFrame = -1;
+      _hasMinimumFrameRate = false;
+   }
+   else
+   {
+      _minimumFrameRate = frameRate;
+      _minSecondsPerFrame = 1 / (double)frameRate;
+      _hasMinimumFrameRate = true;
+   }
 }
 
 void GameClock::StartFrame()

--- a/MegaManLofi/GameClock.cpp
+++ b/MegaManLofi/GameClock.cpp
@@ -9,7 +9,7 @@ using namespace MegaManLofi;
 GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock ) :
    _highResolutionClock( highResolutionClock ),
    _minimumFrameRate( -1 ),
-   _minSecondsPerFrame( -1 ),
+   _minNanoSecondsPerFrame( -1 ),
    _hasMinimumFrameRate( false ),
    _totalFrameCount( 0 ),
    _absoluteStartTimeNano( 0 ),
@@ -29,13 +29,13 @@ void GameClock::SetMinimumFrameRate( long long frameRate )
    else if ( frameRate < 0 )
    {
       _minimumFrameRate = -1;
-      _minSecondsPerFrame = -1;
+      _minNanoSecondsPerFrame = -1;
       _hasMinimumFrameRate = false;
    }
    else
    {
       _minimumFrameRate = frameRate;
-      _minSecondsPerFrame = 1 / (double)frameRate;
+      _minNanoSecondsPerFrame = (long long)( ( 1 / (double)frameRate ) * 1'000'000'000 );
       _hasMinimumFrameRate = true;
    }
 }
@@ -60,5 +60,20 @@ long long GameClock::GetAverageFrameRate() const
 
 double GameClock::GetFrameSeconds() const
 {
-   return _lastFrameDurationNano / 1'000'000'000.;
+   if ( _hasMinimumFrameRate )
+   {
+      if ( _lastFrameDurationNano > _minNanoSecondsPerFrame )
+      {
+         // TODO: count this is a lag frame
+         return _minNanoSecondsPerFrame / 1'000'000'000.;
+      }
+      else
+      {
+         return _lastFrameDurationNano / 1'000'000'000.;
+      }
+   }
+   else
+   {
+      return _lastFrameDurationNano / 1'000'000'000.;
+   }
 }

--- a/MegaManLofi/GameClock.cpp
+++ b/MegaManLofi/GameClock.cpp
@@ -11,7 +11,9 @@ GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock
    _minimumFrameRate( -1 ),
    _minNanoSecondsPerFrame( -1 ),
    _hasMinimumFrameRate( false ),
+   _wasLagFrame( false ),
    _totalFrameCount( 0 ),
+   _lagFrameCount( 0 ),
    _absoluteStartTimeNano( 0 ),
    _frameStartTimeNano( 0 ),
    _lastFrameDurationNano( 0 ),
@@ -51,6 +53,12 @@ void GameClock::EndFrame()
    auto now = _highResolutionClock->Now();
    _lastFrameDurationNano = now - _frameStartTimeNano;
    _totalDurationNano = now - _absoluteStartTimeNano;
+   _wasLagFrame = _hasMinimumFrameRate && ( _lastFrameDurationNano > _minNanoSecondsPerFrame );
+
+   if ( _wasLagFrame )
+   {
+      _lagFrameCount++;
+   }
 }
 
 long long GameClock::GetAverageFrameRate() const
@@ -60,20 +68,5 @@ long long GameClock::GetAverageFrameRate() const
 
 double GameClock::GetFrameSeconds() const
 {
-   if ( _hasMinimumFrameRate )
-   {
-      if ( _lastFrameDurationNano > _minNanoSecondsPerFrame )
-      {
-         // TODO: count this is a lag frame
-         return _minNanoSecondsPerFrame / 1'000'000'000.;
-      }
-      else
-      {
-         return _lastFrameDurationNano / 1'000'000'000.;
-      }
-   }
-   else
-   {
-      return _lastFrameDurationNano / 1'000'000'000.;
-   }
+   return _wasLagFrame ? _minNanoSecondsPerFrame / 1'000'000'000. : _lastFrameDurationNano / 1'000'000'000.;
 }

--- a/MegaManLofi/GameClock.h
+++ b/MegaManLofi/GameClock.h
@@ -29,7 +29,7 @@ namespace MegaManLofi
       const std::shared_ptr<IHighResolutionClock> _highResolutionClock;
 
       long long _minimumFrameRate;
-      double _minSecondsPerFrame;
+      long long _minNanoSecondsPerFrame;
       bool _hasMinimumFrameRate;
 
       long long _totalFrameCount;

--- a/MegaManLofi/GameClock.h
+++ b/MegaManLofi/GameClock.h
@@ -13,6 +13,10 @@ namespace MegaManLofi
    public:
       GameClock( const std::shared_ptr<IHighResolutionClock> highResolutionClock );
 
+      long long GetMinimumFrameRate() const override { return _minimumFrameRate; }
+      void SetMinimumFrameRate( long long frameRate ) override;
+      bool HasMinimumFrameRate() const override { return _hasMinimumFrameRate; }
+
       void StartFrame() override;
       void EndFrame() override;
 
@@ -23,6 +27,10 @@ namespace MegaManLofi
 
    private:
       const std::shared_ptr<IHighResolutionClock> _highResolutionClock;
+
+      long long _minimumFrameRate;
+      double _minSecondsPerFrame;
+      bool _hasMinimumFrameRate;
 
       long long _totalFrameCount;
       long long _absoluteStartTimeNano;

--- a/MegaManLofi/GameClock.h
+++ b/MegaManLofi/GameClock.h
@@ -16,6 +16,7 @@ namespace MegaManLofi
       long long GetMinimumFrameRate() const override { return _minimumFrameRate; }
       void SetMinimumFrameRate( long long frameRate ) override;
       bool HasMinimumFrameRate() const override { return _hasMinimumFrameRate; }
+      long long GetLagFrameCount() const override { return _lagFrameCount; }
 
       void StartFrame() override;
       void EndFrame() override;
@@ -31,8 +32,10 @@ namespace MegaManLofi
       long long _minimumFrameRate;
       long long _minNanoSecondsPerFrame;
       bool _hasMinimumFrameRate;
+      bool _wasLagFrame;
 
       long long _totalFrameCount;
+      long long _lagFrameCount;
       long long _absoluteStartTimeNano;
       long long _frameStartTimeNano;
       long long _lastFrameDurationNano;

--- a/MegaManLofi/GameDefs.h
+++ b/MegaManLofi/GameDefs.h
@@ -14,6 +14,8 @@ namespace MegaManLofi
    class GameDefs
    {
    public:
+      long long MinimumFrameRate = 0;
+
       std::shared_ptr<IGameRenderDefs> RenderDefs;
       std::shared_ptr<IGameInputDefs> InputDefs;
       std::shared_ptr<EntityDefs> EntityDefs;

--- a/MegaManLofi/GameDefsGenerator.cpp
+++ b/MegaManLofi/GameDefsGenerator.cpp
@@ -15,6 +15,10 @@ shared_ptr<GameDefs> GameDefsGenerator::GenerateGameDefs( const shared_ptr<IFram
 {
    auto gameDefs = make_shared<GameDefs>();
 
+   // the player's maximum Y-velocity is 4,000,000 and a tile is 78,000 units tall, so this
+   // should prevent the player from clipping through any surfaces when the frame rate drops
+   gameDefs->MinimumFrameRate = 52;
+
    gameDefs->RenderDefs = ConsoleRenderDefsGenerator::GenerateConsoleRenderDefs( frameRateProvider );
    gameDefs->InputDefs = KeyboardInputDefsGenerator::GenerateKeyboardInputDefs();
    gameDefs->EntityDefs = EntityDefsGenerator::GenerateEntityDefs();

--- a/MegaManLofi/IFrameRateProvider.h
+++ b/MegaManLofi/IFrameRateProvider.h
@@ -5,7 +5,10 @@ namespace MegaManLofi
    class __declspec( novtable ) IFrameRateProvider
    {
    public:
+      virtual long long GetMinimumFrameRate() const = 0;
+      virtual bool HasMinimumFrameRate() const = 0;
       virtual long long GetCurrentFrame() const = 0;
       virtual double GetFrameSeconds() const = 0;
+      virtual long long GetLagFrameCount() const = 0;
    };
 }

--- a/MegaManLofi/IFrameRateProvider.h
+++ b/MegaManLofi/IFrameRateProvider.h
@@ -10,5 +10,7 @@ namespace MegaManLofi
       virtual long long GetCurrentFrame() const = 0;
       virtual double GetFrameSeconds() const = 0;
       virtual long long GetLagFrameCount() const = 0;
+      virtual long long GetElapsedNanoseconds() const = 0;
+      virtual long long GetAverageFrameRate() const = 0;
    };
 }

--- a/MegaManLofi/IGameClock.h
+++ b/MegaManLofi/IGameClock.h
@@ -7,6 +7,10 @@ namespace MegaManLofi
    class __declspec( novtable ) IGameClock : public IFrameRateProvider
    {
    public:
+      virtual long long GetMinimumFrameRate() const = 0;
+      virtual void SetMinimumFrameRate( long long frameRate ) = 0;
+      virtual bool HasMinimumFrameRate() const = 0;
+
       virtual void StartFrame() = 0;
       virtual void EndFrame() = 0;
 

--- a/MegaManLofi/IGameClock.h
+++ b/MegaManLofi/IGameClock.h
@@ -11,8 +11,5 @@ namespace MegaManLofi
 
       virtual void StartFrame() = 0;
       virtual void EndFrame() = 0;
-
-      virtual long long GetElapsedNanoseconds() const = 0;
-      virtual long long GetAverageFrameRate() const = 0;
    };
 }

--- a/MegaManLofi/IGameClock.h
+++ b/MegaManLofi/IGameClock.h
@@ -10,6 +10,7 @@ namespace MegaManLofi
       virtual long long GetMinimumFrameRate() const = 0;
       virtual void SetMinimumFrameRate( long long frameRate ) = 0;
       virtual bool HasMinimumFrameRate() const = 0;
+      virtual long long GetLagFrameCount() const = 0;
 
       virtual void StartFrame() = 0;
       virtual void EndFrame() = 0;

--- a/MegaManLofi/IGameClock.h
+++ b/MegaManLofi/IGameClock.h
@@ -7,10 +7,7 @@ namespace MegaManLofi
    class __declspec( novtable ) IGameClock : public IFrameRateProvider
    {
    public:
-      virtual long long GetMinimumFrameRate() const = 0;
       virtual void SetMinimumFrameRate( long long frameRate ) = 0;
-      virtual bool HasMinimumFrameRate() const = 0;
-      virtual long long GetLagFrameCount() const = 0;
 
       virtual void StartFrame() = 0;
       virtual void EndFrame() = 0;

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -100,6 +100,10 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // game defs
    auto gameDefs = GameDefsGenerator::GenerateGameDefs( clock, uniqueNumberGenerator );
+   if ( gameDefs->MinimumFrameRate > 0 )
+   {
+      clock->SetMinimumFrameRate( gameDefs->MinimumFrameRate );
+   }
    auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( gameDefs->RenderDefs );
    auto keyboardInputDefs = static_pointer_cast<KeyboardInputDefs>( gameDefs->InputDefs );
 

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -86,7 +86,7 @@ TEST_F( ArenaTests, Reset_Always_ClearsEntities )
 {
    BuildArena();
 
-   _arena->AddEntity( make_shared<mock_Entity>() );
+   _arena->AddEntity( shared_ptr<mock_Entity>( new NiceMock<mock_Entity> ) );
 
    EXPECT_EQ( _arena->GetEntityCount(), 2 );
 
@@ -109,8 +109,8 @@ TEST_F( ArenaTests, Reset_Always_RaisesArenaEntitiesClearedEvent )
 TEST_F( ArenaTests, HasEntity_DoesNotHaveEntity_ReturnsFalse )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    ON_CALL( *entityMock1, GetUniqueId() ).WillByDefault( Return( 3 ) );
    ON_CALL( *entityMock2, GetUniqueId() ).WillByDefault( Return( 7 ) );
 
@@ -122,8 +122,8 @@ TEST_F( ArenaTests, HasEntity_DoesNotHaveEntity_ReturnsFalse )
 TEST_F( ArenaTests, HasEntity_HasEntity_ReturnsTrue )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    ON_CALL( *entityMock1, GetUniqueId() ).WillByDefault( Return( 3 ) );
    ON_CALL( *entityMock2, GetUniqueId() ).WillByDefault( Return( 7 ) );
 
@@ -136,7 +136,7 @@ TEST_F( ArenaTests, HasEntity_HasEntity_ReturnsTrue )
 TEST_F( ArenaTests, AddEntity_EntityIsNotInList_AddsEntity )
 {
    BuildArena();
-   auto entityMock = make_shared<mock_Entity>();
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
 
    _arena->AddEntity( entityMock );
 
@@ -147,7 +147,7 @@ TEST_F( ArenaTests, AddEntity_EntityIsNotInList_AddsEntity )
 TEST_F( ArenaTests, AddEntity_EntityIsNotInList_RaisesArenaEntitySpawnedEvent )
 {
    BuildArena();
-   auto entityMock = make_shared<mock_Entity>();
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
 
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) );
 
@@ -157,7 +157,7 @@ TEST_F( ArenaTests, AddEntity_EntityIsNotInList_RaisesArenaEntitySpawnedEvent )
 TEST_F( ArenaTests, AddEntity_EntityIsAlreadyInList_DoesNotAddEntity )
 {
    BuildArena();
-   auto entityMock = make_shared<mock_Entity>();
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock );
 
    _arena->AddEntity( entityMock );
@@ -169,7 +169,7 @@ TEST_F( ArenaTests, AddEntity_EntityIsAlreadyInList_DoesNotAddEntity )
 TEST_F( ArenaTests, AddEntity_EntityIsAlreadyInList_DoesNotRaiseArenaEntitySpawnedEvent )
 {
    BuildArena();
-   auto entityMock = make_shared<mock_Entity>();
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock );
 
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) ).Times( 0 );
@@ -180,8 +180,8 @@ TEST_F( ArenaTests, AddEntity_EntityIsAlreadyInList_DoesNotRaiseArenaEntitySpawn
 TEST_F( ArenaTests, RemoveEntity_EntityIsNotInList_DoesNotRemoveEntity )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock1 );
 
    _arena->RemoveEntity( entityMock2 );
@@ -193,8 +193,8 @@ TEST_F( ArenaTests, RemoveEntity_EntityIsNotInList_DoesNotRemoveEntity )
 TEST_F( ArenaTests, RemoveEntity_EntityIsNotInList_DoesNotRaiseArenaEntityDeSpawnedEvent )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock1 );
 
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntityDeSpawned ) ).Times( 0 );
@@ -205,8 +205,8 @@ TEST_F( ArenaTests, RemoveEntity_EntityIsNotInList_DoesNotRaiseArenaEntityDeSpaw
 TEST_F( ArenaTests, RemoveEntity_EntityIsInList_RemovesEntity )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock1 );
    _arena->AddEntity( entityMock2 );
 
@@ -219,8 +219,8 @@ TEST_F( ArenaTests, RemoveEntity_EntityIsInList_RemovesEntity )
 TEST_F( ArenaTests, RemoveEntity_EntityIsInList_RaisesArenaEntityDeSpawnedEvent )
 {
    BuildArena();
-   auto entityMock1 = make_shared<mock_Entity>();
-   auto entityMock2 = make_shared<mock_Entity>();
+   auto entityMock1 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   auto entityMock2 = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
    _arena->AddEntity( entityMock1 );
    _arena->AddEntity( entityMock2 );
 

--- a/MegaManLofiTests/GameClockTests.cpp
+++ b/MegaManLofiTests/GameClockTests.cpp
@@ -33,6 +33,7 @@ TEST_F( GameClockTests, Constructor_Always_InitializesAllValues )
 {
    EXPECT_EQ( _clock->GetMinimumFrameRate(), -1 );
    EXPECT_FALSE( _clock->HasMinimumFrameRate() );
+   EXPECT_EQ( _clock->GetLagFrameCount(), 0 );
    EXPECT_EQ( _clock->GetElapsedNanoseconds(), 0 );
    EXPECT_EQ( _clock->GetCurrentFrame(), 0 );
    EXPECT_EQ( _clock->GetAverageFrameRate(), 0 );
@@ -113,6 +114,7 @@ TEST_F( GameClockTests, GetFrameSeconds_FrameWasFasterThanMinimumFrameRate_Retur
    _clock->EndFrame();
 
    EXPECT_EQ( _clock->GetFrameSeconds(), .09 );
+   EXPECT_EQ( _clock->GetLagFrameCount(), 0 );
 }
 
 TEST_F( GameClockTests, GetFrameSeconds_FrameWasEqualToMinimumFrameRate_ReturnsTotalFrameSeconds )
@@ -124,6 +126,7 @@ TEST_F( GameClockTests, GetFrameSeconds_FrameWasEqualToMinimumFrameRate_ReturnsT
    _clock->EndFrame();
 
    EXPECT_EQ( _clock->GetFrameSeconds(), .1 );
+   EXPECT_EQ( _clock->GetLagFrameCount(), 0 );
 }
 
 TEST_F( GameClockTests, GetFrameSeconds_FrameWasSlowerThanMinimumFrameRate_ReturnsMinimumFrameSeconds )
@@ -135,4 +138,5 @@ TEST_F( GameClockTests, GetFrameSeconds_FrameWasSlowerThanMinimumFrameRate_Retur
    _clock->EndFrame();
 
    EXPECT_EQ( _clock->GetFrameSeconds(), .1 );
+   EXPECT_EQ( _clock->GetLagFrameCount(), 1 );
 }

--- a/MegaManLofiTests/GameClockTests.cpp
+++ b/MegaManLofiTests/GameClockTests.cpp
@@ -94,3 +94,45 @@ TEST_F( GameClockTests, EndFrame_Always_UpdatesProperties )
    EXPECT_EQ( _clock->GetAverageFrameRate(), 2 );
    EXPECT_EQ( _clock->GetFrameSeconds(), .5 );
 }
+
+TEST_F( GameClockTests, GetFrameSeconds_DoesNotHaveMinimumFrameRateAlways_ReturnsTotalFrameSeconds )
+{
+   _clock->StartFrame();
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1'000'000'000 ) ); // 1 second
+   _clock->EndFrame();
+
+   EXPECT_EQ( _clock->GetFrameSeconds(), 1. );
+}
+
+TEST_F( GameClockTests, GetFrameSeconds_FrameWasFasterThanMinimumFrameRate_ReturnsTotalFrameSeconds )
+{
+   _clock->SetMinimumFrameRate( 10 ); // 100,000,000 nanoseconds per frame
+
+   _clock->StartFrame();
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 90'000'000 ) );
+   _clock->EndFrame();
+
+   EXPECT_EQ( _clock->GetFrameSeconds(), .09 );
+}
+
+TEST_F( GameClockTests, GetFrameSeconds_FrameWasEqualToMinimumFrameRate_ReturnsTotalFrameSeconds )
+{
+   _clock->SetMinimumFrameRate( 10 ); // 100,000,000 nanoseconds per frame
+
+   _clock->StartFrame();
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 100'000'000 ) );
+   _clock->EndFrame();
+
+   EXPECT_EQ( _clock->GetFrameSeconds(), .1 );
+}
+
+TEST_F( GameClockTests, GetFrameSeconds_FrameWasSlowerThanMinimumFrameRate_ReturnsMinimumFrameSeconds )
+{
+   _clock->SetMinimumFrameRate( 10 ); // 100,000,000 nanoseconds per frame
+
+   _clock->StartFrame();
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 110'000'000 ) );
+   _clock->EndFrame();
+
+   EXPECT_EQ( _clock->GetFrameSeconds(), .1 );
+}

--- a/MegaManLofiTests/GameClockTests.cpp
+++ b/MegaManLofiTests/GameClockTests.cpp
@@ -31,10 +31,47 @@ protected:
 
 TEST_F( GameClockTests, Constructor_Always_InitializesAllValues )
 {
+   EXPECT_EQ( _clock->GetMinimumFrameRate(), -1 );
+   EXPECT_FALSE( _clock->HasMinimumFrameRate() );
    EXPECT_EQ( _clock->GetElapsedNanoseconds(), 0 );
    EXPECT_EQ( _clock->GetCurrentFrame(), 0 );
    EXPECT_EQ( _clock->GetAverageFrameRate(), 0 );
    EXPECT_EQ( _clock->GetFrameSeconds(), 0 );
+}
+
+TEST_F( GameClockTests, SetMinimumFrameRate_FrameRateIsZero_ThrowsException )
+{
+   string message;
+
+   try
+   {
+      _clock->SetMinimumFrameRate( 0 );
+   }
+   catch ( invalid_argument e )
+   {
+      message = e.what();
+   }
+
+   EXPECT_EQ( message, "Minimum frame rate cannot be zero" );
+}
+
+TEST_F( GameClockTests, SetMinimumFrameRate_FrameRateIsPositive_SetsMinimumFrameRate )
+{
+   _clock->SetMinimumFrameRate( 60 );
+
+   EXPECT_TRUE( _clock->HasMinimumFrameRate() );
+   EXPECT_EQ( _clock->GetMinimumFrameRate(), 60 );
+}
+
+TEST_F( GameClockTests, SetMinimumFrameRate_FrameRateIsNegative_RemovesMinimumFrameRate )
+{
+   _clock->SetMinimumFrameRate( 20 );
+   EXPECT_TRUE( _clock->HasMinimumFrameRate() );
+
+   _clock->SetMinimumFrameRate( -20 );
+
+   EXPECT_FALSE( _clock->HasMinimumFrameRate() );
+   EXPECT_EQ( _clock->GetMinimumFrameRate(), -1 );
 }
 
 TEST_F( GameClockTests, StartFrame_Always_SetsFrameStartTime )

--- a/MegaManLofiTests/mock_FrameRateProvider.h
+++ b/MegaManLofiTests/mock_FrameRateProvider.h
@@ -7,6 +7,9 @@
 class mock_FrameRateProvider : public MegaManLofi::IFrameRateProvider
 {
 public:
+   MOCK_METHOD( long long, GetMinimumFrameRate, ( ), ( const, override ) );
+   MOCK_METHOD( bool, HasMinimumFrameRate, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
    MOCK_METHOD( double, GetFrameSeconds, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetLagFrameCount, ( ), ( const, override ) );
 };

--- a/MegaManLofiTests/mock_FrameRateProvider.h
+++ b/MegaManLofiTests/mock_FrameRateProvider.h
@@ -12,4 +12,6 @@ public:
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
    MOCK_METHOD( double, GetFrameSeconds, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetLagFrameCount, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetElapsedNanoseconds, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetAverageFrameRate, ( ), ( const, override ) );
 };

--- a/MegaManLofiTests/mock_GameClock.h
+++ b/MegaManLofiTests/mock_GameClock.h
@@ -8,6 +8,9 @@
 class mock_GameClock : public MegaManLofi::IGameClock
 {
 public:
+   MOCK_METHOD( long long, GetMinimumFrameRate, ( ), ( const, override ) );
+   MOCK_METHOD( void, SetMinimumFrameRate, ( long long ), ( override ) );
+   MOCK_METHOD( bool, HasMinimumFrameRate, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
    MOCK_METHOD( double, GetFrameSeconds, ( ), ( const, override ) );
    MOCK_METHOD( void, StartFrame, ( ), ( override ) );

--- a/MegaManLofiTests/mock_GameClock.h
+++ b/MegaManLofiTests/mock_GameClock.h
@@ -11,6 +11,7 @@ public:
    MOCK_METHOD( long long, GetMinimumFrameRate, ( ), ( const, override ) );
    MOCK_METHOD( void, SetMinimumFrameRate, ( long long ), ( override ) );
    MOCK_METHOD( bool, HasMinimumFrameRate, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetLagFrameCount, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetCurrentFrame, ( ), ( const, override ) );
    MOCK_METHOD( double, GetFrameSeconds, ( ), ( const, override ) );
    MOCK_METHOD( void, StartFrame, ( ), ( override ) );


### PR DESCRIPTION
Addresses #36 

Even though the average frame rate is normally astronomical, it is possible for it to dip very low, I noticed it when trying to use Camtasia to record gameplay. When that happens, it's possible for the player to clip through solid surfaces.

I was going to try and use some rudimentary ray-casting calculations to try and detect environment collisions, but it was getting too messy and complicated, so I figured it'd be easier to allow a "minimum frame rate". The game will still try to go as fast as the CPU can handle, but if it detects that the last frame took too long, `GetFrameSeconds()` will return a value based on the minimum frame rate, and we'll count it as a lag frame.

The minimum frame rate value I landed on is 52, here's why:

- The player's maximum Y-velocity is 4,000,000 units per second.
- A single tile is 78,000 units tall
- At 52 FPS, the farthest the player can go in a single frame is 76,923 units.
- Therefore, the player can't move farther than one tile in a single frame.

This covers the maximum X-velocity as well (which is 1,200,000 units per second), since a tile is 38,000 units wide and the farthest the player can move in the X-direction at 52 FPS is 23,076 units.

NOTE: I'm not sure what will happen when we introduce entity collisions, I'll have to test those at low frame rates.