### PR TITLE
Raise event when active arena changes

### DIFF
--- a/MegaManLofi/EntityConsoleSpriteRepository.cpp
+++ b/MegaManLofi/EntityConsoleSpriteRepository.cpp
@@ -2,7 +2,7 @@
 
 #include "EntityConsoleSpriteRepository.h"
 #include "GameEventAggregator.h"
-#include "ReadOnlyStage.h"
+#include "IArenaInfoProvider.h"
 #include "ReadOnlyArena.h"
 #include "EntityConsoleSpriteCopier.h"
 #include "ConsoleSpriteDefs.h"
@@ -13,10 +13,10 @@ using namespace std;
 using namespace MegaManLofi;
 
 EntityConsoleSpriteRepository::EntityConsoleSpriteRepository( const shared_ptr<GameEventAggregator> eventAggregator,
-                                                              const shared_ptr<ReadOnlyStage> stage,
+                                                              const shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                                               const shared_ptr<EntityConsoleSpriteCopier> spriteCopier,
                                                               const shared_ptr<ConsoleSpriteDefs> spriteDefs ) :
-   _stage( stage ),
+   _arenaInfoProvider( arenaInfoProvider ),
    _spriteCopier( spriteCopier ),
    _spriteDefs( spriteDefs )
 {
@@ -32,7 +32,7 @@ const shared_ptr<EntityConsoleSprite> EntityConsoleSpriteRepository::GetSprite( 
 
 void EntityConsoleSpriteRepository::HandleEntitySpawned()
 {
-   auto arena = _stage->GetActiveArena();
+   auto arena = _arenaInfoProvider->GetActiveArena();
 
    for ( int i = 0; i < arena->GetEntityCount(); i++ )
    {
@@ -56,7 +56,7 @@ void EntityConsoleSpriteRepository::HandleEntityDeSpawned()
 
    for ( auto [uniqueId, entity] : _spriteMap )
    {
-      if ( !_stage->GetActiveArena()->HasEntity( uniqueId ) )
+      if ( !_arenaInfoProvider->GetActiveArena()->HasEntity( uniqueId ) )
       {
          idsToRemove.push_back( uniqueId );
       }

--- a/MegaManLofi/EntityConsoleSpriteRepository.h
+++ b/MegaManLofi/EntityConsoleSpriteRepository.h
@@ -6,7 +6,7 @@
 namespace MegaManLofi
 {
    class GameEventAggregator;
-   class ReadOnlyStage;
+   class IArenaInfoProvider;
    class EntityConsoleSprite;
    class EntityConsoleSpriteCopier;
    class ConsoleSpriteDefs;
@@ -15,7 +15,7 @@ namespace MegaManLofi
    {
    public:
       EntityConsoleSpriteRepository( const std::shared_ptr<GameEventAggregator> eventAggregator,
-                                     const std::shared_ptr<ReadOnlyStage> stage,
+                                     const std::shared_ptr<IArenaInfoProvider> arenaInfoProvider,
                                      const std::shared_ptr<EntityConsoleSpriteCopier> spriteCopier,
                                      const std::shared_ptr<ConsoleSpriteDefs> spriteDefs );
 
@@ -28,7 +28,7 @@ namespace MegaManLofi
       void HandleEntitiesCleared();
 
    private:
-      const std::shared_ptr<ReadOnlyStage> _stage;
+      const std::shared_ptr<IArenaInfoProvider> _arenaInfoProvider;
       const std::shared_ptr<EntityConsoleSpriteCopier> _spriteCopier;
       const std::shared_ptr<ConsoleSpriteDefs> _spriteDefs;
 

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -33,6 +33,7 @@ Game::Game( const shared_ptr<GameEventAggregator> eventAggregator,
 {
    _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::KillPlayer, this ) );
    _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::KillPlayer, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::ActiveArenaChanged, std::bind( &Game::HandleActiveArenaChanged, this ) );
 }
 
 void Game::Tick()
@@ -210,4 +211,11 @@ void Game::KillPlayer()
    {
       _nextState = GameState::GameOver;
    }
+}
+
+void Game::HandleActiveArenaChanged()
+{
+   auto arena = _stage->GetMutableActiveArena();
+   arena->SetPlayerEntity( _player );
+   _arenaPhysics->AssignTo( arena );
 }

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -51,6 +51,7 @@ namespace MegaManLofi
       void OpenPlayingMenu();
       void ClosePlayingMenu();
       void KillPlayer();
+      void HandleActiveArenaChanged();
 
    private:
       const std::shared_ptr<GameEventAggregator> _eventAggregator;

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -14,6 +14,8 @@ namespace MegaManLofi
       ArenaEntityDeSpawned,
       ArenaEntitiesCleared,
 
+      ActiveArenaChanged,
+
       Pitfall,
       TileDeath
    };

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -120,7 +120,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // game objects
    auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );
-   auto stage = shared_ptr<Stage>( new Stage( gameDefs->StageDefs ) );
+   auto stage = shared_ptr<Stage>( new Stage( gameDefs->StageDefs, eventAggregator ) );
    for ( auto [arenaId, arenaDefs] : gameDefs->StageDefs->ArenaMap )
    {
       auto arena = shared_ptr<Arena>( new Arena( arenaDefs, gameDefs->WorldDefs, eventAggregator ) );

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -159,7 +159,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // rendering utilities
    auto spriteCopier = shared_ptr<EntityConsoleSpriteCopier>( new EntityConsoleSpriteCopier );
-   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, stage, spriteCopier, consoleRenderDefs->SpriteDefs ) );
+   auto spriteRepository = shared_ptr<EntityConsoleSpriteRepository>( new EntityConsoleSpriteRepository( eventAggregator, game, spriteCopier, consoleRenderDefs->SpriteDefs ) );
 
    // renderers objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs, game, spriteRepository ) );

--- a/MegaManLofi/Stage.cpp
+++ b/MegaManLofi/Stage.cpp
@@ -1,12 +1,15 @@
 #include "Stage.h"
 #include "StageDefs.h"
+#include "GameEventAggregator.h"
 #include "Arena.h"
 
 using namespace std;
 using namespace MegaManLofi;
 
-Stage::Stage( const shared_ptr<StageDefs> stageDefs ) :
-   _stageDefs( stageDefs )
+Stage::Stage( const shared_ptr<StageDefs> stageDefs,
+              const shared_ptr<GameEventAggregator> eventAggregator ) :
+   _stageDefs( stageDefs ),
+   _eventAggregator( eventAggregator )
 {
    _activeArenaId = _stageDefs->StartArenaId;
 }
@@ -18,8 +21,16 @@ void Stage::AddArena( std::shared_ptr<Arena> arena )
 
 void Stage::Reset()
 {
-   auto activeArena = static_pointer_cast<Arena>( GetActiveArena() );
-   activeArena->Clear();
-
+   _arenaMap[_activeArenaId]->Clear();
    _activeArenaId = _stageDefs->StartArenaId;
+}
+
+void Stage::SetActiveArena( int arenaId )
+{
+   if ( arenaId != _activeArenaId )
+   {
+      _arenaMap[_activeArenaId]->Clear();
+      _activeArenaId = arenaId;
+      _eventAggregator->RaiseEvent( GameEvent::ActiveArenaChanged );
+   }
 }

--- a/MegaManLofi/Stage.h
+++ b/MegaManLofi/Stage.h
@@ -5,19 +5,22 @@
 namespace MegaManLofi
 {
    class StageDefs;
+   class GameEventAggregator;
 
    class Stage : public ReadOnlyStage
    {
    public:
       Stage() { }
-      Stage( const std::shared_ptr<StageDefs> stageDefs );
+      Stage( const std::shared_ptr<StageDefs> stageDefs,
+             const std::shared_ptr<GameEventAggregator> eventAggregator );
 
       virtual const std::shared_ptr<Arena> GetMutableActiveArena() const { return _arenaMap.at( _activeArenaId ); }
       virtual void AddArena( std::shared_ptr<Arena> arena );
       virtual void Reset();
-      virtual void SetActiveArena( int arenaId ) { _activeArenaId = arenaId; }
+      virtual void SetActiveArena( int arenaId );
 
    private:
       const std::shared_ptr<StageDefs> _stageDefs;
+      const std::shared_ptr<GameEventAggregator> _eventAggregator;
    };
 }

--- a/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
+++ b/MegaManLofiTests/EntityConsoleSpriteRepositoryTests.cpp
@@ -5,7 +5,7 @@
 #include <MegaManLofi/ConsoleSpriteDefs.h>
 #include <MegaManLofi/GameEvent.h>
 
-#include "mock_ReadOnlyStage.h"
+#include "mock_ArenaInfoProvider.h"
 #include "mock_ReadOnlyArena.h"
 #include "mock_EntityConsoleSpriteCopier.h"
 #include "mock_ReadOnlyEntity.h"
@@ -21,7 +21,7 @@ public:
    void SetUp() override
    {
       _eventAggregator.reset( new GameEventAggregator );
-      _stageMock.reset( new NiceMock<mock_ReadOnlyStage> );
+      _arenaInfoProviderMock.reset( new NiceMock<mock_ArenaInfoProvider> );
       _arenaMock.reset( new NiceMock<mock_ReadOnlyArena> );
       _spriteCopier.reset( new NiceMock<mock_EntityConsoleSpriteCopier> );
       _spriteDefs.reset( new ConsoleSpriteDefs );
@@ -35,7 +35,7 @@ public:
       _spriteCopyMock2.reset( new NiceMock<mock_EntityConsoleSprite> );
       _spriteCopyMock3.reset( new NiceMock<mock_EntityConsoleSprite> );
 
-      ON_CALL( *_stageMock, GetActiveArena() ).WillByDefault( Return( _arenaMock ) );
+      ON_CALL( *_arenaInfoProviderMock, GetActiveArena() ).WillByDefault( Return( _arenaMock ) );
 
       ON_CALL( *_entityMock1, GetUniqueId() ).WillByDefault( Return( 10 ) );
       ON_CALL( *_entityMock1, GetEntityMetaId() ).WillByDefault( Return( 20 ) );
@@ -54,12 +54,12 @@ public:
       ON_CALL( *_spriteCopier, MakeCopy( static_pointer_cast<EntityConsoleSprite>( _spriteMock2 ) ) ).WillByDefault( Return( _spriteCopyMock2 ) );
       ON_CALL( *_spriteCopier, MakeCopy( static_pointer_cast<EntityConsoleSprite>( _spriteMock3 ) ) ).WillByDefault( Return( _spriteCopyMock3 ) );
 
-      _repository.reset( new EntityConsoleSpriteRepository( _eventAggregator, _stageMock, _spriteCopier, _spriteDefs ) );
+      _repository.reset( new EntityConsoleSpriteRepository( _eventAggregator, _arenaInfoProviderMock, _spriteCopier, _spriteDefs ) );
    }
 
 protected:
    shared_ptr<GameEventAggregator> _eventAggregator;
-   shared_ptr<mock_ReadOnlyStage> _stageMock;
+   shared_ptr<mock_ArenaInfoProvider> _arenaInfoProviderMock;
    shared_ptr<mock_ReadOnlyArena> _arenaMock;
    shared_ptr<mock_EntityConsoleSpriteCopier> _spriteCopier;
    shared_ptr<ConsoleSpriteDefs> _spriteDefs;

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -584,6 +584,17 @@ TEST_F( GameTests, EventHandling_TileDeathEventRaised_ChangesNextGameStateToGame
    EXPECT_EQ( _game->GetGameState(), GameState::GameOver );
 }
 
+TEST_F( GameTests, EventHandling_ActiveArenaChangedEventRaised_AssignsPlayerAndPhysicsToArena )
+{
+   auto eventAggregator = make_shared<GameEventAggregator>();
+   _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _playerPhysicsMock, _arenaPhysicsMock, _entityFactoryMock ) );
+
+   EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
+   EXPECT_CALL( *_arenaPhysicsMock, AssignTo( static_pointer_cast<Arena>( _arenaMock ) ) );
+
+   eventAggregator->RaiseEvent( GameEvent::ActiveArenaChanged );
+}
+
 TEST_F( GameTests, GetPlayer_Always_ReturnsPlayer )
 {
    BuildGame();

--- a/MegaManLofiTests/StageTests.cpp
+++ b/MegaManLofiTests/StageTests.cpp
@@ -9,12 +9,15 @@ using namespace std;
 using namespace testing;
 using namespace MegaManLofi;
 
+#include "mock_GameEventAggregator.h"
+
 class StageTests : public Test
 {
 public:
    void SetUp() override
    {
       _stageDefs.reset( new StageDefs );
+      _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _arenaMock1.reset( new NiceMock<mock_Arena> );
       _arenaMock2.reset( new NiceMock<mock_Arena> );
 
@@ -26,11 +29,12 @@ public:
 
    void BuildStage()
    {
-      _stage.reset( new Stage( _stageDefs ) );
+      _stage.reset( new Stage( _stageDefs, _eventAggregatorMock ) );
    }
 
 protected:
    shared_ptr<StageDefs> _stageDefs;
+   shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<mock_Arena> _arenaMock1;
    shared_ptr<mock_Arena> _arenaMock2;
 
@@ -79,4 +83,50 @@ TEST_F( StageTests, GetArena_Always_ReturnsCorrectArena )
 
    EXPECT_EQ( _stage->GetArena( 1 ), _arenaMock1 );
    EXPECT_EQ( _stage->GetArena( 2 ), _arenaMock2 );
+}
+
+TEST_F( StageTests, SetActiveArena_ActiveArenaDoesNotChange_DoesNotRaiseActiveArenaChangedEvent )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( _ ) ).Times( 0 );
+
+   _stage->SetActiveArena( 1 );
+}
+
+TEST_F( StageTests, SetActiveArena_ActiveArenaChanges_ClearsOldActiveArena )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock1 );
+
+   EXPECT_CALL( *_arenaMock1, Clear() );
+
+   _stage->SetActiveArena( 2 );
+}
+
+TEST_F( StageTests, SetActiveArena_ActiveArenaChanges_ChangesActiveArena )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock1 );
+
+   _stage->SetActiveArena( 2 );
+
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock2 );
+}
+
+TEST_F( StageTests, SetActiveArena_ActiveArenaChanges_RaisesActiveArenaChangedEvent )
+{
+   BuildStage();
+   _stage->AddArena( _arenaMock1 );
+   _stage->AddArena( _arenaMock2 );
+   EXPECT_EQ( _stage->GetActiveArena(), _arenaMock1 );
+
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ActiveArenaChanged ) );
+
+   _stage->SetActiveArena( 2 );
 }


### PR DESCRIPTION
The new event is `GameEvent::ActiveArenaChanged`, which `Stage` raises and `Game` picks up. Note that `EntityConsoleSpriteRepository` does not need to handle this event, because it will have already cleared its sprite list when `Stage` calls `Arena::Clear()`.

Eventually `Game` will do more in the handler for this event, but for now it hardly does anything, because there's only one Arena anyway.