### PR TITLE
Actually make use of the active region

### DIFF
--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -5,6 +5,7 @@
 #include "WorldDefs.h"
 #include "GameEventAggregator.h"
 #include "Entity.h"
+#include "RectangleUtilities.h"
 
 using namespace std;
 using namespace MegaManLofi;
@@ -69,5 +70,24 @@ void Arena::RemoveEntity( const std::shared_ptr<Entity> entity )
          _eventAggregator->RaiseEvent( GameEvent::ArenaEntityDeSpawned );
          break;
       }
+   }
+}
+
+void Arena::DeSpawnInactiveEntities()
+{
+   vector<shared_ptr<Entity>> entitiesToDeSpawn;
+
+   for ( auto entity : _entities )
+   {
+      if ( !RectangleUtilities::RectanglesIntersectF( entity->GetHitBox(), entity->GetArenaPositionLeft(), entity->GetArenaPositionTop(),
+                                                      _activeRegion, 0, 0 ) )
+      {
+         entitiesToDeSpawn.push_back( entity );
+      }
+   }
+
+   for ( auto entity : entitiesToDeSpawn )
+   {
+      RemoveEntity( entity );
    }
 }

--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -79,8 +79,8 @@ void Arena::DeSpawnInactiveEntities()
 
    for ( auto entity : _entities )
    {
-      if ( !RectangleUtilities::RectanglesIntersectF( entity->GetHitBox(), entity->GetArenaPositionLeft(), entity->GetArenaPositionTop(),
-                                                      _activeRegion, 0, 0 ) )
+      if ( !RectangleUtilities::RectanglesIntersectF( entity->GetHitBox(), entity->GetArenaPositionLeft(), entity->GetArenaPositionTop(), _activeRegion, 0, 0 ) &&
+           entity != _playerEntity )
       {
          entitiesToDeSpawn.push_back( entity );
       }

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -22,9 +22,10 @@ namespace MegaManLofi
       virtual const std::shared_ptr<Entity> GetMutableEntity( int index ) const { return _entities[index]; }
       virtual void SetArenaId( int id ) { _arenaId = id; }
       virtual void SetPlayerEntity( const std::shared_ptr<Entity> playerEntity );
-      virtual void SetActiveRegion( Quad<float> region ) { _activeRegion = region; }
+      virtual void SetActiveRegion( Rectangle<float> region ) { _activeRegion = region; }
       virtual void AddEntity( const std::shared_ptr<Entity> entity );
       virtual void RemoveEntity( const std::shared_ptr<Entity> entity );
+      virtual void DeSpawnInactiveEntities();
 
    private:
       const std::shared_ptr<ArenaDefs> _arenaDefs;

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -342,10 +342,23 @@ void ArenaPhysics::UpdateActiveRegion()
 {
    auto arena = _stage->GetMutableActiveArena();
    const auto& playerPosition = arena->GetPlayerEntity()->GetArenaPosition();
-   auto regionLeft = playerPosition.Left - ( _worldDefs->ActiveRegionWidth / 2 );
-   auto regionTop = playerPosition.Top - ( _worldDefs->ActiveRegionHeight / 2 );
+   auto regionLeft = max( 0.0f, playerPosition.Left - ( _worldDefs->ActiveRegionWidth / 2 ) );
+   auto regionTop = max( 0.0f, playerPosition.Top - ( _worldDefs->ActiveRegionHeight / 2 ) );
+   auto regionRight = regionLeft + _worldDefs->ActiveRegionWidth;
+   auto regionBottom = regionTop + _worldDefs->ActiveRegionHeight;
 
-   arena->SetActiveRegion( { regionLeft, regionTop, regionLeft + _worldDefs->ActiveRegionWidth, regionTop + _worldDefs->ActiveRegionHeight } );
+   if ( regionRight > arena->GetWidth() )
+   {
+      regionLeft = max( 0.0f, regionLeft - ( regionRight - arena->GetWidth() ) );
+      regionRight = arena->GetWidth();
+   }
+   if ( regionBottom > arena->GetHeight() )
+   {
+      regionTop = max( 0.0f, regionTop - ( regionBottom - arena->GetHeight() ) );
+      regionBottom = arena->GetHeight();
+   }
+
+   arena->SetActiveRegion( { regionLeft, regionTop, regionRight, regionBottom } );
 }
 
 bool ArenaPhysics::DetectTileDeath() const

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -23,23 +23,19 @@ ArenaPhysics::ArenaPhysics( const shared_ptr<IFrameRateProvider> frameRateProvid
 
 void ArenaPhysics::AssignTo( const shared_ptr<Stage> stage )
 {
-   _entityTileIndicesCache.clear();
+   Reset();
    _stage = stage;
-   UpdateEntityTileIndicesCaches();
+   
 }
 
 void ArenaPhysics::Reset()
 {
    _entityTileIndicesCache.clear();
-
-   if ( _stage )
-   {
-      UpdateEntityTileIndicesCaches();
-   }
 }
 
 void ArenaPhysics::Tick()
 {
+   UpdateEntityTileIndicesCaches();
    MoveEntities();
    UpdateActiveRegion();
    DetectTileDeath();
@@ -51,6 +47,10 @@ void ArenaPhysics::UpdateEntityTileIndicesCaches()
 
    for ( int i = 0; i < arena->GetEntityCount(); i++ )
    {
+      if ( arena->GetEntityCount() > 1 )
+      {
+         bool testing = true;
+      }
       UpdateEntityTileIndicesCache( arena->GetEntity( i ) );
    }
 }
@@ -306,6 +306,7 @@ bool ArenaPhysics::DetectPlayerCrossedPortal( Direction direction, const shared_
          auto newTopPosition = ( portal->ToTileOffset * _worldDefs->TileHeight) + ( topPosition - portalTop );
          entity->SetArenaPosition( { newLeftPosition, newTopPosition } );
          UpdateEntityTileIndicesCaches();
+         UpdateActiveRegion();
          return true;
       }
    }
@@ -322,6 +323,7 @@ bool ArenaPhysics::DetectPlayerCrossedPortal( Direction direction, const shared_
          auto newTopPosition = direction == Direction::Down ? 0 : _stage->GetActiveArena()->GetHeight() - entity->GetHitBox().Height;
          entity->SetArenaPosition( { newLeftPosition, newTopPosition } );
          UpdateEntityTileIndicesCaches();
+         UpdateActiveRegion();
          return true;
       }
    }

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -358,7 +358,7 @@ void ArenaPhysics::UpdateActiveRegion()
       regionBottom = arena->GetHeight();
    }
 
-   arena->SetActiveRegion( { regionLeft, regionTop, regionRight, regionBottom } );
+   arena->SetActiveRegion( { regionLeft, regionTop, regionRight - regionLeft, regionBottom - regionTop } );
 }
 
 bool ArenaPhysics::DetectTileDeath() const

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -49,6 +49,7 @@ void Game::Tick()
    {
       _playerPhysics->Tick();
       _arenaPhysics->Tick();
+      _stage->GetMutableActiveArena()->DeSpawnInactiveEntities();
    }
 }
 

--- a/MegaManLofi/ReadOnlyArena.h
+++ b/MegaManLofi/ReadOnlyArena.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "Quad.h"
+#include "Rectangle.h"
 #include "ArenaTile.h"
 
 namespace MegaManLofi
@@ -24,7 +24,7 @@ namespace MegaManLofi
       virtual float GetHeight() const { return _height; }
       virtual int GetHorizontalTiles() const { return _horizontalTiles; }
       virtual int GetVerticalTiles() const { return _verticalTiles; }
-      virtual const Quad<float>& GetActiveRegion() const { return _activeRegion; }
+      virtual const Rectangle<float>& GetActiveRegion() const { return _activeRegion; }
       virtual const ArenaTile& GetTile( int index ) const { return _tiles[index]; }
       virtual bool HasEntity( int uniqueId ) const;
 
@@ -37,6 +37,6 @@ namespace MegaManLofi
       float _height;
       int _horizontalTiles;
       int _verticalTiles;
-      Quad<float> _activeRegion;
+      Rectangle<float> _activeRegion;
    };
 }

--- a/MegaManLofi/RectangleUtilities.cpp
+++ b/MegaManLofi/RectangleUtilities.cpp
@@ -3,48 +3,24 @@
 using namespace std;
 using namespace MegaManLofi;
 
-bool RectangleUtilities::RectanglesIntersect( const Rectangle<float>& rect1, const Rectangle<float>& rect2 )
+bool RectangleUtilities::RectanglesIntersectF( const Rectangle<float>& r1, float r1LeftOffset, float r1TopOffset,
+                                               const Rectangle<float>& r2, float r2LeftOffset, float r2TopOffset )
 {
-   auto rect1Right = rect1.Left + rect1.Width;
-   auto rect2Right = rect2.Left + rect2.Width;
-   auto rect1Bottom = rect1.Top + rect1.Height;
-   auto rect2Bottom = rect2.Top + rect2.Height;
+   auto r1Left = r1.Left + r1LeftOffset;
+   auto r1Top = r1.Top + r1TopOffset;
+   auto r1Right = r1Left + r1.Width;
+   auto r1Bottom = r1Top + r1.Height;
 
-   bool leftInBounds = rect1.Left > rect2.Left && rect1Right < rect2Right;
-   bool rightInBounds = rect1Right > rect2.Left && rect1Right < rect2Right;
-   bool topInBounds = rect1.Top > rect2.Top && rect1.Top < rect2Bottom;
-   bool bottomInBounds = rect1Bottom > rect1.Top && rect1Bottom < rect2Bottom;
+   auto r2Left = r2.Left + r2LeftOffset;
+   auto r2Top = r2.Top + r2TopOffset;
+   auto r2Right = r2Left + r2.Width;
+   auto r2Bottom = r2Top + r2.Height;
+
+   bool leftInBounds = r1Left > r2Left && r1Right < r2Right;
+   bool rightInBounds = r1Right > r2Left && r1Right < r2Right;
+   bool topInBounds = r1Top > r2Top && r1Top < r2Bottom;
+   bool bottomInBounds = r1Bottom > r2Top && r1Bottom < r2Bottom;
 
    return ( leftInBounds && topInBounds ) || ( rightInBounds && topInBounds ) ||
           ( leftInBounds && bottomInBounds ) || ( rightInBounds && bottomInBounds );
-}
-
-void RectangleUtilities::UnclipHorizontal( Rectangle<float>& clippingRect, const Rectangle<float>& clippedRect )
-{
-   auto clippingRectMiddle = clippingRect.Left + ( clippingRect.Width / 2 );
-   auto clippedRectMiddle = clippedRect.Left + ( clippedRect.Width / 2 );
-
-   if ( clippingRectMiddle < clippedRectMiddle )
-   {
-      clippingRect.Left = clippedRect.Left - clippingRect.Width;
-   }
-   else
-   {
-      clippingRect.Left = clippedRect.Left + clippedRect.Width;
-   }
-}
-
-void RectangleUtilities::UnclipVertical( Rectangle<float>& clippingRect, const Rectangle<float>& clippedRect )
-{
-   auto clippingRectMiddle = clippingRect.Top + ( clippingRect.Height / 2 );
-   auto clippedRectMiddle = clippedRect.Top + ( clippedRect.Height / 2 );
-
-   if ( clippingRectMiddle < clippedRectMiddle )
-   {
-      clippingRect.Top = clippedRect.Top - clippingRect.Height;
-   }
-   else
-   {
-      clippingRect.Top = clippedRect.Top + clippedRect.Height;
-   }
 }

--- a/MegaManLofi/RectangleUtilities.h
+++ b/MegaManLofi/RectangleUtilities.h
@@ -7,9 +7,7 @@ namespace MegaManLofi
    class RectangleUtilities
    {
    public:
-      static bool RectanglesIntersect( const Rectangle<float>& rect1, const Rectangle<float>& rect2 );
-
-      static void UnclipHorizontal( Rectangle<float>& clippingRect, const Rectangle<float>& clippedRect );
-      static void UnclipVertical( Rectangle<float>& clippingRect, const Rectangle<float>& clippedRect );
+      static bool RectanglesIntersectF( const Rectangle<float>& r1, float r1LeftOffset, float r1TopOffset,
+                                        const Rectangle<float>& r2, float r2LeftOffset, float r2TopOffset );
    };
 }

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -277,7 +277,7 @@ TEST_F( ArenaTests, DeSpawnInactiveEntities_NoInactiveEntities_DoesNotDeSpawnEnt
    EXPECT_EQ( _arena->GetEntityCount(), 3 );
 }
 
-TEST_F( ArenaTests, DeSpawnInactiveEntities_InactiveEntitiesFound_DeSpawnsEntities )
+TEST_F( ArenaTests, DeSpawnInactiveEntities_InactiveEntitiesFound_DeSpawnsNonPlayerEntities )
 {
    Rectangle<float> playerHitBox = { 10, 10, 30, 30 };
    ON_CALL( *_playerMock, GetHitBox() ).WillByDefault( ReturnRef( playerHitBox ) );
@@ -294,10 +294,11 @@ TEST_F( ArenaTests, DeSpawnInactiveEntities_InactiveEntitiesFound_DeSpawnsEntiti
 
    _arena->SetActiveRegion( { 90, 105, 200, 200 } );
 
-   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntityDeSpawned ) ).Times( 2 );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntityDeSpawned ) );
 
    _arena->DeSpawnInactiveEntities();
 
-   EXPECT_EQ( _arena->GetEntityCount(), 1 );
-   EXPECT_EQ( _arena->GetEntity( 0 ), entityMock2 );
+   EXPECT_EQ( _arena->GetEntityCount(), 2 );
+   EXPECT_EQ( _arena->GetEntity( 0 ), _playerMock );
+   EXPECT_EQ( _arena->GetEntity( 1 ), entityMock2 );
 }

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -535,6 +535,7 @@ TEST_F( GameTests, Tick_GameStateIsPlayingAndNotPaused_DoesPlayerAndArenaActions
 
    EXPECT_CALL( *_playerPhysicsMock, Tick() );
    EXPECT_CALL( *_arenaPhysicsMock, Tick() );
+   EXPECT_CALL( *_arenaMock, DeSpawnInactiveEntities() );
 
    _game->Tick();
 }

--- a/MegaManLofiTests/RectangleUtilitiesTests.cpp
+++ b/MegaManLofiTests/RectangleUtilitiesTests.cpp
@@ -9,106 +9,130 @@ using namespace MegaManLofi;
 
 class RectangleUtilitiesTests : public Test { };
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarUpperLeft_ReturnsFalse )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperLeftNoOffsets_ReturnsFalse )
 {
    Rectangle<float> r1 { 0, 0, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarUpperRight_ReturnsFalse )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperRightNoOffsets_ReturnsFalse )
 {
    Rectangle<float> r1 { 10, 0, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarLowerRight_ReturnsFalse )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightNoOffsets_ReturnsFalse )
 {
    Rectangle<float> r1 { 10, 10, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_FarLowerLeft_ReturnsFalse )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerLeftNoOffsets_ReturnsFalse )
 {
    Rectangle<float> r1 { 0, 10, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_FALSE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_LowerRightIntersects_ReturnsTrue )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_LowerRightIntersectsNoOffsets_ReturnsTrue )
 {
    Rectangle<float> r1 { 1, 1, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_LowerLeftIntersects_ReturnsTrue )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_LowerLeftIntersectsNoOffsets_ReturnsTrue )
 {
    Rectangle<float> r1 { 9, 1, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_UpperRightIntersects_ReturnsTrue )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_UpperRightIntersectsNoOffsets_ReturnsTrue )
 {
    Rectangle<float> r1 { 1, 9, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, RectanglesIntersect_UpperLeftIntersects_ReturnsTrue )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_UpperLeftIntersectsNoOffsets_ReturnsTrue )
 {
    Rectangle<float> r1 { 9, 9, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   EXPECT_TRUE( RectangleUtilities::RectanglesIntersect( r1, r2 ) );
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheLeftSide_ClampsToTheLeftSide )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperLeftWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> clippingRect { 1, 1, 10, 10 };
-   Rectangle<float> clippedRect { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 0, 0, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   RectangleUtilities::UnclipHorizontal( clippingRect, clippedRect );
-
-   EXPECT_EQ( clippingRect.Left, 0 );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, UnclipHorizontal_OnTheRightSide_ClampsToTheRighttSide )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperRightWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> clippingRect { 19, 1, 10, 10 };
-   Rectangle<float> clippedRect { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 10, 0, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   RectangleUtilities::UnclipHorizontal( clippingRect, clippedRect );
-
-   EXPECT_EQ( clippingRect.Left, 20 );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, UnclipVertical_OnTheTopSide_ClampsToTheTopSide )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> clippingRect { 0, 1, 10, 10 };
-   Rectangle<float> clippedRect { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 10, 10, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   RectangleUtilities::UnclipVertical( clippingRect, clippedRect );
-
-   EXPECT_EQ( clippingRect.Top, 0 );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
 }
 
-TEST_F( RectangleUtilitiesTests, UnclipVertical_OnTheBottomSide_ClampsToTheBottomSide )
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerLeftWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> clippingRect { 0, 19, 10, 10 };
-   Rectangle<float> clippedRect { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 0, 10, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
 
-   RectangleUtilities::UnclipVertical( clippingRect, clippedRect );
+   EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
+}
 
-   EXPECT_EQ( clippingRect.Top, 20 );
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_LowerRightIntersectsWithOffsets_ReturnsTrue )
+{
+   Rectangle<float> r1 { 1, 1, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
+
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
+}
+
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_LowerLeftIntersectsWithOffsets_ReturnsTrue )
+{
+   Rectangle<float> r1 { 9, 1, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
+
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
+}
+
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_UpperRightIntersectsWithOffsets_ReturnsTrue )
+{
+   Rectangle<float> r1 { 1, 9, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
+
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
+}
+
+TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_UpperLeftIntersectsWithOffsets_ReturnsTrue )
+{
+   Rectangle<float> r1 { 9, 9, 10, 10 };
+   Rectangle<float> r2 { 10, 10, 10, 10 };
+
+   EXPECT_TRUE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
 }

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -15,7 +15,7 @@ public:
    MOCK_METHOD( float, GetHeight, ( ), ( const, override ) );
    MOCK_METHOD( int, GetHorizontalTiles, ( ), ( const, override ) );
    MOCK_METHOD( int, GetVerticalTiles, ( ), ( const, override ) );
-   MOCK_METHOD( const MegaManLofi::Quad<float>&, GetActiveRegion, ( ), ( const, override ) );
+   MOCK_METHOD( const MegaManLofi::Rectangle<float>&, GetActiveRegion, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::ArenaTile&, GetTile, ( int ), ( const, override ) );
    MOCK_METHOD( bool, HasEntity, ( int ), ( const, override ) );
 
@@ -23,7 +23,8 @@ public:
    MOCK_METHOD( void, Clear, ( ), ( override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::Entity>, GetMutableEntity, ( int ), ( const, override ) );
    MOCK_METHOD( void, SetPlayerEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
-   MOCK_METHOD( void, SetActiveRegion, ( MegaManLofi::Quad<float> ), ( override ) );
+   MOCK_METHOD( void, SetActiveRegion, ( MegaManLofi::Rectangle<float> ), ( override ) );
    MOCK_METHOD( void, AddEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
    MOCK_METHOD( void, RemoveEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
+   MOCK_METHOD( void, DeSpawnInactiveEntities, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_ReadOnlyArena.h
+++ b/MegaManLofiTests/mock_ReadOnlyArena.h
@@ -15,7 +15,7 @@ public:
    MOCK_METHOD( float, GetHeight, ( ), ( const, override ) );
    MOCK_METHOD( int, GetHorizontalTiles, ( ), ( const, override ) );
    MOCK_METHOD( int, GetVerticalTiles, ( ), ( const, override ) );
-   MOCK_METHOD( const MegaManLofi::Quad<float>&, GetActiveRegion, ( ), ( const, override ) );
+   MOCK_METHOD( const MegaManLofi::Rectangle<float>&, GetActiveRegion, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::ArenaTile&, GetTile, ( int ), ( const, override ) );
    MOCK_METHOD( bool, HasEntity, ( int ), ( const, override ) );
 };


### PR DESCRIPTION
This does two main things with the active region:

1) Makes sure it stays within the arena bounds, so it snaps to the edges but maintains its dimensions (and will shrink according to the arena bounds if necessary).
2) De-spawns any (non-player) entities outside of the active region.

Now bullets will de-spawn when they've left the screen. This will also eventually be useful for when enemies walk outside the active region.

I also fixed a tough bug where bullets would immediately de-spawn when you try to shoot them after switching arenas. It had something to do with when we update the tile indices caches, but I'm still not really sure exactly what. I think `ArenaPhysics` needs a serious refactor at some point, it's getting a little out of hand.