### PR TITLE
Add a framework for Stages with multiple Arenas

### DIFF
--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -2,6 +2,7 @@
 
 #include "Arena.h"
 #include "ArenaDefs.h"
+#include "WorldDefs.h"
 #include "GameEventAggregator.h"
 #include "Entity.h"
 
@@ -9,18 +10,19 @@ using namespace std;
 using namespace MegaManLofi;
 
 Arena::Arena( const shared_ptr<ArenaDefs> arenaDefs,
+              const shared_ptr<WorldDefs> worldDefs,
               const shared_ptr<GameEventAggregator> eventAggregator ) :
    _arenaDefs( arenaDefs ),
    _eventAggregator( eventAggregator )
 {
    _arenaId = arenaDefs->ArenaId;
-   _tiles = arenaDefs->DefaultTiles;
-   _width = arenaDefs->DefaultTileWidth * arenaDefs->DefaultHorizontalTiles;
-   _height = arenaDefs->DefaultTileHeight * arenaDefs->DefaultVerticalTiles;
-   _tileWidth = arenaDefs->DefaultTileWidth;
-   _tileHeight = arenaDefs->DefaultTileHeight;
-   _horizontalTiles = arenaDefs->DefaultHorizontalTiles;
-   _verticalTiles = arenaDefs->DefaultVerticalTiles;
+   _tiles = arenaDefs->Tiles;
+   _width = worldDefs->TileWidth * arenaDefs->HorizontalTiles;
+   _height = worldDefs->TileHeight * arenaDefs->VerticalTiles;
+   _tileWidth = worldDefs->TileWidth;
+   _tileHeight = worldDefs->TileHeight;
+   _horizontalTiles = arenaDefs->HorizontalTiles;
+   _verticalTiles = arenaDefs->VerticalTiles;
 
    Reset();
 }
@@ -32,7 +34,7 @@ void Arena::Reset()
 
    if ( _playerEntity )
    {
-      _playerEntity->SetArenaPosition( _arenaDefs->DefaultPlayerPosition );
+      _playerEntity->SetArenaPosition( _arenaDefs->PlayerStartPosition );
       AddEntity( _playerEntity );
    }
 }

--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -13,6 +13,7 @@ Arena::Arena( const shared_ptr<ArenaDefs> arenaDefs,
    _arenaDefs( arenaDefs ),
    _eventAggregator( eventAggregator )
 {
+   _arenaId = arenaDefs->ArenaId;
    _tiles = arenaDefs->DefaultTiles;
    _width = arenaDefs->DefaultTileWidth * arenaDefs->DefaultHorizontalTiles;
    _height = arenaDefs->DefaultTileHeight * arenaDefs->DefaultVerticalTiles;

--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -39,6 +39,13 @@ void Arena::Reset()
    }
 }
 
+void Arena::Clear()
+{
+   _entities.clear();
+   _eventAggregator->RaiseEvent( GameEvent::ArenaEntitiesCleared );
+   _playerEntity = nullptr;
+}
+
 void Arena::SetPlayerEntity( const shared_ptr<Entity> playerEntity )
 {
    _playerEntity = playerEntity;

--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -34,8 +34,7 @@ void Arena::Reset()
 
    if ( _playerEntity )
    {
-      _playerEntity->SetArenaPosition( _arenaDefs->PlayerStartPosition );
-      AddEntity( _playerEntity );
+      SetPlayerEntity( _playerEntity );
    }
 }
 
@@ -46,9 +45,11 @@ void Arena::Clear()
    _playerEntity = nullptr;
 }
 
+// MUFFINS: test this
 void Arena::SetPlayerEntity( const shared_ptr<Entity> playerEntity )
 {
    _playerEntity = playerEntity;
+   _playerEntity->SetArenaPosition( _arenaDefs->PlayerStartPosition );
    AddEntity( playerEntity );
 }
 

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -17,6 +17,7 @@ namespace MegaManLofi
              const std::shared_ptr<GameEventAggregator> eventAggregator );
 
       virtual void Reset();
+      virtual void Clear();
 
       virtual void SetArenaId( int id ) { _arenaId = id; }
       virtual void SetPlayerEntity( const std::shared_ptr<Entity> playerEntity );

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -16,6 +16,7 @@ namespace MegaManLofi
 
       virtual void Reset();
 
+      virtual void SetArenaId( int id ) { _arenaId = id; }
       virtual void SetPlayerEntity( const std::shared_ptr<Entity> playerEntity );
       virtual void SetActiveRegion( Quad<float> region ) { _activeRegion = region; }
       virtual void AddEntity( const std::shared_ptr<Entity> entity );

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -5,6 +5,7 @@
 namespace MegaManLofi
 {
    class ArenaDefs;
+   class WorldDefs;
    class GameEventAggregator;
 
    class Arena : public ReadOnlyArena
@@ -12,6 +13,7 @@ namespace MegaManLofi
    public:
       Arena() { }
       Arena( const std::shared_ptr<ArenaDefs> arenaDefs,
+             const std::shared_ptr<WorldDefs> worldDefs,
              const std::shared_ptr<GameEventAggregator> eventAggregator );
 
       virtual void Reset();

--- a/MegaManLofi/ArenaDefs.h
+++ b/MegaManLofi/ArenaDefs.h
@@ -12,17 +12,11 @@ namespace MegaManLofi
    public:
       int ArenaId = 0;
 
-      float DefaultTileWidth = 0;
-      float DefaultTileHeight = 0;
+      int HorizontalTiles = 0;
+      int VerticalTiles = 0;
 
-      int DefaultHorizontalTiles = 0;
-      int DefaultVerticalTiles = 0;
+      std::vector<ArenaTile> Tiles;
 
-      float ActiveRegionWidth = 0;
-      float ActiveRegionHeight = 0;
-
-      std::vector<ArenaTile> DefaultTiles;
-
-      Coordinate<float> DefaultPlayerPosition = { 0, 0 };
+      Coordinate<float> PlayerStartPosition = { 0, 0 };
    };
 }

--- a/MegaManLofi/ArenaDefs.h
+++ b/MegaManLofi/ArenaDefs.h
@@ -10,6 +10,8 @@ namespace MegaManLofi
    class ArenaDefs
    {
    public:
+      int ArenaId = 0;
+
       float DefaultTileWidth = 0;
       float DefaultTileHeight = 0;
 

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -1,30 +1,23 @@
 #include "ArenaDefsGenerator.h"
-#include "ArenaDefs.h"
 #include "ArenaTileGenerator.h"
+#include "ArenaDefs.h"
+#include "WorldDefs.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-shared_ptr<ArenaDefs> ArenaDefsGenerator::GenerateArenaDefs()
+shared_ptr<ArenaDefs> ArenaDefsGenerator::GenerateArenaDefs( const shared_ptr<WorldDefs> worldDefs )
 {
    auto arenaDefs = make_shared<ArenaDefs>();
 
    arenaDefs->ArenaId = 0;
 
-   // this results in a 4,560 x 2,340 unit viewport, which translates super well to a 120 x 30 character console
-   arenaDefs->DefaultTileWidth = 38;
-   arenaDefs->DefaultTileHeight = 78;
+   arenaDefs->HorizontalTiles = 360;
+   arenaDefs->VerticalTiles = 60;
 
-   arenaDefs->DefaultHorizontalTiles = 360;
-   arenaDefs->DefaultVerticalTiles = 60;
+   arenaDefs->Tiles = ArenaTileGenerator::GenerateArenaTiles();
 
-   arenaDefs->DefaultTiles = ArenaTileGenerator::GenerateArenaTiles();
-
-   // this conveniently matches the console viewport size
-   arenaDefs->ActiveRegionWidth = 120 * arenaDefs->DefaultTileWidth;
-   arenaDefs->ActiveRegionHeight = 30 * arenaDefs->DefaultTileHeight;
-
-   arenaDefs->DefaultPlayerPosition = { arenaDefs->DefaultTileWidth * 8, arenaDefs->DefaultTileHeight * 6 };
+   arenaDefs->PlayerStartPosition = { worldDefs->TileWidth * 8, worldDefs->TileHeight * 6 };
 
    return arenaDefs;
 }

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -9,6 +9,8 @@ shared_ptr<ArenaDefs> ArenaDefsGenerator::GenerateArenaDefs()
 {
    auto arenaDefs = make_shared<ArenaDefs>();
 
+   arenaDefs->ArenaId = 0;
+
    // this results in a 4,560 x 2,340 unit viewport, which translates super well to a 120 x 30 character console
    arenaDefs->DefaultTileWidth = 38;
    arenaDefs->DefaultTileHeight = 78;

--- a/MegaManLofi/ArenaDefsGenerator.h
+++ b/MegaManLofi/ArenaDefsGenerator.h
@@ -5,10 +5,11 @@
 namespace MegaManLofi
 {
    class ArenaDefs;
+   class WorldDefs;
 
    class ArenaDefsGenerator
    {
    public:
-      static std::shared_ptr<ArenaDefs> GenerateArenaDefs();
+      static std::shared_ptr<ArenaDefs> GenerateArenaDefs( const std::shared_ptr<WorldDefs> worldDefs );
    };
 }

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -2,6 +2,7 @@
 #include "IFrameRateProvider.h"
 #include "GameEventAggregator.h"
 #include "ArenaDefs.h"
+#include "WorldDefs.h"
 #include "Arena.h"
 #include "Entity.h"
 #include "FrameAction.h"
@@ -11,10 +12,12 @@ using namespace MegaManLofi;
 
 ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvider,
                             const shared_ptr<GameEventAggregator> eventAggregator,
-                            const shared_ptr<ArenaDefs> arenaDefs ) :
+                            const shared_ptr<ArenaDefs> arenaDefs,
+                            const shared_ptr<WorldDefs> worldDefs ) :
    _frameRateProvider( frameRateProvider ),
    _eventAggregator( eventAggregator ),
    _arenaDefs( arenaDefs ),
+   _worldDefs( worldDefs ),
    _arena( nullptr )
 {
 }
@@ -236,10 +239,10 @@ void ArenaPhysics::HandleEntityEnvironmentCollision( const shared_ptr<Entity> en
 void ArenaPhysics::UpdateActiveRegion()
 {
    const auto& playerPosition = _arena->GetPlayerEntity()->GetArenaPosition();
-   auto regionLeft = playerPosition.Left - ( _arenaDefs->ActiveRegionWidth / 2 );
-   auto regionTop = playerPosition.Top - ( _arenaDefs->ActiveRegionHeight / 2 );
+   auto regionLeft = playerPosition.Left - ( _worldDefs->ActiveRegionWidth / 2 );
+   auto regionTop = playerPosition.Top - ( _worldDefs->ActiveRegionHeight / 2 );
 
-   _arena->SetActiveRegion( { regionLeft, regionTop, regionLeft + _arenaDefs->ActiveRegionWidth, regionTop + _arenaDefs->ActiveRegionHeight } );
+   _arena->SetActiveRegion( { regionLeft, regionTop, regionLeft + _worldDefs->ActiveRegionWidth, regionTop + _worldDefs->ActiveRegionHeight } );
 }
 
 bool ArenaPhysics::DetectTileDeath() const

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -23,10 +23,16 @@ void ArenaPhysics::AssignTo( const shared_ptr<Arena> arena )
 {
    _entityTileIndicesCache.clear();
    _arena = arena;
+   UpdateEntityTileIndicesCaches();
+}
 
-   for ( int i = 0; i < _arena->GetEntityCount(); i++ )
+void ArenaPhysics::Reset()
+{
+   _entityTileIndicesCache.clear();
+
+   if ( _arena )
    {
-      UpdateEntityTileIndicesCache( _arena->GetEntity( i ) );
+      UpdateEntityTileIndicesCaches();
    }
 }
 
@@ -35,6 +41,14 @@ void ArenaPhysics::Tick()
    MoveEntities();
    UpdateActiveRegion();
    DetectTileDeath();
+}
+
+void ArenaPhysics::UpdateEntityTileIndicesCaches()
+{
+   for ( int i = 0; i < _arena->GetEntityCount(); i++ )
+   {
+      UpdateEntityTileIndicesCache( _arena->GetEntity( i ) );
+   }
 }
 
 void ArenaPhysics::UpdateEntityTileIndicesCache( const shared_ptr<ReadOnlyEntity> entity )

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -11,6 +11,7 @@ namespace MegaManLofi
    class IFrameRateProvider;
    class GameEventAggregator;
    class ArenaDefs;
+   class WorldDefs;
    class Arena;
    class Entity;
    class ReadOnlyEntity;
@@ -21,7 +22,8 @@ namespace MegaManLofi
       ArenaPhysics() { }
       ArenaPhysics( const std::shared_ptr<IFrameRateProvider> frameRateProvider,
                     const std::shared_ptr<GameEventAggregator> eventAggregator,
-                    const std::shared_ptr<ArenaDefs> arenaDefs );
+                    const std::shared_ptr<ArenaDefs> arenaDefs,
+                    const std::shared_ptr<WorldDefs> worldDefs );
 
       virtual void AssignTo( const std::shared_ptr<Arena> arena );
       virtual void Reset();
@@ -44,6 +46,7 @@ namespace MegaManLofi
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<GameEventAggregator> _eventAggregator;
       const std::shared_ptr<ArenaDefs> _arenaDefs;
+      const std::shared_ptr<WorldDefs> _worldDefs;
 
       std::shared_ptr<Arena> _arena;
 

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -24,9 +24,11 @@ namespace MegaManLofi
                     const std::shared_ptr<ArenaDefs> arenaDefs );
 
       virtual void AssignTo( const std::shared_ptr<Arena> arena );
+      virtual void Reset();
       virtual void Tick();
 
    private:
+      void UpdateEntityTileIndicesCaches();
       void UpdateEntityTileIndicesCache( const std::shared_ptr<ReadOnlyEntity> entity );
       void MoveEntities();
       void MoveEntity( const std::shared_ptr<Entity> entity );

--- a/MegaManLofi/DiagnosticsConsoleRenderer.cpp
+++ b/MegaManLofi/DiagnosticsConsoleRenderer.cpp
@@ -36,7 +36,7 @@ void DiagnosticsConsoleRenderer::Render()
    auto totalFramesString = format( " Total frames:       {0} ", _frameRateProvider->GetCurrentFrame() );
    auto framesPerSecondString = format( " Average frame rate: {0} ", _frameRateProvider->GetAverageFrameRate() );
    auto lagFramesString = format( " Lag frames:         {0} ", _frameRateProvider->GetLagFrameCount() );
-   auto arenaEntitiesString = format( " Arena entities:     {0} ", _arenaInfoProvider->GetArena()->GetEntityCount() );
+   auto arenaEntitiesString = format( " Arena entities:     {0} ", _arenaInfoProvider->GetActiveArena()->GetEntityCount() );
    auto activeSpritesString = format( " Active sprites:     {0} ", _spriteRepository->GetSpriteCount() );
 
    while ( elapsedSecondsString.length() < DIAGNOSTICS_WIDTH ) { elapsedSecondsString += ' '; }

--- a/MegaManLofi/EntityConsoleSpriteRepository.cpp
+++ b/MegaManLofi/EntityConsoleSpriteRepository.cpp
@@ -2,6 +2,7 @@
 
 #include "EntityConsoleSpriteRepository.h"
 #include "GameEventAggregator.h"
+#include "ReadOnlyStage.h"
 #include "ReadOnlyArena.h"
 #include "EntityConsoleSpriteCopier.h"
 #include "ConsoleSpriteDefs.h"
@@ -12,10 +13,10 @@ using namespace std;
 using namespace MegaManLofi;
 
 EntityConsoleSpriteRepository::EntityConsoleSpriteRepository( const shared_ptr<GameEventAggregator> eventAggregator,
-                                                              const shared_ptr<ReadOnlyArena> arena,
+                                                              const shared_ptr<ReadOnlyStage> stage,
                                                               const shared_ptr<EntityConsoleSpriteCopier> spriteCopier,
                                                               const shared_ptr<ConsoleSpriteDefs> spriteDefs ) :
-   _arena( arena ),
+   _stage( stage ),
    _spriteCopier( spriteCopier ),
    _spriteDefs( spriteDefs )
 {
@@ -31,9 +32,11 @@ const shared_ptr<EntityConsoleSprite> EntityConsoleSpriteRepository::GetSprite( 
 
 void EntityConsoleSpriteRepository::HandleEntitySpawned()
 {
-   for ( int i = 0; i < _arena->GetEntityCount(); i++ )
+   auto arena = _stage->GetActiveArena();
+
+   for ( int i = 0; i < arena->GetEntityCount(); i++ )
    {
-      auto entity = _arena->GetEntity( i );
+      auto entity = arena->GetEntity( i );
       auto uniqueId = entity->GetUniqueId();
 
       if ( _spriteMap.count( uniqueId ) == 0 )
@@ -53,7 +56,7 @@ void EntityConsoleSpriteRepository::HandleEntityDeSpawned()
 
    for ( auto [uniqueId, entity] : _spriteMap )
    {
-      if ( !_arena->HasEntity( uniqueId ) )
+      if ( !_stage->GetActiveArena()->HasEntity( uniqueId ) )
       {
          idsToRemove.push_back( uniqueId );
       }

--- a/MegaManLofi/EntityConsoleSpriteRepository.h
+++ b/MegaManLofi/EntityConsoleSpriteRepository.h
@@ -6,7 +6,7 @@
 namespace MegaManLofi
 {
    class GameEventAggregator;
-   class ReadOnlyArena;
+   class ReadOnlyStage;
    class EntityConsoleSprite;
    class EntityConsoleSpriteCopier;
    class ConsoleSpriteDefs;
@@ -15,7 +15,7 @@ namespace MegaManLofi
    {
    public:
       EntityConsoleSpriteRepository( const std::shared_ptr<GameEventAggregator> eventAggregator,
-                                     const std::shared_ptr<ReadOnlyArena> arena,
+                                     const std::shared_ptr<ReadOnlyStage> stage,
                                      const std::shared_ptr<EntityConsoleSpriteCopier> spriteCopier,
                                      const std::shared_ptr<ConsoleSpriteDefs> spriteDefs );
 
@@ -28,7 +28,7 @@ namespace MegaManLofi
       void HandleEntitiesCleared();
 
    private:
-      const std::shared_ptr<ReadOnlyArena> _arena;
+      const std::shared_ptr<ReadOnlyStage> _stage;
       const std::shared_ptr<EntityConsoleSpriteCopier> _spriteCopier;
       const std::shared_ptr<ConsoleSpriteDefs> _spriteDefs;
 

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -42,7 +42,7 @@ void Game::Tick()
    {
       _player->ResetPhysics();
       _arena->Reset();
-      _arenaPhysics->AssignTo( _arena );
+      _arenaPhysics->Reset();
       _restartStageNextFrame = false;
       _eventAggregator->RaiseEvent( GameEvent::StageStarted );
    }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -42,6 +42,7 @@ void Game::Tick()
    {
       _player->ResetPosition();
       _arena->Reset();
+      _playerPhysics->Reset();
       _arenaPhysics->Reset();
       _restartStageNextFrame = false;
       _eventAggregator->RaiseEvent( GameEvent::StageStarted );

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -40,7 +40,7 @@ void Game::Tick()
 {
    if ( _restartStageNextFrame )
    {
-      _player->ResetPhysics();
+      _player->ResetPosition();
       _arena->Reset();
       _arenaPhysics->Reset();
       _restartStageNextFrame = false;

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -61,7 +61,7 @@ const shared_ptr<ReadOnlyEntity> Game::GetPlayerEntity() const
    return _player;
 }
 
-const shared_ptr<ReadOnlyArena> Game::GetArena() const
+const shared_ptr<ReadOnlyArena> Game::GetActiveArena() const
 {
    return _stage->GetActiveArena();
 }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -1,6 +1,7 @@
 #include "Game.h"
 #include "GameEventAggregator.h"
 #include "Player.h"
+#include "Stage.h"
 #include "Arena.h"
 #include "PlayerPhysics.h"
 #include "ArenaPhysics.h"
@@ -15,13 +16,13 @@ using namespace MegaManLofi;
 
 Game::Game( const shared_ptr<GameEventAggregator> eventAggregator,
             const shared_ptr<Player> player,
-            const shared_ptr<Arena> arena,
+            const shared_ptr<Stage> stage,
             const shared_ptr<PlayerPhysics> playerPhysics,
             const shared_ptr<ArenaPhysics> arenaPhysics,
             const shared_ptr<EntityFactory> entityFactory ) :
    _eventAggregator( eventAggregator ),
    _player( player ),
-   _arena( arena ),
+   _stage( stage ),
    _playerPhysics( playerPhysics ),
    _arenaPhysics( arenaPhysics ),
    _entityFactory( entityFactory ),
@@ -32,25 +33,18 @@ Game::Game( const shared_ptr<GameEventAggregator> eventAggregator,
 {
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::KillPlayer, this ) );
    _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::KillPlayer, this ) );
-
-   _arena->SetPlayerEntity( _player );
 }
 
 void Game::Tick()
 {
-   if ( _restartStageNextFrame )
-   {
-      _player->ResetPosition();
-      _arena->Reset();
-      _playerPhysics->Reset();
-      _arenaPhysics->Reset();
-      _restartStageNextFrame = false;
-      _eventAggregator->RaiseEvent( GameEvent::StageStarted );
-   }
-
    _state = _nextState;
 
-   if ( _state == GameState::Playing && !_isPaused )
+   if ( _restartStageNextFrame )
+   {
+      _restartStageNextFrame = false;
+      StartStage();
+   }
+   else if ( _state == GameState::Playing && !_isPaused )
    {
       _playerPhysics->Tick();
       _arenaPhysics->Tick();
@@ -69,7 +63,7 @@ const shared_ptr<ReadOnlyEntity> Game::GetPlayerEntity() const
 
 const shared_ptr<ReadOnlyArena> Game::GetArena() const
 {
-   return _arena;
+   return _stage->GetActiveArena();
 }
 
 void Game::ExecuteCommand( GameCommand command )
@@ -83,8 +77,7 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    switch ( command )
    {
       case GameCommand::StartGame:
-         StartStage();
-         _eventAggregator->RaiseEvent( GameEvent::GameStarted );
+         StartGame();
          break;
       case GameCommand::StartStage:
          StartStage();
@@ -132,12 +125,26 @@ void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs
    }
 }
 
-void Game::StartStage()
+void Game::StartGame()
 {
    _player->Reset();
-   _arena->Reset();
    _playerPhysics->AssignTo( _player );
-   _arenaPhysics->AssignTo( _arena );
+   StartStage();
+   _eventAggregator->RaiseEvent( GameEvent::GameStarted );
+}
+
+void Game::StartStage()
+{
+   _stage->Reset();
+   _player->ResetPosition();
+
+   auto arena = _stage->GetMutableActiveArena();
+   arena->SetPlayerEntity( _player );
+   _arenaPhysics->AssignTo( arena );
+
+   _playerPhysics->Reset();
+   _arenaPhysics->Reset();
+
    _nextState = GameState::Playing;
    _isPaused = false;
    _eventAggregator->RaiseEvent( GameEvent::StageStarted );
@@ -164,7 +171,7 @@ void Game::Shoot()
 
    auto bullet = _entityFactory->CreateBullet( { left, top }, _player->GetDirection() );
 
-   _arena->AddEntity( bullet );
+   _stage->GetMutableActiveArena()->AddEntity( bullet );
 }
 
 void Game::TogglePause()

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -38,7 +38,7 @@ namespace MegaManLofi
 
       const std::shared_ptr<ReadOnlyPlayer> GetPlayer() const override;
       const std::shared_ptr<ReadOnlyEntity> GetPlayerEntity() const override;
-      const std::shared_ptr<ReadOnlyArena> GetArena() const override;
+      const std::shared_ptr<ReadOnlyArena> GetActiveArena() const override;
 
       void ExecuteCommand( GameCommand command ) override;
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -12,7 +12,7 @@ namespace MegaManLofi
 {
    class GameEventAggregator;
    class Player;
-   class Arena;
+   class Stage;
    class PlayerPhysics;
    class ArenaPhysics;
    class EntityFactory;
@@ -26,7 +26,7 @@ namespace MegaManLofi
    public:
       Game( const std::shared_ptr<GameEventAggregator> eventAggregator,
             const std::shared_ptr<Player> player,
-            const std::shared_ptr<Arena> arena,
+            const std::shared_ptr<Stage> stage,
             const std::shared_ptr<PlayerPhysics> playerPhysics,
             const std::shared_ptr<ArenaPhysics> arenaPhysics,
             const std::shared_ptr<EntityFactory> entityFactory );
@@ -44,6 +44,7 @@ namespace MegaManLofi
       void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
    private:
+      void StartGame();
       void StartStage();
       void Shoot();
       void TogglePause();
@@ -54,7 +55,7 @@ namespace MegaManLofi
    private:
       const std::shared_ptr<GameEventAggregator> _eventAggregator;
       const std::shared_ptr<Player> _player;
-      const std::shared_ptr<Arena> _arena;
+      const std::shared_ptr<Stage> _stage;
       const std::shared_ptr<PlayerPhysics> _playerPhysics;
       const std::shared_ptr<ArenaPhysics> _arenaPhysics;
       const std::shared_ptr<EntityFactory> _entityFactory;

--- a/MegaManLofi/GameDefs.h
+++ b/MegaManLofi/GameDefs.h
@@ -9,6 +9,7 @@ namespace MegaManLofi
    class EntityDefs;
    class PlayerDefs;
    class WorldDefs;
+   class StageDefs;
    class ArenaDefs;
    class PlayerPhysicsDefs;
 
@@ -22,6 +23,7 @@ namespace MegaManLofi
       std::shared_ptr<EntityDefs> EntityDefs;
       std::shared_ptr<PlayerDefs> PlayerDefs;
       std::shared_ptr<WorldDefs> WorldDefs;
+      std::shared_ptr<StageDefs> StageDefs;
       std::shared_ptr<ArenaDefs> ArenaDefs;
       std::shared_ptr<PlayerPhysicsDefs> PlayerPhysicsDefs;
    };

--- a/MegaManLofi/GameDefs.h
+++ b/MegaManLofi/GameDefs.h
@@ -8,6 +8,7 @@ namespace MegaManLofi
    class IGameInputDefs;
    class EntityDefs;
    class PlayerDefs;
+   class WorldDefs;
    class ArenaDefs;
    class PlayerPhysicsDefs;
 
@@ -20,6 +21,7 @@ namespace MegaManLofi
       std::shared_ptr<IGameInputDefs> InputDefs;
       std::shared_ptr<EntityDefs> EntityDefs;
       std::shared_ptr<PlayerDefs> PlayerDefs;
+      std::shared_ptr<WorldDefs> WorldDefs;
       std::shared_ptr<ArenaDefs> ArenaDefs;
       std::shared_ptr<PlayerPhysicsDefs> PlayerPhysicsDefs;
    };

--- a/MegaManLofi/GameDefsGenerator.cpp
+++ b/MegaManLofi/GameDefsGenerator.cpp
@@ -25,7 +25,7 @@ shared_ptr<GameDefs> GameDefsGenerator::GenerateGameDefs( const shared_ptr<IFram
    gameDefs->EntityDefs = EntityDefsGenerator::GenerateEntityDefs();
    gameDefs->PlayerDefs = PlayerDefsGenerator::GeneratePlayerDefs( uniqueNumberGenerator );
    gameDefs->WorldDefs = WorldDefsGenerator::GenerateWorldDefs();
-   gameDefs->ArenaDefs = ArenaDefsGenerator::GenerateArenaDefs();
+   gameDefs->ArenaDefs = ArenaDefsGenerator::GenerateArenaDefs( gameDefs->WorldDefs );
    gameDefs->PlayerPhysicsDefs = PlayerPhysicsDefsGenerator::GeneratePlayerPhysicsDefs();
 
    return gameDefs;

--- a/MegaManLofi/GameDefsGenerator.cpp
+++ b/MegaManLofi/GameDefsGenerator.cpp
@@ -5,6 +5,7 @@
 #include "EntityDefsGenerator.h"
 #include "PlayerDefsGenerator.h"
 #include "WorldDefsGenerator.h"
+#include "StageDefsGenerator.h"
 #include "ArenaDefsGenerator.h"
 #include "PlayerPhysicsDefsGenerator.h"
 
@@ -25,6 +26,7 @@ shared_ptr<GameDefs> GameDefsGenerator::GenerateGameDefs( const shared_ptr<IFram
    gameDefs->EntityDefs = EntityDefsGenerator::GenerateEntityDefs();
    gameDefs->PlayerDefs = PlayerDefsGenerator::GeneratePlayerDefs( uniqueNumberGenerator );
    gameDefs->WorldDefs = WorldDefsGenerator::GenerateWorldDefs();
+   gameDefs->StageDefs = StageDefsGenerator::GenerateStageDefs( gameDefs->WorldDefs );
    gameDefs->ArenaDefs = ArenaDefsGenerator::GenerateArenaDefs( gameDefs->WorldDefs );
    gameDefs->PlayerPhysicsDefs = PlayerPhysicsDefsGenerator::GeneratePlayerPhysicsDefs();
 

--- a/MegaManLofi/GameDefsGenerator.cpp
+++ b/MegaManLofi/GameDefsGenerator.cpp
@@ -4,6 +4,7 @@
 #include "KeyboardInputDefsGenerator.h"
 #include "EntityDefsGenerator.h"
 #include "PlayerDefsGenerator.h"
+#include "WorldDefsGenerator.h"
 #include "ArenaDefsGenerator.h"
 #include "PlayerPhysicsDefsGenerator.h"
 
@@ -23,6 +24,7 @@ shared_ptr<GameDefs> GameDefsGenerator::GenerateGameDefs( const shared_ptr<IFram
    gameDefs->InputDefs = KeyboardInputDefsGenerator::GenerateKeyboardInputDefs();
    gameDefs->EntityDefs = EntityDefsGenerator::GenerateEntityDefs();
    gameDefs->PlayerDefs = PlayerDefsGenerator::GeneratePlayerDefs( uniqueNumberGenerator );
+   gameDefs->WorldDefs = WorldDefsGenerator::GenerateWorldDefs();
    gameDefs->ArenaDefs = ArenaDefsGenerator::GenerateArenaDefs();
    gameDefs->PlayerPhysicsDefs = PlayerPhysicsDefsGenerator::GeneratePlayerPhysicsDefs();
 

--- a/MegaManLofi/IArenaInfoProvider.h
+++ b/MegaManLofi/IArenaInfoProvider.h
@@ -9,6 +9,6 @@ namespace MegaManLofi
    class __declspec( novtable ) IArenaInfoProvider
    {
    public:
-      virtual const std::shared_ptr<ReadOnlyArena> GetArena() const = 0;
+      virtual const std::shared_ptr<ReadOnlyArena> GetActiveArena() const = 0;
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -128,8 +128,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
       stage->AddArena( arena );
    }
    auto entityFactory = shared_ptr<EntityFactory>( new EntityFactory( gameDefs->EntityDefs, uniqueNumberGenerator ) );
-   // TODO: give the game a stage instead of an Arena
-   auto game = shared_ptr<Game>( new Game( eventAggregator, player, static_pointer_cast<Arena>( stage->GetActiveArena() ), playerPhysics, arenaPhysics, entityFactory ) );
+   auto game = shared_ptr<Game>( new Game( eventAggregator, player, stage, playerPhysics, arenaPhysics, entityFactory ) );
 
    // menus
    auto playingMenu = shared_ptr<PlayingMenu>( new PlayingMenu( game ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -160,8 +160,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // rendering utilities
    auto spriteCopier = shared_ptr<EntityConsoleSpriteCopier>( new EntityConsoleSpriteCopier );
-   // TODO: what do we do about this?
-   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, static_pointer_cast<Arena>( stage->GetActiveArena() ), spriteCopier, consoleRenderDefs->SpriteDefs ) );
+   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, stage, spriteCopier, consoleRenderDefs->SpriteDefs ) );
 
    // renderers objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs, game, spriteRepository ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -16,12 +16,14 @@
 #include "UniqueNumberGenerator.h"
 #include "GameDefsGenerator.h"
 #include "GameDefs.h"
+#include "StageDefs.h"
 #include "ConsoleRenderDefs.h"
 #include "KeyboardInputDefs.h"
 #include "KeyboardInputReader.h"
 #include "PlayerPhysics.h"
 #include "ArenaPhysics.h"
 #include "Player.h"
+#include "Stage.h"
 #include "Arena.h"
 #include "EntityFactory.h"
 #include "Game.h"
@@ -118,9 +120,16 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // game objects
    auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );
-   auto arena = shared_ptr<Arena>( new Arena( gameDefs->ArenaDefs, gameDefs->WorldDefs, eventAggregator ) );
+   auto stage = shared_ptr<Stage>( new Stage( gameDefs->StageDefs ) );
+   for ( auto [arenaId, arenaDef] : gameDefs->StageDefs->ArenaMap )
+   {
+      auto arena = shared_ptr<Arena>( new Arena( gameDefs->ArenaDefs, gameDefs->WorldDefs, eventAggregator ) );
+      arena->SetArenaId( arenaId );
+      stage->AddArena( arena );
+   }
    auto entityFactory = shared_ptr<EntityFactory>( new EntityFactory( gameDefs->EntityDefs, uniqueNumberGenerator ) );
-   auto game = shared_ptr<Game>( new Game( eventAggregator, player, arena, playerPhysics, arenaPhysics, entityFactory ) );
+   // TODO: give the game a stage instead of an Arena
+   auto game = shared_ptr<Game>( new Game( eventAggregator, player, static_pointer_cast<Arena>( stage->GetActiveArena() ), playerPhysics, arenaPhysics, entityFactory ) );
 
    // menus
    auto playingMenu = shared_ptr<PlayingMenu>( new PlayingMenu( game ) );
@@ -151,7 +160,8 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // rendering utilities
    auto spriteCopier = shared_ptr<EntityConsoleSpriteCopier>( new EntityConsoleSpriteCopier );
-   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, arena, spriteCopier, consoleRenderDefs->SpriteDefs ) );
+   // TODO: what do we do about this?
+   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, static_pointer_cast<Arena>( stage->GetActiveArena() ), spriteCopier, consoleRenderDefs->SpriteDefs ) );
 
    // renderers objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs, game, spriteRepository ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -114,11 +114,11 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // utilities
    auto playerPhysics = shared_ptr<PlayerPhysics>( new PlayerPhysics( clock, frameActionRegistry, gameDefs->PlayerPhysicsDefs ) );
-   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, eventAggregator, gameDefs->ArenaDefs ) );
+   auto arenaPhysics = shared_ptr<ArenaPhysics>( new ArenaPhysics( clock, eventAggregator, gameDefs->ArenaDefs, gameDefs->WorldDefs ) );
 
    // game objects
    auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );
-   auto arena = shared_ptr<Arena>( new Arena( gameDefs->ArenaDefs, eventAggregator ) );
+   auto arena = shared_ptr<Arena>( new Arena( gameDefs->ArenaDefs, gameDefs->WorldDefs, eventAggregator ) );
    auto entityFactory = shared_ptr<EntityFactory>( new EntityFactory( gameDefs->EntityDefs, uniqueNumberGenerator ) );
    auto game = shared_ptr<Game>( new Game( eventAggregator, player, arena, playerPhysics, arenaPhysics, entityFactory ) );
 

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="ReadOnlyPlayer.cpp" />
     <ClCompile Include="ReadOnlyStage.cpp" />
     <ClCompile Include="RectangleUtilities.cpp" />
+    <ClCompile Include="Stage.cpp" />
     <ClCompile Include="StageDefsGenerator.cpp" />
     <ClCompile Include="StageStartedConsoleAnimation.cpp" />
     <ClCompile Include="TitleStateConsoleRenderer.cpp" />
@@ -312,6 +313,7 @@
     <ClInclude Include="ReadOnlyStage.h" />
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
+    <ClInclude Include="Stage.h" />
     <ClInclude Include="StageDefs.h" />
     <ClInclude Include="StageDefsGenerator.h" />
     <ClInclude Include="StageStartedConsoleAnimation.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -206,6 +206,7 @@
     <ClCompile Include="ThreadWrapper.cpp" />
     <ClCompile Include="TitleImageGenerator.cpp" />
     <ClCompile Include="UniqueNumberGenerator.cpp" />
+    <ClCompile Include="WorldDefsGenerator.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Arena.h" />
@@ -315,6 +316,8 @@
     <ClInclude Include="Quad.h" />
     <ClInclude Include="TitleImageGenerator.h" />
     <ClInclude Include="UniqueNumberGenerator.h" />
+    <ClInclude Include="WorldDefs.h" />
+    <ClInclude Include="WorldDefsGenerator.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -309,6 +309,7 @@
     <ClInclude Include="ReadOnlyPlayer.h" />
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
+    <ClInclude Include="StageDefs.h" />
     <ClInclude Include="StageStartedConsoleAnimation.h" />
     <ClInclude Include="TitleStateInputHandler.h" />
     <ClInclude Include="TitleStateConsoleRenderer.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="ReadOnlyArena.cpp" />
     <ClCompile Include="ReadOnlyEntity.cpp" />
     <ClCompile Include="ReadOnlyPlayer.cpp" />
+    <ClCompile Include="ReadOnlyStage.cpp" />
     <ClCompile Include="RectangleUtilities.cpp" />
     <ClCompile Include="StageDefsGenerator.cpp" />
     <ClCompile Include="StageStartedConsoleAnimation.cpp" />
@@ -308,6 +309,7 @@
     <ClInclude Include="ReadOnlyArena.h" />
     <ClInclude Include="ReadOnlyEntity.h" />
     <ClInclude Include="ReadOnlyPlayer.h" />
+    <ClInclude Include="ReadOnlyStage.h" />
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
     <ClInclude Include="StageDefs.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -200,6 +200,7 @@
     <ClCompile Include="ReadOnlyEntity.cpp" />
     <ClCompile Include="ReadOnlyPlayer.cpp" />
     <ClCompile Include="RectangleUtilities.cpp" />
+    <ClCompile Include="StageDefsGenerator.cpp" />
     <ClCompile Include="StageStartedConsoleAnimation.cpp" />
     <ClCompile Include="TitleStateConsoleRenderer.cpp" />
     <ClCompile Include="TitleStateInputHandler.cpp" />
@@ -310,6 +311,7 @@
     <ClInclude Include="Rectangle.h" />
     <ClInclude Include="RectangleUtilities.h" />
     <ClInclude Include="StageDefs.h" />
+    <ClInclude Include="StageDefsGenerator.h" />
     <ClInclude Include="StageStartedConsoleAnimation.h" />
     <ClInclude Include="TitleStateInputHandler.h" />
     <ClInclude Include="TitleStateConsoleRenderer.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -584,5 +584,8 @@
     <ClInclude Include="WorldDefsGenerator.h">
       <Filter>Header Files\GameDefGenerators</Filter>
     </ClInclude>
+    <ClInclude Include="StageDefs.h">
+      <Filter>Header Files\GameDefs</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -255,6 +255,9 @@
     <ClCompile Include="WorldDefsGenerator.cpp">
       <Filter>Source Files\GameDefGenerators</Filter>
     </ClCompile>
+    <ClCompile Include="StageDefsGenerator.cpp">
+      <Filter>Source Files\GameDefGenerators</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -586,6 +589,9 @@
     </ClInclude>
     <ClInclude Include="StageDefs.h">
       <Filter>Header Files\GameDefs</Filter>
+    </ClInclude>
+    <ClInclude Include="StageDefsGenerator.h">
+      <Filter>Header Files\GameDefGenerators</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -258,6 +258,9 @@
     <ClCompile Include="StageDefsGenerator.cpp">
       <Filter>Source Files\GameDefGenerators</Filter>
     </ClCompile>
+    <ClCompile Include="ReadOnlyStage.cpp">
+      <Filter>Source Files\GameObjects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -592,6 +595,9 @@
     </ClInclude>
     <ClInclude Include="StageDefsGenerator.h">
       <Filter>Header Files\GameDefGenerators</Filter>
+    </ClInclude>
+    <ClInclude Include="ReadOnlyStage.h">
+      <Filter>Header Files\GameObjects</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="PlayerPhysics.cpp">
       <Filter>Source Files\Physics</Filter>
     </ClCompile>
+    <ClCompile Include="WorldDefsGenerator.cpp">
+      <Filter>Source Files\GameDefGenerators</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -574,6 +577,12 @@
     </ClInclude>
     <ClInclude Include="PlayerPhysics.h">
       <Filter>Header Files\Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="WorldDefs.h">
+      <Filter>Header Files\GameDefs</Filter>
+    </ClInclude>
+    <ClInclude Include="WorldDefsGenerator.h">
+      <Filter>Header Files\GameDefGenerators</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -73,6 +73,12 @@
     <Filter Include="Source Files\GameDefGenerators\SubGenerators">
       <UniqueIdentifier>{7bd07139-5eaf-4aae-82b1-1e2e6210d460}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Physics">
+      <UniqueIdentifier>{577ac10b-e9d1-4eae-931b-c239b85d65e4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Physics">
+      <UniqueIdentifier>{510ade20-7d9f-4f32-8fdc-e979fb3bd212}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MegaManLofi.cpp">
@@ -137,12 +143,6 @@
     </ClCompile>
     <ClCompile Include="Arena.cpp">
       <Filter>Source Files\GameObjects</Filter>
-    </ClCompile>
-    <ClCompile Include="PlayerPhysics.cpp">
-      <Filter>Source Files\Utilities</Filter>
-    </ClCompile>
-    <ClCompile Include="ArenaPhysics.cpp">
-      <Filter>Source Files\Utilities</Filter>
     </ClCompile>
     <ClCompile Include="GameOverStateConsoleRenderer.cpp">
       <Filter>Source Files\Render</Filter>
@@ -245,6 +245,12 @@
     </ClCompile>
     <ClCompile Include="ReadOnlyArena.cpp">
       <Filter>Source Files\GameObjects</Filter>
+    </ClCompile>
+    <ClCompile Include="ArenaPhysics.cpp">
+      <Filter>Source Files\Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerPhysics.cpp">
+      <Filter>Source Files\Physics</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -416,12 +422,6 @@
     <ClInclude Include="IFrameRateProvider.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
-    <ClInclude Include="PlayerPhysics.h">
-      <Filter>Header Files\Utilities</Filter>
-    </ClInclude>
-    <ClInclude Include="ArenaPhysics.h">
-      <Filter>Header Files\Utilities</Filter>
-    </ClInclude>
     <ClInclude Include="Quad.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
@@ -568,6 +568,12 @@
     </ClInclude>
     <ClInclude Include="ReadOnlyArena.h">
       <Filter>Header Files\GameObjects</Filter>
+    </ClInclude>
+    <ClInclude Include="ArenaPhysics.h">
+      <Filter>Header Files\Physics</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerPhysics.h">
+      <Filter>Header Files\Physics</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -261,6 +261,9 @@
     <ClCompile Include="ReadOnlyStage.cpp">
       <Filter>Source Files\GameObjects</Filter>
     </ClCompile>
+    <ClCompile Include="Stage.cpp">
+      <Filter>Source Files\GameObjects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -597,6 +600,9 @@
       <Filter>Header Files\GameDefGenerators</Filter>
     </ClInclude>
     <ClInclude Include="ReadOnlyStage.h">
+      <Filter>Header Files\GameObjects</Filter>
+    </ClInclude>
+    <ClInclude Include="Stage.h">
       <Filter>Header Files\GameObjects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -25,11 +25,11 @@ Player::Player( const shared_ptr<PlayerDefs> playerDefs,
 
 void Player::Reset()
 {
-   ResetPhysics();
    _livesRemaining = _playerDefs->DefaultLives;
+   ResetPosition();
 }
 
-void Player::ResetPhysics()
+void Player::ResetPosition()
 {
    _hitBox = _playerDefs->DefaultHitBox;
    _velocityX = _playerDefs->DefaultVelocityX;

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -21,7 +21,7 @@ namespace MegaManLofi
               const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
       virtual void Reset();
-      virtual void ResetPhysics();
+      virtual void ResetPosition();
 
       virtual void SetLivesRemaining( unsigned int lives ) { _livesRemaining = lives; };
       virtual void SetIsJumping( bool isJumping ) { _isJumping = isJumping; }

--- a/MegaManLofi/PlayerPhysics.cpp
+++ b/MegaManLofi/PlayerPhysics.cpp
@@ -25,6 +25,11 @@ PlayerPhysics::PlayerPhysics( const shared_ptr<IFrameRateProvider> frameRateProv
 void PlayerPhysics::AssignTo( const shared_ptr<Player> player )
 {
    _player = player;
+   Reset();
+}
+
+void PlayerPhysics::Reset()
+{
    _lastExtendJumpFrame = 0;
 }
 

--- a/MegaManLofi/PlayerPhysics.h
+++ b/MegaManLofi/PlayerPhysics.h
@@ -20,6 +20,7 @@ namespace MegaManLofi
                      const std::shared_ptr<PlayerPhysicsDefs> physicsDefs );
 
       virtual void AssignTo( const std::shared_ptr<Player> player );
+      virtual void Reset();
       virtual void Tick();
 
       virtual void PointTo( Direction direction ) const;

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -126,7 +126,7 @@ void PlayingStateConsoleRenderer::HandleTileDeathEvent()
 
 void PlayingStateConsoleRenderer::UpdateCaches()
 {
-   _arena = _arenaInfoProvider->GetArena();
+   _arena = _arenaInfoProvider->GetActiveArena();
 
    auto viewportWidthUnits = _renderDefs->ArenaViewportWidthChars * _renderDefs->ArenaCharWidth;
    auto viewportHeightUnits = _renderDefs->ArenaViewportHeightChars * _renderDefs->ArenaCharHeight;

--- a/MegaManLofi/ReadOnlyArena.cpp
+++ b/MegaManLofi/ReadOnlyArena.cpp
@@ -5,6 +5,7 @@ using namespace std;
 using namespace MegaManLofi;
 
 ReadOnlyArena::ReadOnlyArena() :
+   _arenaId( 0 ),
    _playerEntity( nullptr ),
    _width( 0 ),
    _height( 0 ),

--- a/MegaManLofi/ReadOnlyArena.h
+++ b/MegaManLofi/ReadOnlyArena.h
@@ -16,6 +16,7 @@ namespace MegaManLofi
    public:
       ReadOnlyArena();
 
+      virtual int GetArenaId() const { return _arenaId; }
       virtual const std::shared_ptr<ReadOnlyEntity> GetEntity( int index ) const;
       virtual const std::shared_ptr<ReadOnlyEntity> GetPlayerEntity() const;
       virtual int GetEntityCount() const { return (int)_entities.size(); }
@@ -30,6 +31,7 @@ namespace MegaManLofi
       virtual bool HasEntity( int uniqueId ) const;
 
    protected:
+      int _arenaId;
       std::vector<std::shared_ptr<Entity>> _entities;
       std::shared_ptr<Entity> _playerEntity;
       std::vector<ArenaTile> _tiles;

--- a/MegaManLofi/ReadOnlyStage.cpp
+++ b/MegaManLofi/ReadOnlyStage.cpp
@@ -1,0 +1,9 @@
+#include "ReadOnlyStage.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+ReadOnlyStage::ReadOnlyStage() :
+   _activeArenaId( 0 )
+{
+}

--- a/MegaManLofi/ReadOnlyStage.cpp
+++ b/MegaManLofi/ReadOnlyStage.cpp
@@ -1,4 +1,5 @@
 #include "ReadOnlyStage.h"
+#include "Arena.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -6,4 +7,14 @@ using namespace MegaManLofi;
 ReadOnlyStage::ReadOnlyStage() :
    _activeArenaId( 0 )
 {
+}
+
+const shared_ptr<ReadOnlyArena> ReadOnlyStage::GetArena( int arenaId ) const
+{
+   return _arenaMap.at( arenaId );
+}
+
+const shared_ptr<ReadOnlyArena> ReadOnlyStage::GetActiveArena() const
+{
+   return _arenaMap.at( _activeArenaId );
 }

--- a/MegaManLofi/ReadOnlyStage.h
+++ b/MegaManLofi/ReadOnlyStage.h
@@ -5,6 +5,7 @@
 
 namespace MegaManLofi
 {
+   class Arena;
    class ReadOnlyArena;
 
    class ReadOnlyStage
@@ -12,11 +13,11 @@ namespace MegaManLofi
    public:
       ReadOnlyStage();
 
-      virtual const std::shared_ptr<ReadOnlyArena> GetArena( int arenaId ) const { return _arenaMap.at( arenaId ); }
-      virtual const std::shared_ptr<ReadOnlyArena> GetActiveArena() const { return _arenaMap.at( _activeArenaId ); }
+      virtual const std::shared_ptr<ReadOnlyArena> GetArena( int arenaId ) const;
+      virtual const std::shared_ptr<ReadOnlyArena> GetActiveArena() const;
 
    protected:
-      std::map<int, std::shared_ptr<ReadOnlyArena>> _arenaMap;
+      std::map<int, std::shared_ptr<Arena>> _arenaMap;
       int _activeArenaId;
    };
 }

--- a/MegaManLofi/ReadOnlyStage.h
+++ b/MegaManLofi/ReadOnlyStage.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <map>
+
+namespace MegaManLofi
+{
+   class ReadOnlyArena;
+
+   class ReadOnlyStage
+   {
+   public:
+      ReadOnlyStage();
+
+      virtual const std::shared_ptr<ReadOnlyArena> GetArena( int arenaId ) const { return _arenaMap.at( arenaId ); }
+      virtual const std::shared_ptr<ReadOnlyArena> GetActiveArena() const { return _arenaMap.at( _activeArenaId ); }
+
+   private:
+      std::map<int, std::shared_ptr<ReadOnlyArena>> _arenaMap;
+      int _activeArenaId;
+   };
+}

--- a/MegaManLofi/ReadOnlyStage.h
+++ b/MegaManLofi/ReadOnlyStage.h
@@ -15,7 +15,7 @@ namespace MegaManLofi
       virtual const std::shared_ptr<ReadOnlyArena> GetArena( int arenaId ) const { return _arenaMap.at( arenaId ); }
       virtual const std::shared_ptr<ReadOnlyArena> GetActiveArena() const { return _arenaMap.at( _activeArenaId ); }
 
-   private:
+   protected:
       std::map<int, std::shared_ptr<ReadOnlyArena>> _arenaMap;
       int _activeArenaId;
    };

--- a/MegaManLofi/Stage.cpp
+++ b/MegaManLofi/Stage.cpp
@@ -11,7 +11,7 @@ Stage::Stage( const shared_ptr<StageDefs> stageDefs ) :
    _activeArenaId = _stageDefs->StartArenaId;
 }
 
-void Stage::AddArena( std::shared_ptr<ReadOnlyArena> arena )
+void Stage::AddArena( std::shared_ptr<Arena> arena )
 {
    _arenaMap[arena->GetArenaId()] = arena;
 }

--- a/MegaManLofi/Stage.cpp
+++ b/MegaManLofi/Stage.cpp
@@ -1,6 +1,6 @@
 #include "Stage.h"
 #include "StageDefs.h"
-#include "ReadOnlyArena.h"
+#include "Arena.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -8,7 +8,7 @@ using namespace MegaManLofi;
 Stage::Stage( const shared_ptr<StageDefs> stageDefs ) :
    _stageDefs( stageDefs )
 {
-   Reset();
+   _activeArenaId = _stageDefs->StartArenaId;
 }
 
 void Stage::AddArena( std::shared_ptr<ReadOnlyArena> arena )
@@ -18,5 +18,8 @@ void Stage::AddArena( std::shared_ptr<ReadOnlyArena> arena )
 
 void Stage::Reset()
 {
+   auto activeArena = static_pointer_cast<Arena>( GetActiveArena() );
+   activeArena->Clear();
+
    _activeArenaId = _stageDefs->StartArenaId;
 }

--- a/MegaManLofi/Stage.cpp
+++ b/MegaManLofi/Stage.cpp
@@ -1,0 +1,22 @@
+#include "Stage.h"
+#include "StageDefs.h"
+#include "ReadOnlyArena.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+Stage::Stage( const shared_ptr<StageDefs> stageDefs ) :
+   _stageDefs( stageDefs )
+{
+   Reset();
+}
+
+void Stage::AddArena( std::shared_ptr<ReadOnlyArena> arena )
+{
+   _arenaMap[arena->GetArenaId()] = arena;
+}
+
+void Stage::Reset()
+{
+   _activeArenaId = _stageDefs->StartArenaId;
+}

--- a/MegaManLofi/Stage.h
+++ b/MegaManLofi/Stage.h
@@ -12,7 +12,8 @@ namespace MegaManLofi
       Stage() { }
       Stage( const std::shared_ptr<StageDefs> stageDefs );
 
-      virtual void AddArena( std::shared_ptr<ReadOnlyArena> arena );
+      virtual const std::shared_ptr<Arena> GetMutableActiveArena() const { return _arenaMap.at( _activeArenaId ); }
+      virtual void AddArena( std::shared_ptr<Arena> arena );
       virtual void Reset();
       virtual void SetActiveArena( int arenaId ) { _activeArenaId = arenaId; }
 

--- a/MegaManLofi/Stage.h
+++ b/MegaManLofi/Stage.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ReadOnlyStage.h"
+
+namespace MegaManLofi
+{
+   class StageDefs;
+
+   class Stage : public ReadOnlyStage
+   {
+   public:
+      Stage() { }
+      Stage( const std::shared_ptr<StageDefs> stageDefs );
+
+      virtual void AddArena( std::shared_ptr<ReadOnlyArena> arena );
+      virtual void Reset();
+      virtual void SetActiveArena( int arenaId ) { _activeArenaId = arenaId; }
+
+   private:
+      const std::shared_ptr<StageDefs> _stageDefs;
+   };
+}

--- a/MegaManLofi/StageDefs.h
+++ b/MegaManLofi/StageDefs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <map>
 
 namespace MegaManLofi
@@ -12,6 +13,6 @@ namespace MegaManLofi
 
       int StartArenaId = 0;
 
-      std::map<int, ArenaDefs> ArenaMap;
+      std::map<int, std::shared_ptr<ArenaDefs>> ArenaMap;
    };
 }

--- a/MegaManLofi/StageDefs.h
+++ b/MegaManLofi/StageDefs.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <map>
+
+namespace MegaManLofi
+{
+   class ArenaDefs;
+
+   class StageDefs
+   {
+   public:
+
+      int StartArenaId = 0;
+
+      std::map<int, ArenaDefs> ArenaMap;
+   };
+}

--- a/MegaManLofi/StageDefsGenerator.cpp
+++ b/MegaManLofi/StageDefsGenerator.cpp
@@ -1,0 +1,18 @@
+#include "StageDefsGenerator.h"
+#include "ArenaDefsGenerator.h"
+#include "StageDefs.h"
+#include "ArenaDefs.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+shared_ptr<StageDefs> StageDefsGenerator::GenerateStageDefs( shared_ptr<WorldDefs> worldDefs )
+{
+   auto stageDefs = make_shared<StageDefs>();
+
+   stageDefs->StartArenaId = 0;
+
+   stageDefs->ArenaMap[0] = ArenaDefsGenerator::GenerateArenaDefs( worldDefs );
+
+   return stageDefs;
+}

--- a/MegaManLofi/StageDefsGenerator.h
+++ b/MegaManLofi/StageDefsGenerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+
+namespace MegaManLofi
+{
+   class StageDefs;
+   class ArenaDefs;
+   class WorldDefs;
+
+   class StageDefsGenerator
+   {
+   public:
+      static std::shared_ptr<StageDefs> GenerateStageDefs( const std::shared_ptr<WorldDefs> worldDefs );
+   };
+}

--- a/MegaManLofi/WorldDefs.h
+++ b/MegaManLofi/WorldDefs.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <vector>
+
+namespace MegaManLofi
+{
+   class WorldDefs
+   {
+   public:
+      float TileWidth = 0;
+      float TileHeight = 0;
+
+      float ActiveRegionWidth = 0;
+      float ActiveRegionHeight = 0;
+   };
+}

--- a/MegaManLofi/WorldDefsGenerator.cpp
+++ b/MegaManLofi/WorldDefsGenerator.cpp
@@ -1,0 +1,20 @@
+#include "WorldDefsGenerator.h"
+#include "WorldDefs.h"
+
+using namespace std;
+using namespace MegaManLofi;
+
+shared_ptr<WorldDefs> WorldDefsGenerator::GenerateWorldDefs()
+{
+   auto worldDefs = make_shared<WorldDefs>();
+
+   // this results in a 4,560 x 2,340 unit viewport, which translates super well to a 120 x 30 character console
+   worldDefs->TileWidth = 38;
+   worldDefs->TileHeight = 78;
+
+   // this conveniently matches the console viewport size
+   worldDefs->ActiveRegionWidth = 120 * worldDefs->TileWidth;
+   worldDefs->ActiveRegionHeight = 30 * worldDefs->TileHeight;
+
+   return worldDefs;
+}

--- a/MegaManLofi/WorldDefsGenerator.h
+++ b/MegaManLofi/WorldDefsGenerator.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+namespace MegaManLofi
+{
+   class WorldDefs;
+
+   class WorldDefsGenerator
+   {
+   public:
+      static std::shared_ptr<WorldDefs> GenerateWorldDefs();
+   };
+}

--- a/MegaManLofiTests/ArenaPhysicsTests.cpp
+++ b/MegaManLofiTests/ArenaPhysicsTests.cpp
@@ -4,6 +4,7 @@
 
 #include <MegaManLofi/ArenaPhysics.h>
 #include <MegaManLofi/ArenaDefs.h>
+#include <MegaManLofi/WorldDefs.h>
 #include <MegaManLofi/FrameAction.h>
 #include <MegaManLofi/Rectangle.h>
 #include <MegaManLofi/GameEvent.h>
@@ -24,11 +25,12 @@ public:
       _frameRateProviderMock.reset( new NiceMock<mock_FrameRateProvider> );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _arenaDefs.reset( new ArenaDefs() );
+      _worldDefs.reset( new WorldDefs() );
       _arenaMock.reset( new NiceMock<mock_Arena> );
       _defaultTile = { true, true, true, true, false };
 
-      _arenaDefs->ActiveRegionWidth = 20;
-      _arenaDefs->ActiveRegionHeight = 10;
+      _worldDefs->ActiveRegionWidth = 20;
+      _worldDefs->ActiveRegionHeight = 10;
 
       ON_CALL( *_arenaMock, GetWidth() ).WillByDefault( Return( 20.0f ) );
       ON_CALL( *_arenaMock, GetHeight() ).WillByDefault( Return( 16.0f ) );
@@ -44,7 +46,7 @@ public:
 
    void BuildArenaPhysics()
    {
-      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _eventAggregatorMock, _arenaDefs ) );
+      _arenaPhysics.reset( new ArenaPhysics( _frameRateProviderMock, _eventAggregatorMock, _arenaDefs, _worldDefs ) );
       _arenaPhysics->AssignTo( _arenaMock );
    }
 
@@ -52,6 +54,7 @@ protected:
    shared_ptr<mock_FrameRateProvider> _frameRateProviderMock;
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<ArenaDefs> _arenaDefs;
+   shared_ptr<WorldDefs> _worldDefs;
    shared_ptr<mock_Arena> _arenaMock;
 
    ArenaTile _defaultTile;

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -25,6 +25,7 @@ public:
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
+      _arenaDefs->ArenaId = 11;
       _arenaDefs->DefaultTileWidth = 2;
       _arenaDefs->DefaultTileHeight = 2;
       _arenaDefs->DefaultHorizontalTiles = 10;
@@ -56,6 +57,7 @@ TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnDefs )
    _arenaDefs->DefaultTiles[5] = { false, true, false, true };
    BuildArena();
 
+   EXPECT_EQ( _arena->GetArenaId(), 11 );
    EXPECT_EQ( _arena->GetWidth(), 20 );
    EXPECT_EQ( _arena->GetHeight(), 16 );
    EXPECT_EQ( _arena->GetTileWidth(), 2 );

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -99,6 +99,28 @@ TEST_F( ArenaTests, Reset_Always_RaisesArenaEntitiesClearedEvent )
    _arena->Reset();
 }
 
+TEST_F( ArenaTests, Clear_Always_ClearsEntitiesAndPlayer )
+{
+   BuildArena();
+
+   EXPECT_EQ( _arena->GetEntityCount(), 1 );
+   EXPECT_EQ( _arena->GetPlayerEntity(), _playerMock );
+
+   _arena->Clear();
+
+   EXPECT_EQ( _arena->GetEntityCount(), 0 );
+   EXPECT_EQ( _arena->GetPlayerEntity(), nullptr );
+}
+
+TEST_F( ArenaTests, Clear_Always_RaisesArenaEntitiesClearedEvent )
+{
+   BuildArena();
+
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitiesCleared ) );
+
+   _arena->Clear();
+}
+
 TEST_F( ArenaTests, HasEntity_DoesNotHaveEntity_ReturnsFalse )
 {
    BuildArena();

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -51,7 +51,7 @@ protected:
    shared_ptr<Arena> _arena;
 };
 
-TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnConfig )
+TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnDefs )
 {
    _arenaDefs->DefaultTiles[5] = { false, true, false, true };
    BuildArena();

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -1,7 +1,5 @@
 #include "gtest/gtest.h"
 
-#include <memory>
-
 #include <MegaManLofi/Arena.h>
 #include <MegaManLofi/ArenaDefs.h>
 #include <MegaManLofi/WorldDefs.h>

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -4,6 +4,7 @@
 
 #include <MegaManLofi/Arena.h>
 #include <MegaManLofi/ArenaDefs.h>
+#include <MegaManLofi/WorldDefs.h>
 #include <MegaManLofi/FrameAction.h>
 
 #include "mock_GameEventAggregator.h"
@@ -22,30 +23,33 @@ public:
    void SetUp() override
    {
       _arenaDefs.reset( new ArenaDefs );
+      _worldDefs.reset( new WorldDefs );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
       _arenaDefs->ArenaId = 11;
-      _arenaDefs->DefaultTileWidth = 2;
-      _arenaDefs->DefaultTileHeight = 2;
-      _arenaDefs->DefaultHorizontalTiles = 10;
-      _arenaDefs->DefaultVerticalTiles = 8;
-      _arenaDefs->DefaultPlayerPosition = { 10, 8 };
+      _arenaDefs->HorizontalTiles = 10;
+      _arenaDefs->VerticalTiles = 8;
+      _arenaDefs->PlayerStartPosition = { 10, 8 };
 
-      for ( int i = 0; i < _arenaDefs->DefaultHorizontalTiles * _arenaDefs->DefaultVerticalTiles; i++ )
+      _worldDefs->TileWidth = 2;
+      _worldDefs->TileHeight = 2;
+
+      for ( int i = 0; i < _arenaDefs->HorizontalTiles * _arenaDefs->VerticalTiles; i++ )
       {
-         _arenaDefs->DefaultTiles.push_back( { true, true, true, true } );
+         _arenaDefs->Tiles.push_back( { true, true, true, true } );
       }
    }
 
    void BuildArena()
    {
-      _arena.reset( new Arena( _arenaDefs, _eventAggregatorMock ) );
+      _arena.reset( new Arena( _arenaDefs, _worldDefs, _eventAggregatorMock ) );
       _arena->SetPlayerEntity( _playerMock );
    }
 
 protected:
    shared_ptr<ArenaDefs> _arenaDefs;
+   shared_ptr<WorldDefs> _worldDefs;
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<mock_Player> _playerMock;
 
@@ -54,7 +58,7 @@ protected:
 
 TEST_F( ArenaTests, Constructor_Always_SetsDefaultInfoBasedOnDefs )
 {
-   _arenaDefs->DefaultTiles[5] = { false, true, false, true };
+   _arenaDefs->Tiles[5] = { false, true, false, true };
    BuildArena();
 
    EXPECT_EQ( _arena->GetArenaId(), 11 );

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -119,6 +119,19 @@ TEST_F( ArenaTests, Clear_Always_RaisesArenaEntitiesClearedEvent )
    _arena->Clear();
 }
 
+TEST_F( ArenaTests, SetPlayerEntity_Always_ResetsPlayerEntityPositionFromDefs )
+{
+   BuildArena();
+
+   Coordinate<float> position;
+   EXPECT_CALL( *_playerMock, SetArenaPosition( _ ) ).WillOnce( SaveArg<0>( &position ) );
+
+   _arena->SetPlayerEntity( _playerMock );
+
+   EXPECT_EQ( position.Left, _arenaDefs->PlayerStartPosition.Left );
+   EXPECT_EQ( position.Top, _arenaDefs->PlayerStartPosition.Top );
+}
+
 TEST_F( ArenaTests, HasEntity_DoesNotHaveEntity_ReturnsFalse )
 {
    BuildArena();

--- a/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
+++ b/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
@@ -5,6 +5,7 @@
 #include <MegaManLofi/ConsoleSpriteDefs.h>
 #include <MegaManLofi/GameEvent.h>
 
+#include "mock_ReadOnlyStage.h"
 #include "mock_ReadOnlyArena.h"
 #include "mock_EntityConsoleSpriteCopier.h"
 #include "mock_ReadOnlyEntity.h"
@@ -20,6 +21,7 @@ public:
    void SetUp() override
    {
       _eventAggregator.reset( new GameEventAggregator );
+      _stageMock.reset( new NiceMock<mock_ReadOnlyStage> );
       _arenaMock.reset( new NiceMock<mock_ReadOnlyArena> );
       _spriteCopier.reset( new NiceMock<mock_EntityConsoleSpriteCopier> );
       _spriteDefs.reset( new ConsoleSpriteDefs );
@@ -32,6 +34,8 @@ public:
       _spriteCopyMock1.reset( new NiceMock<mock_EntityConsoleSprite> );
       _spriteCopyMock2.reset( new NiceMock<mock_EntityConsoleSprite> );
       _spriteCopyMock3.reset( new NiceMock<mock_EntityConsoleSprite> );
+
+      ON_CALL( *_stageMock, GetActiveArena() ).WillByDefault( Return( _arenaMock ) );
 
       ON_CALL( *_entityMock1, GetUniqueId() ).WillByDefault( Return( 10 ) );
       ON_CALL( *_entityMock1, GetEntityMetaId() ).WillByDefault( Return( 20 ) );
@@ -50,11 +54,12 @@ public:
       ON_CALL( *_spriteCopier, MakeCopy( static_pointer_cast<EntityConsoleSprite>( _spriteMock2 ) ) ).WillByDefault( Return( _spriteCopyMock2 ) );
       ON_CALL( *_spriteCopier, MakeCopy( static_pointer_cast<EntityConsoleSprite>( _spriteMock3 ) ) ).WillByDefault( Return( _spriteCopyMock3 ) );
 
-      _repository.reset( new EntityConsoleSpriteRepository( _eventAggregator, _arenaMock, _spriteCopier, _spriteDefs ) );
+      _repository.reset( new EntityConsoleSpriteRepository( _eventAggregator, _stageMock, _spriteCopier, _spriteDefs ) );
    }
 
 protected:
    shared_ptr<GameEventAggregator> _eventAggregator;
+   shared_ptr<mock_ReadOnlyStage> _stageMock;
    shared_ptr<mock_ReadOnlyArena> _arenaMock;
    shared_ptr<mock_EntityConsoleSpriteCopier> _spriteCopier;
    shared_ptr<ConsoleSpriteDefs> _spriteDefs;

--- a/MegaManLofiTests/GameRendererTests.cpp
+++ b/MegaManLofiTests/GameRendererTests.cpp
@@ -61,8 +61,8 @@ protected:
 
 TEST_F( GameRendererTests, Constructor_Always_InitializesScreenBuffer )
 {
-   auto baseConfig = static_pointer_cast<IGameRenderDefs>( _renderDefs );
-   EXPECT_CALL( *_screenBufferMock, LoadRenderDefs( baseConfig ) );
+   auto baseDefs = static_pointer_cast<IGameRenderDefs>( _renderDefs );
+   EXPECT_CALL( *_screenBufferMock, LoadRenderDefs( baseDefs ) );
 
    BuildRenderer();
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -517,6 +517,7 @@ TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsGameObjects )
 
    EXPECT_CALL( *_playerMock, ResetPhysics() );
    EXPECT_CALL( *_arenaMock, Reset() );
+   EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 
    _game->Tick();
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -598,9 +598,9 @@ TEST_F( GameTests, GetPlayerEntity_Always_ReturnsPlayerAsEntity )
    EXPECT_EQ( _game->GetPlayerEntity(), _playerMock );
 }
 
-TEST_F( GameTests, GetArena_Always_ReturnsActiveArena )
+TEST_F( GameTests, GetActiveArena_Always_ReturnsActiveArena )
 {
    BuildGame();
 
-   EXPECT_EQ( _game->GetArena(), _arenaMock );
+   EXPECT_EQ( _game->GetActiveArena(), _arenaMock );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -517,6 +517,7 @@ TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsGameObjects )
 
    EXPECT_CALL( *_playerMock, ResetPosition() );
    EXPECT_CALL( *_arenaMock, Reset() );
+   EXPECT_CALL( *_playerPhysicsMock, Reset() );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 
    _game->Tick();

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -13,6 +13,7 @@
 
 #include "mock_GameEventAggregator.h"
 #include "mock_Player.h"
+#include "mock_Stage.h"
 #include "mock_Arena.h"
 #include "mock_PlayerPhysics.h"
 #include "mock_ArenaPhysics.h"
@@ -30,6 +31,7 @@ public:
    {
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerMock.reset( new NiceMock<mock_Player> );
+      _stageMock.reset( new NiceMock<mock_Stage> );
       _arenaMock.reset( new NiceMock<mock_Arena> );
       _playerPhysicsMock.reset( new NiceMock<mock_PlayerPhysics> );
       _arenaPhysicsMock.reset( new NiceMock<mock_ArenaPhysics> );
@@ -41,16 +43,20 @@ public:
       ON_CALL( *_playerMock, GetHitBox() ).WillByDefault( ReturnRef( _playerHitBox ) );
       ON_CALL( *_playerMock, GetDirection() ).WillByDefault( Return( Direction::Right ) );
       ON_CALL( *_playerMock, GetLivesRemaining() ).WillByDefault( Return( 5 ) );
+
+      ON_CALL( *_stageMock, GetActiveArena() ).WillByDefault( Return( _arenaMock ) );
+      ON_CALL( *_stageMock, GetMutableActiveArena() ).WillByDefault( Return( _arenaMock ) );
    }
 
    void BuildGame()
    {
-      _game.reset( new Game( _eventAggregatorMock, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+      _game.reset( new Game( _eventAggregatorMock, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
    }
 
 protected:
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<mock_Player> _playerMock;
+   shared_ptr<mock_Stage> _stageMock;
    shared_ptr<mock_Arena> _arenaMock;
    shared_ptr<mock_PlayerPhysics> _playerPhysicsMock;
    shared_ptr<mock_ArenaPhysics> _arenaPhysicsMock;
@@ -68,32 +74,17 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToTitle )
    EXPECT_EQ( _game->GetGameState(), GameState::Title );
 }
 
-TEST_F( GameTests, Constructor_Always_AddsPlayerToArena )
-{
-   EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
-
-   BuildGame();
-}
-
 TEST_F( GameTests, ExecuteCommand_StartGame_ResetsGameObjects )
 {
    BuildGame();
 
    EXPECT_CALL( *_playerMock, Reset() );
-   EXPECT_CALL( *_arenaMock, Reset() );
-
-   _game->ExecuteCommand( GameCommand::StartGame );
-}
-
-TEST_F( GameTests, ExecuteCommand_StartGame_AssignsObjectsToPhysics )
-{
-   BuildGame();
-
-   auto basePlayer = static_pointer_cast<Player>( _playerMock );
-   auto baseArena = static_pointer_cast<Arena>( _arenaMock );
-
-   EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
-   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena ) );
+   EXPECT_CALL( *_playerPhysicsMock, AssignTo( static_pointer_cast<Player>( _playerMock ) ) );
+   EXPECT_CALL( *_stageMock, Reset() );
+   EXPECT_CALL( *_playerMock, ResetPosition() );
+   EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( static_pointer_cast<Arena>( _arenaMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 
    _game->ExecuteCommand( GameCommand::StartGame );
 }
@@ -122,21 +113,11 @@ TEST_F( GameTests, ExecuteCommand_StartStage_ResetsGameObjects )
 {
    BuildGame();
 
-   EXPECT_CALL( *_playerMock, Reset() );
-   EXPECT_CALL( *_arenaMock, Reset() );
-
-   _game->ExecuteCommand( GameCommand::StartStage );
-}
-
-TEST_F( GameTests, ExecuteCommand_StartStage_AssignsObjectsToPhysics )
-{
-   BuildGame();
-
-   auto basePlayer = static_pointer_cast<Player>( _playerMock );
-   auto baseArena = static_pointer_cast<Arena>( _arenaMock );
-
-   EXPECT_CALL( *_playerPhysicsMock, AssignTo( basePlayer ) );
-   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( baseArena ) );
+   EXPECT_CALL( *_stageMock, Reset() );
+   EXPECT_CALL( *_playerMock, ResetPosition() );
+   EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( static_pointer_cast<Arena>( _arenaMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 
    _game->ExecuteCommand( GameCommand::StartStage );
 }
@@ -512,12 +493,13 @@ TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsGameObjects )
    EXPECT_CALL( *_playerMock, SetLivesRemaining( 4 ) );
 
    auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
 
+   EXPECT_CALL( *_stageMock, Reset() );
    EXPECT_CALL( *_playerMock, ResetPosition() );
-   EXPECT_CALL( *_arenaMock, Reset() );
-   EXPECT_CALL( *_playerPhysicsMock, Reset() );
+   EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( static_pointer_cast<Arena>( _arenaMock ) ) );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 
    _game->Tick();
@@ -559,7 +541,7 @@ TEST_F( GameTests, Tick_GameStateIsPlayingAndNotPaused_DoesPlayerAndArenaActions
 TEST_F( GameTests, EventHandling_PitfallEventRaisedWithLivesLeft_DecrementsPlayerLivesRemaining )
 {
    auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
 
    EXPECT_CALL( *_playerMock, SetLivesRemaining( 4 ) );
 
@@ -571,7 +553,7 @@ TEST_F( GameTests, EventHandling_PitfallEventRaisedWithNoLivesLeft_ChangesNextGa
 {
    ON_CALL( *_playerMock, GetLivesRemaining() ).WillByDefault( Return( 0 ) );
    auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
 
    eventAggregator->RaiseEvent( GameEvent::Pitfall );
    _game->Tick();
@@ -582,7 +564,7 @@ TEST_F( GameTests, EventHandling_PitfallEventRaisedWithNoLivesLeft_ChangesNextGa
 TEST_F( GameTests, EventHandling_TileDeathEventRaisedWithLivesLeft_DecrementsPlayerLivesRemaining )
 {
    auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
 
    EXPECT_CALL( *_playerMock, SetLivesRemaining( 4 ) );
 
@@ -594,10 +576,31 @@ TEST_F( GameTests, EventHandling_TileDeathEventRaised_ChangesNextGameStateToGame
 {
    ON_CALL( *_playerMock, GetLivesRemaining() ).WillByDefault( Return( 0 ) );
    auto eventAggregator = make_shared<GameEventAggregator>();
-   _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
 
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
    _game->Tick();
 
    EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
+}
+
+TEST_F( GameTests, GetPlayer_Always_ReturnsPlayer )
+{
+   BuildGame();
+
+   EXPECT_EQ( _game->GetPlayer(), _playerMock );
+}
+
+TEST_F( GameTests, GetPlayerEntity_Always_ReturnsPlayerAsEntity )
+{
+   BuildGame();
+
+   EXPECT_EQ( _game->GetPlayerEntity(), _playerMock );
+}
+
+TEST_F( GameTests, GetArena_Always_ReturnsActiveArena )
+{
+   BuildGame();
+
+   EXPECT_EQ( _game->GetArena(), _arenaMock );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -515,7 +515,7 @@ TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsGameObjects )
    _game.reset( new Game( eventAggregator, _playerMock, _arenaMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
 
-   EXPECT_CALL( *_playerMock, ResetPhysics() );
+   EXPECT_CALL( *_playerMock, ResetPosition() );
    EXPECT_CALL( *_arenaMock, Reset() );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );
 

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -71,6 +71,7 @@
     <ClInclude Include="mock_ReadOnlyPlayer.h" />
     <ClInclude Include="mock_ReadOnlyStage.h" />
     <ClInclude Include="mock_ScreenBuffer.h" />
+    <ClInclude Include="mock_Stage.h" />
     <ClInclude Include="mock_Thread.h" />
     <ClInclude Include="mock_UniqueNumberGenerator.h" />
   </ItemGroup>
@@ -103,6 +104,7 @@
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
     <ClCompile Include="RectangleUtilitiesTests.cpp" />
     <ClCompile Include="StageStartedConsoleAnimationTests.cpp" />
+    <ClCompile Include="StageTests.cpp" />
     <ClCompile Include="TitleStateInputHandlerTests.cpp" />
     <ClCompile Include="UniqueNumberGeneratorTests.cpp" />
   </ItemGroup>

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="mock_ReadOnlyArena.h" />
     <ClInclude Include="mock_ReadOnlyEntity.h" />
     <ClInclude Include="mock_ReadOnlyPlayer.h" />
+    <ClInclude Include="mock_ReadOnlyStage.h" />
     <ClInclude Include="mock_ScreenBuffer.h" />
     <ClInclude Include="mock_Thread.h" />
     <ClInclude Include="mock_UniqueNumberGenerator.h" />

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClInclude Include="mock_GameRunner.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_ReadOnlyStage.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -39,12 +39,6 @@
     <ClCompile Include="ArenaTests.cpp">
       <Filter>Tests\GameObjects</Filter>
     </ClCompile>
-    <ClCompile Include="PlayerPhysicsTests.cpp">
-      <Filter>Tests\Utilities</Filter>
-    </ClCompile>
-    <ClCompile Include="ArenaPhysicsTests.cpp">
-      <Filter>Tests\Utilities</Filter>
-    </ClCompile>
     <ClCompile Include="GameOverStateInputHandlerTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
@@ -92,6 +86,12 @@
     </ClCompile>
     <ClCompile Include="EntityConsoleSpriteRepositoryTests.cpp">
       <Filter>Tests\Render</Filter>
+    </ClCompile>
+    <ClCompile Include="ArenaPhysicsTests.cpp">
+      <Filter>Tests\Physics</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerPhysicsTests.cpp">
+      <Filter>Tests\Physics</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -225,6 +225,9 @@
     </Filter>
     <Filter Include="Tests\Render\Animations">
       <UniqueIdentifier>{da0cac45-9def-420d-9060-6a4218471f8b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Physics">
+      <UniqueIdentifier>{2529fc09-d4e0-4ba7-9adc-c02a2b74bbbc}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
+++ b/MegaManLofiTests/MegaManLofiTests.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="PlayerPhysicsTests.cpp">
       <Filter>Tests\Physics</Filter>
     </ClCompile>
+    <ClCompile Include="StageTests.cpp">
+      <Filter>Tests\GameObjects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">
@@ -204,6 +207,9 @@
       <Filter>Mocks</Filter>
     </ClInclude>
     <ClInclude Include="mock_ReadOnlyStage.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="mock_Stage.h">
       <Filter>Mocks</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -50,7 +50,7 @@ protected:
    shared_ptr<Player> _player;
 };
 
-TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
+TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromDefs )
 {
    _playerDefs->DefaultVelocityX = 100;
    _playerDefs->DefaultVelocityY = 200;
@@ -82,7 +82,7 @@ TEST_F( PlayerTests, GetEntityType_Always_ReturnsBody )
    EXPECT_EQ( _player->GetEntityType(), EntityType::Body );
 }
 
-TEST_F( PlayerTests, Reset_Always_ResetsDefaultPropertiesFromConfig )
+TEST_F( PlayerTests, Reset_Always_ResetsDefaultPropertiesFromDefs )
 {
    BuildPlayer();
 
@@ -100,6 +100,30 @@ TEST_F( PlayerTests, Reset_Always_ResetsDefaultPropertiesFromConfig )
 
    _player->Reset();
 
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
+   EXPECT_EQ( _player->GetDirection(), Direction::Left );
+   EXPECT_EQ( _player->GetMovementType(), MovementType::Airborne );
+   EXPECT_FALSE( _player->IsJumping() );
+}
+
+TEST_F( PlayerTests, ResetPosition_Always_ResetsPositionPropertiesFromDefs )
+{
+   BuildPlayer();
+
+   _player->SetHitBox( { 100, 200, 300, 400 } );
+   _player->SetVelocityX( 100 );
+   _player->SetVelocityY( 200 );
+   _player->SetDirection( Direction::Right );
+   _player->SetMovementType( MovementType::Walking );
+   _player->SetIsJumping( true );
+
+   _player->ResetPosition();
+
+   EXPECT_EQ( _player->GetHitBox().Left, 0 );
+   EXPECT_EQ( _player->GetHitBox().Top, 0 );
+   EXPECT_EQ( _player->GetHitBox().Width, 4 );
+   EXPECT_EQ( _player->GetHitBox().Height, 4 );
    EXPECT_EQ( _player->GetVelocityX(), 0 );
    EXPECT_EQ( _player->GetVelocityY(), 0 );
    EXPECT_EQ( _player->GetDirection(), Direction::Left );

--- a/MegaManLofiTests/StageTests.cpp
+++ b/MegaManLofiTests/StageTests.cpp
@@ -1,0 +1,72 @@
+#include "gtest/gtest.h"
+
+#include <MegaManLofi/Stage.h>
+#include <MegaManLofi/StageDefs.h>
+
+#include "mock_ReadOnlyArena.h"
+
+using namespace std;
+using namespace testing;
+using namespace MegaManLofi;
+
+class StageTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _stageDefs.reset( new StageDefs );
+      _arenaMock1.reset( new NiceMock<mock_ReadOnlyArena> );
+      _arenaMock2.reset( new NiceMock<mock_ReadOnlyArena> );
+
+      _stageDefs->StartArenaId = 1;
+
+      ON_CALL( *_arenaMock1, GetArenaId() ).WillByDefault( Return( 1 ) );
+      ON_CALL( *_arenaMock2, GetArenaId() ).WillByDefault( Return( 2 ) );
+   }
+
+   void BuildStage()
+   {
+      _stage.reset( new Stage( _stageDefs ) );
+   }
+
+protected:
+   shared_ptr<StageDefs> _stageDefs;
+   shared_ptr<mock_ReadOnlyArena> _arenaMock1;
+   shared_ptr<mock_ReadOnlyArena> _arenaMock2;
+
+   shared_ptr<Stage> _stage;
+};
+
+TEST_F( StageTests, Constructor_Always_SetsActiveArenaFromDefs )
+{
+   _stageDefs->StartArenaId = 2;
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock2 );
+}
+
+TEST_F( StageTests, Reset_Always_ResetsActiveArenaFromDefs )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+   _stage->SetActiveArena( 2 );
+
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock2 );
+
+   _stage->Reset();
+
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock1 );
+}
+
+TEST_F( StageTests, GetArena_Always_ReturnsCorrectArena )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+
+   EXPECT_EQ( _stage->GetArena( 1 ), _arenaMock1 );
+   EXPECT_EQ( _stage->GetArena( 2 ), _arenaMock2 );
+}

--- a/MegaManLofiTests/StageTests.cpp
+++ b/MegaManLofiTests/StageTests.cpp
@@ -3,7 +3,7 @@
 #include <MegaManLofi/Stage.h>
 #include <MegaManLofi/StageDefs.h>
 
-#include "mock_ReadOnlyArena.h"
+#include "mock_Arena.h"
 
 using namespace std;
 using namespace testing;
@@ -15,8 +15,8 @@ public:
    void SetUp() override
    {
       _stageDefs.reset( new StageDefs );
-      _arenaMock1.reset( new NiceMock<mock_ReadOnlyArena> );
-      _arenaMock2.reset( new NiceMock<mock_ReadOnlyArena> );
+      _arenaMock1.reset( new NiceMock<mock_Arena> );
+      _arenaMock2.reset( new NiceMock<mock_Arena> );
 
       _stageDefs->StartArenaId = 1;
 
@@ -31,8 +31,8 @@ public:
 
 protected:
    shared_ptr<StageDefs> _stageDefs;
-   shared_ptr<mock_ReadOnlyArena> _arenaMock1;
-   shared_ptr<mock_ReadOnlyArena> _arenaMock2;
+   shared_ptr<mock_Arena> _arenaMock1;
+   shared_ptr<mock_Arena> _arenaMock2;
 
    shared_ptr<Stage> _stage;
 };
@@ -45,6 +45,16 @@ TEST_F( StageTests, Constructor_Always_SetsActiveArenaFromDefs )
    _stage->AddArena( _arenaMock2 );
 
    EXPECT_EQ( _stage->GetActiveArena(), _arenaMock2 );
+}
+
+TEST_F( StageTests, Reset_Always_ClearsActiveArena )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+
+   EXPECT_CALL( *_arenaMock1, Clear() );
+
+   _stage->Reset();
 }
 
 TEST_F( StageTests, Reset_Always_ResetsActiveArenaFromDefs )

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -22,6 +22,7 @@ public:
    MOCK_METHOD( bool, HasEntity, ( int ), ( const, override ) );
 
    MOCK_METHOD( void, Reset, ( ), ( override ) );
+   MOCK_METHOD( void, Clear, ( ), ( override ) );
    MOCK_METHOD( void, SetPlayerEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
    MOCK_METHOD( void, SetActiveRegion, ( MegaManLofi::Quad<float> ), ( override ) );
    MOCK_METHOD( void, AddEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -7,6 +7,7 @@
 class mock_Arena : public MegaManLofi::Arena
 {
 public:
+   MOCK_METHOD( int, GetArenaId, ( ), ( const, override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyEntity>, GetEntity, ( int ), ( const, override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyEntity>, GetPlayerEntity, ( ), ( const, override ) );
    MOCK_METHOD( int, GetEntityCount, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_ArenaInfoProvider.h
+++ b/MegaManLofiTests/mock_ArenaInfoProvider.h
@@ -7,5 +7,5 @@
 class mock_ArenaInfoProvider : public MegaManLofi::IArenaInfoProvider
 {
 public:
-   MOCK_METHOD( const std::shared_ptr<MegaManLofi::IReadOnlyArena>, GetArena, ( ), ( const, override ) );
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyArena>, GetActiveArena, ( ), ( const, override ) );
 };

--- a/MegaManLofiTests/mock_ArenaPhysics.h
+++ b/MegaManLofiTests/mock_ArenaPhysics.h
@@ -8,5 +8,6 @@ class mock_ArenaPhysics : public MegaManLofi::ArenaPhysics
 {
 public:
    MOCK_METHOD( void, AssignTo, ( const std::shared_ptr<MegaManLofi::Arena> ), ( override ) );
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( void, Tick, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -35,7 +35,7 @@ public:
    MOCK_METHOD( bool, IsJumping, ( ), ( const, override ) );
 
    MOCK_METHOD( void, Reset, ( ), ( override ) );
-   MOCK_METHOD( void, ResetPhysics, ( ), ( override ) );
+   MOCK_METHOD( void, ResetPosition, ( ), ( override ) );
    MOCK_METHOD( void, SetLivesRemaining, ( unsigned int ), ( override ) );
    MOCK_METHOD( void, SetIsJumping, ( bool ), ( override ) );
 };

--- a/MegaManLofiTests/mock_PlayerPhysics.h
+++ b/MegaManLofiTests/mock_PlayerPhysics.h
@@ -9,6 +9,7 @@ class mock_PlayerPhysics : public MegaManLofi::PlayerPhysics
 {
 public:
    MOCK_METHOD( void, AssignTo, ( std::shared_ptr<MegaManLofi::Player> ), ( override ) );
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( void, Tick, (), ( override ) );
    MOCK_METHOD( void, PointTo, ( MegaManLofi::Direction ), ( const, override ) );
    MOCK_METHOD( void, PushTo, ( MegaManLofi::Direction ), ( const, override ) );

--- a/MegaManLofiTests/mock_ReadOnlyArena.h
+++ b/MegaManLofiTests/mock_ReadOnlyArena.h
@@ -7,6 +7,7 @@
 class mock_ReadOnlyArena : public MegaManLofi::ReadOnlyArena
 {
 public:
+   MOCK_METHOD( int, GetArenaId, ( ), ( const, override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyEntity>, GetEntity, ( int ), ( const, override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyEntity>, GetPlayerEntity, ( ), ( const, override ) );
    MOCK_METHOD( int, GetEntityCount, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_ReadOnlyStage.h
+++ b/MegaManLofiTests/mock_ReadOnlyStage.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <MegaManLofi/ReadOnlyStage.h>
+
+class mock_ReadOnlyStage : public MegaManLofi::ReadOnlyStage
+{
+public:
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyArena>, GetArena, ( int ), ( const, override ) );
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyArena>, GetActiveArena, ( ), ( const, override ) );
+};

--- a/MegaManLofiTests/mock_Stage.h
+++ b/MegaManLofiTests/mock_Stage.h
@@ -7,6 +7,10 @@
 class mock_Stage : public MegaManLofi::Stage
 {
 public:
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyArena>, GetArena, ( int ), ( const, override ) );
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::ReadOnlyArena>, GetActiveArena, ( ), ( const, override ) );
+
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::Arena>, GetMutableActiveArena, ( ), ( const, override ) );
    MOCK_METHOD( void, AddArena, ( std::shared_ptr<MegaManLofi::Arena> ), ( override ) );
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( void, SetActiveArena, ( int ), ( override ) );

--- a/MegaManLofiTests/mock_Stage.h
+++ b/MegaManLofiTests/mock_Stage.h
@@ -7,7 +7,7 @@
 class mock_Stage : public MegaManLofi::Stage
 {
 public:
-   MOCK_METHOD( void, AddArena, ( std::shared_ptr<MegaManLofi::ReadOnlyArena> ), ( override ) );
+   MOCK_METHOD( void, AddArena, ( std::shared_ptr<MegaManLofi::Arena> ), ( override ) );
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( void, SetActiveArena, ( int ), ( override ) );
 };

--- a/MegaManLofiTests/mock_Stage.h
+++ b/MegaManLofiTests/mock_Stage.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <MegaManLofi/Stage.h>
+
+class mock_Stage : public MegaManLofi::Stage
+{
+public:
+   MOCK_METHOD( void, AddArena, ( std::shared_ptr<MegaManLofi::ReadOnlyArena> ), ( override ) );
+   MOCK_METHOD( void, Reset, ( ), ( override ) );
+   MOCK_METHOD( void, SetActiveArena, ( int ), ( override ) );
+};


### PR DESCRIPTION
This just sets the groundwork, there's still only one `Arena`, but now it's part of a `Stage` object. There's also no indication of when a stage's arena has been switched, but that will come with a future update when more arenas are added.