### PR TITLE
Basic Collision Detection

### DIFF
--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -114,9 +114,8 @@ void Arena::CheckSpawnPoints()
             spawnPoint->IsActive = true;
             spawnPoint->IntervalElapsedSeconds = 0;
 
-            if ( !spawnPoint->HasSpawned || spawnPoint->ReSpawns || spawnPoint->ReSpawnsAtInterval )
+            if ( !spawnPoint->IsDecommissioned )
             {
-               spawnPoint->HasSpawned = true;
                auto entity = _entityFactory->CreateEntity( spawnPoint->EntityMetaId, spawnPoint->Direction );
                entity->SetArenaPosition( spawnPoint->ArenaPosition );
                AddEntity( entity );

--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -105,6 +105,10 @@ void Arena::CheckSpawnPoints()
                   spawnPoint->IntervalElapsedSeconds = 0;
                   auto entity = _entityFactory->CreateEntity( spawnPoint->EntityMetaId, spawnPoint->Direction );
                   entity->SetArenaPosition( spawnPoint->ArenaPosition );
+                  if ( spawnPoint->IsBoundToUniqueId )
+                  {
+                     spawnPoint->UniqueIdBinding = entity->GetUniqueId();
+                  }
                   AddEntity( entity );
                }
             }
@@ -118,6 +122,10 @@ void Arena::CheckSpawnPoints()
             {
                auto entity = _entityFactory->CreateEntity( spawnPoint->EntityMetaId, spawnPoint->Direction );
                entity->SetArenaPosition( spawnPoint->ArenaPosition );
+               if ( spawnPoint->IsBoundToUniqueId )
+               {
+                  spawnPoint->UniqueIdBinding = entity->GetUniqueId();
+               }
                AddEntity( entity );
             }
          }

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -24,6 +24,8 @@ namespace MegaManLofi
       virtual void Reset();
 
       virtual const std::shared_ptr<Entity> GetMutableEntity( int index ) const { return _entities[index]; }
+      virtual int GetSpawnPointCount() const { return (int)_spawnPoints.size(); }
+      virtual const std::shared_ptr<SpawnPoint> GetSpawnPoint( int index ) const { return _spawnPoints[index]; }
       virtual void SetArenaId( int id ) { _arenaId = id; }
       virtual void SetPlayerEntity( const std::shared_ptr<Entity> playerEntity );
       virtual void SetActiveRegion( Rectangle<float> region ) { _activeRegion = region; }

--- a/MegaManLofi/Arena.h
+++ b/MegaManLofi/Arena.h
@@ -6,6 +6,7 @@ namespace MegaManLofi
 {
    class ArenaDefs;
    class WorldDefs;
+   class EntityDefs;
    class GameEventAggregator;
    class IFrameRateProvider;
    class EntityFactory;
@@ -16,6 +17,7 @@ namespace MegaManLofi
       Arena() { }
       Arena( const std::shared_ptr<ArenaDefs> arenaDefs,
              const std::shared_ptr<WorldDefs> worldDefs,
+             const std::shared_ptr<EntityDefs> entityDefs,
              const std::shared_ptr<GameEventAggregator> eventAggregator,
              const std::shared_ptr<IFrameRateProvider> frameRateProvider,
              const std::shared_ptr<EntityFactory> entityFactory );
@@ -34,9 +36,15 @@ namespace MegaManLofi
       virtual void RemoveEntity( const std::shared_ptr<Entity> entity );
       virtual void CheckSpawnPoints();
       virtual void DeSpawnInactiveEntities();
+      virtual void DetectEntityCollisions();
+
+   private:
+      void PlayerPickUpItem( const std::shared_ptr<Entity> player, const std::shared_ptr<Entity> item );
+      void EntityTakeHealthPayload( const std::shared_ptr<Entity> taker, const std::shared_ptr<Entity> giver );
 
    private:
       const std::shared_ptr<ArenaDefs> _arenaDefs;
+      const std::shared_ptr<EntityDefs> _entityDefs;
       const std::shared_ptr<GameEventAggregator> _eventAggregator;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
       const std::shared_ptr<EntityFactory> _entityFactory;

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -23,11 +23,13 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    arenaDefsMap[0]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[0]->SpawnPoints[0].EntityMetaId = 2;
    arenaDefsMap[0]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 4, worldDefs->TileHeight * 52 };
+   arenaDefsMap[0]->SpawnPoints[0].IsBoundToUniqueId = true;
 
    // large health drop at 306, 38
    arenaDefsMap[0]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[0]->SpawnPoints[1].EntityMetaId = 3;
    arenaDefsMap[0]->SpawnPoints[1].ArenaPosition = { worldDefs->TileWidth * 306, worldDefs->TileHeight * 38 };
+   arenaDefsMap[0]->SpawnPoints[1].IsBoundToUniqueId = true;
 
    /********************* ARENA 2 *********************/
 
@@ -42,6 +44,7 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    arenaDefsMap[1]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[1]->SpawnPoints[0].EntityMetaId = 3;
    arenaDefsMap[1]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 112, worldDefs->TileHeight * 24 };
+   arenaDefsMap[1]->SpawnPoints[0].IsBoundToUniqueId = true;
 
    /********************* ARENA 3 *********************/
 
@@ -56,6 +59,7 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    arenaDefsMap[2]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[2]->SpawnPoints[0].EntityMetaId = 3;
    arenaDefsMap[2]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 112, worldDefs->TileHeight * 6 };
+   arenaDefsMap[2]->SpawnPoints[0].IsBoundToUniqueId = true;
 
    return arenaDefsMap;
 }

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -22,13 +22,11 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    // small health drop at 4, 52
    arenaDefsMap[0]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[0]->SpawnPoints[0].EntityMetaId = 2;
-   arenaDefsMap[0]->SpawnPoints[0].ReSpawns = true;
    arenaDefsMap[0]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 4, worldDefs->TileHeight * 52 };
 
    // large health drop at 306, 38
    arenaDefsMap[0]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[0]->SpawnPoints[1].EntityMetaId = 3;
-   arenaDefsMap[0]->SpawnPoints[1].ReSpawns = true;
    arenaDefsMap[0]->SpawnPoints[1].ArenaPosition = { worldDefs->TileWidth * 306, worldDefs->TileHeight * 38 };
 
    /********************* ARENA 2 *********************/
@@ -43,7 +41,6 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    // large health drop at 112, 24
    arenaDefsMap[1]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[1]->SpawnPoints[0].EntityMetaId = 3;
-   arenaDefsMap[1]->SpawnPoints[0].ReSpawns = true;
    arenaDefsMap[1]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 112, worldDefs->TileHeight * 24 };
 
    /********************* ARENA 3 *********************/
@@ -58,7 +55,6 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    // large health drop at 112, 6
    arenaDefsMap[2]->SpawnPoints.push_back( SpawnPoint() );
    arenaDefsMap[2]->SpawnPoints[0].EntityMetaId = 3;
-   arenaDefsMap[2]->SpawnPoints[0].ReSpawns = true;
    arenaDefsMap[2]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 112, worldDefs->TileHeight * 6 };
 
    return arenaDefsMap;

--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -370,7 +370,7 @@ void ArenaPhysics::UpdateRegions()
       } );
 }
 
-bool ArenaPhysics::DetectTileDeath() const
+void ArenaPhysics::DetectTileDeath() const
 {
    auto arena = _stage->GetActiveArena();
    auto player = arena->GetPlayerEntity();
@@ -385,12 +385,10 @@ bool ArenaPhysics::DetectTileDeath() const
          if ( tile.CausesDeath )
          {
             _eventAggregator->RaiseEvent( GameEvent::TileDeath );
-            return true;
+            return;
          }
       }
    }
-
-   return false;
 }
 
 void ArenaPhysics::DetectEntityMovementType( const shared_ptr<Entity> entity ) const

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -40,7 +40,7 @@ namespace MegaManLofi
       void DetectEntityMovementType( const std::shared_ptr<Entity> entity ) const;
 
       void UpdateRegions();
-      bool DetectTileDeath() const;
+      void DetectTileDeath() const;
 
    private:
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;

--- a/MegaManLofi/Entity.h
+++ b/MegaManLofi/Entity.h
@@ -20,6 +20,7 @@ namespace MegaManLofi
       virtual void SetMaxGravityVelocity( float velocity ) { _maxGravityVelocity = velocity; }
       virtual void SetGravityAccelerationPerSecond( float acceleration ) { _gravityAccelerationPerSecond = acceleration; }
       virtual void SetFrictionDecelerationPerSecond( float deceleration ) { _frictionDecelerationPerSecond = deceleration; }
+      virtual void SetHealth( unsigned int health ) { _health = health; }
 
       virtual void StopX() { _velocityX = 0; }
       virtual void StopY() { _velocityY = 0; }

--- a/MegaManLofi/Entity.h
+++ b/MegaManLofi/Entity.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ReadOnlyEntity.h"
+#include "EntityCollisionPayload.h"
 
 namespace MegaManLofi
 {
@@ -22,5 +23,6 @@ namespace MegaManLofi
 
       virtual void StopX() { _velocityX = 0; }
       virtual void StopY() { _velocityY = 0; }
+      virtual bool TakeCollisionPayload( const EntityCollisionPayload& payload ) { return false; }
    };
 }

--- a/MegaManLofi/EntityCollisionPayload.h
+++ b/MegaManLofi/EntityCollisionPayload.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace MegaManLofi
+{
+   struct EntityCollisionPayload
+   {
+      unsigned int Health = 0;
+      unsigned int Lives = 0;
+   };
+}

--- a/MegaManLofi/EntityCollisionPayload.h
+++ b/MegaManLofi/EntityCollisionPayload.h
@@ -4,7 +4,7 @@ namespace MegaManLofi
 {
    struct EntityCollisionPayload
    {
-      unsigned int Health = 0;
-      unsigned int Lives = 0;
+      int Health = 0;
+      int Lives = 0;
    };
 }

--- a/MegaManLofi/EntityDefs.h
+++ b/MegaManLofi/EntityDefs.h
@@ -5,6 +5,7 @@
 #include "EntityType.h"
 #include "ItemInfo.h"
 #include "ProjectileInfo.h"
+#include "EntityCollisionPayload.h"
 
 namespace MegaManLofi
 {
@@ -16,5 +17,7 @@ namespace MegaManLofi
       std::map<int, EntityType> EntityTypeMap;
       std::map<int, ItemInfo> ItemInfoMap;
       std::map<int, ProjectileInfo> ProjectileInfoMap;
+
+      std::map<int, EntityCollisionPayload> CollisionPayloadMap;
    };
 }

--- a/MegaManLofi/EntityDefsGenerator.cpp
+++ b/MegaManLofi/EntityDefsGenerator.cpp
@@ -18,16 +18,19 @@ shared_ptr<EntityDefs> EntityDefsGenerator::GenerateEntityDefs()
    // bullet
    entityDefs->ProjectileInfoMap[1].HitBox = { 0, 0, 10, 10 }; // player is 152 x 234
    entityDefs->ProjectileInfoMap[1].Velocity = 2'500;
+   entityDefs->CollisionPayloadMap[1].Health = -10;
 
    // small health drop
    entityDefs->ItemInfoMap[2].HitBox = { 0, 0, 10, 10 };
    entityDefs->ItemInfoMap[2].MaxGravityVelocity = 4'000;
    entityDefs->ItemInfoMap[2].GravityAccelerationPerSecond = 10'000;
+   entityDefs->CollisionPayloadMap[2].Health = 10;
 
    // large health drop
    entityDefs->ItemInfoMap[3].HitBox = { 0, 0, 38, 78 }; // one full tile
    entityDefs->ItemInfoMap[3].MaxGravityVelocity = 4'000;
    entityDefs->ItemInfoMap[3].GravityAccelerationPerSecond = 10'000;
+   entityDefs->CollisionPayloadMap[3].Health = 25;
 
    return entityDefs;
 }

--- a/MegaManLofi/EntityPhysics.cpp
+++ b/MegaManLofi/EntityPhysics.cpp
@@ -56,7 +56,6 @@ void EntityPhysics::ApplyGravity( const shared_ptr<Entity> entity )
    }
 }
 
-// MUFFINS: test this
 void EntityPhysics::ApplyFriction( const shared_ptr<Entity> entity )
 {
    if ( entity->GetEntityType() == EntityType::Player && _frameActionRegistry->ActionFlagged( FrameAction::PlayerPushed ) )

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -150,6 +150,7 @@ void Game::StartGame()
 void Game::StartStage()
 {
    _player->ResetPosition();
+   _player->ResetHealth();
 
    auto arena = _stage->GetMutableActiveArena();
    arena->Reset();
@@ -213,6 +214,7 @@ void Game::ClosePlayingMenu()
 
 void Game::HandleEnvironmentDeath()
 {
+   _player->SetHealth( 0 );
    _player->SetLivesRemaining( _player->GetLivesRemaining() - 1 );
    HandleCollisionDeath();
 }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -55,6 +55,7 @@ void Game::Tick()
       _arenaPhysics->Tick();
 
       auto arena = _stage->GetMutableActiveArena();
+      arena->DetectEntityCollisions();
       arena->DeSpawnInactiveEntities();
       arena->CheckSpawnPoints();
    }

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -34,8 +34,9 @@ Game::Game( const shared_ptr<GameEventAggregator> eventAggregator,
    _isPaused( false ),
    _restartStageNextFrame( false )
 {
-   _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::KillPlayer, this ) );
-   _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::KillPlayer, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &Game::HandleEnvironmentDeath, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &Game::HandleEnvironmentDeath, this ) );
+   _eventAggregator->RegisterEventHandler( GameEvent::CollisionDeath, std::bind( &Game::HandleCollisionDeath, this ) );
    _eventAggregator->RegisterEventHandler( GameEvent::ActiveArenaChanged, std::bind( &Game::HandleActiveArenaChanged, this ) );
 }
 
@@ -209,10 +210,14 @@ void Game::ClosePlayingMenu()
    }
 }
 
-void Game::KillPlayer()
+void Game::HandleEnvironmentDeath()
 {
    _player->SetLivesRemaining( _player->GetLivesRemaining() - 1 );
+   HandleCollisionDeath();
+}
 
+void Game::HandleCollisionDeath()
+{
    if ( _player->GetLivesRemaining() > 0 )
    {
       _restartStageNextFrame = true;

--- a/MegaManLofi/Game.h
+++ b/MegaManLofi/Game.h
@@ -52,7 +52,8 @@ namespace MegaManLofi
       void TogglePause();
       void OpenPlayingMenu();
       void ClosePlayingMenu();
-      void KillPlayer();
+      void HandleEnvironmentDeath();
+      void HandleCollisionDeath();
       void HandleActiveArenaChanged();
 
    private:

--- a/MegaManLofi/GameEvent.h
+++ b/MegaManLofi/GameEvent.h
@@ -17,6 +17,7 @@ namespace MegaManLofi
       ActiveArenaChanged,
 
       Pitfall,
-      TileDeath
+      TileDeath,
+      CollisionDeath
    };
 }

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -121,7 +121,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
 
    // game objects
    auto entityFactory = shared_ptr<EntityFactory>( new EntityFactory( gameDefs->EntityDefs, uniqueNumberGenerator ) );
-   auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock ) );
+   auto player = shared_ptr<Player>( new Player( gameDefs->PlayerDefs, frameActionRegistry, clock, eventAggregator ) );
    auto stage = shared_ptr<Stage>( new Stage( gameDefs->StageDefs, eventAggregator ) );
    for ( auto [arenaId, arenaDefs] : gameDefs->StageDefs->ArenaMap )
    {

--- a/MegaManLofi/MegaManLofi.cpp
+++ b/MegaManLofi/MegaManLofi.cpp
@@ -125,7 +125,7 @@ void LoadAndRun( const shared_ptr<ConsoleBuffer> consoleBuffer )
    auto stage = shared_ptr<Stage>( new Stage( gameDefs->StageDefs, eventAggregator ) );
    for ( auto [arenaId, arenaDefs] : gameDefs->StageDefs->ArenaMap )
    {
-      auto arena = shared_ptr<Arena>( new Arena( arenaDefs, gameDefs->WorldDefs, eventAggregator, clock, entityFactory ) );
+      auto arena = shared_ptr<Arena>( new Arena( arenaDefs, gameDefs->WorldDefs, gameDefs->EntityDefs, eventAggregator, clock, entityFactory ) );
       arena->SetArenaId( arenaId );
       stage->AddArena( arena );
    }

--- a/MegaManLofi/MegaManLofi.vcxproj
+++ b/MegaManLofi/MegaManLofi.vcxproj
@@ -233,6 +233,7 @@
     <ClInclude Include="Coordinate.h" />
     <ClInclude Include="DiagnosticsConsoleRenderer.h" />
     <ClInclude Include="Direction.h" />
+    <ClInclude Include="EntityCollisionPayload.h" />
     <ClInclude Include="EntityConsoleSprite.h" />
     <ClInclude Include="EntityConsoleSpriteCopier.h" />
     <ClInclude Include="EntityDefs.h" />

--- a/MegaManLofi/MegaManLofi.vcxproj.filters
+++ b/MegaManLofi/MegaManLofi.vcxproj.filters
@@ -608,5 +608,8 @@
     <ClInclude Include="EntityPhysics.h">
       <Filter>Header Files\Physics</Filter>
     </ClInclude>
+    <ClInclude Include="EntityCollisionPayload.h">
+      <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -26,6 +26,7 @@ Player::Player( const shared_ptr<PlayerDefs> playerDefs,
    _pushAccelerationPerSecond = _playerDefs->PushAccelerationPerSecond;
    _jumpAccelerationPerSecond = _playerDefs->JumpAccelerationPerSecond;
    _maxJumpExtensionSeconds = _playerDefs->MaxJumpExtensionSeconds;
+   _maxHealth = _playerDefs->MaxHealth;
 
    Reset();
 }
@@ -33,6 +34,7 @@ Player::Player( const shared_ptr<PlayerDefs> playerDefs,
 void Player::Reset()
 {
    _livesRemaining = _playerDefs->DefaultLives;
+   _health = _maxHealth;
    ResetPosition();
 }
 

--- a/MegaManLofi/Player.cpp
+++ b/MegaManLofi/Player.cpp
@@ -52,6 +52,11 @@ void Player::ResetPosition()
    _lastExtendJumpFrame = 0;
 }
 
+void Player::ResetHealth()
+{
+   _health = _playerDefs->MaxHealth;
+}
+
 void Player::PushTo( Direction direction )
 {
    float velocityDelta = 0;

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -24,6 +24,7 @@ namespace MegaManLofi
 
       virtual void Reset();
       virtual void ResetPosition();
+      virtual void ResetHealth();
 
       virtual void SetLivesRemaining( unsigned int lives ) { _livesRemaining = lives; };
       virtual void PointTo( Direction direction ) { _direction = direction; }

--- a/MegaManLofi/Player.h
+++ b/MegaManLofi/Player.h
@@ -10,6 +10,7 @@ namespace MegaManLofi
    class PlayerDefs;
    class FrameActionRegistry;
    class IFrameRateProvider;
+   class GameEventAggregator;
 
    class Player : public ReadOnlyPlayer,
                   public Entity
@@ -18,7 +19,8 @@ namespace MegaManLofi
       Player() { }
       Player( const std::shared_ptr<PlayerDefs> playerDefs,
               const std::shared_ptr<FrameActionRegistry> frameActionRegistry,
-              const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+              const std::shared_ptr<IFrameRateProvider> frameRateProvider,
+              const std::shared_ptr<GameEventAggregator> eventAggregator );
 
       virtual void Reset();
       virtual void ResetPosition();
@@ -30,10 +32,12 @@ namespace MegaManLofi
       virtual void ExtendJump();
 
       virtual void StopY() override;
+      virtual bool TakeCollisionPayload( const EntityCollisionPayload& payload ) override;
 
    private:
       const std::shared_ptr<PlayerDefs> _playerDefs;
       const std::shared_ptr<FrameActionRegistry> _frameActionRegistry;
       const std::shared_ptr<IFrameRateProvider> _frameRateProvider;
+      const std::shared_ptr<GameEventAggregator> _eventAggregator;
    };
 }

--- a/MegaManLofi/PlayerDefs.h
+++ b/MegaManLofi/PlayerDefs.h
@@ -25,6 +25,7 @@ namespace MegaManLofi
       float MaxJumpExtensionSeconds = 0;
 
       unsigned int DefaultLives = 0;
+      unsigned int MaxHealth = 0;
       Direction DefaultDirection = (Direction)0;
       Rectangle<float> DefaultHitBox = { 0, 0, 0, 0 };
       MovementType DefaultMovementType = (MovementType)0;

--- a/MegaManLofi/PlayerDefsGenerator.cpp
+++ b/MegaManLofi/PlayerDefsGenerator.cpp
@@ -29,6 +29,7 @@ shared_ptr<PlayerDefs> PlayerDefsGenerator::GeneratePlayerDefs( const shared_ptr
    playerDefs->MaxJumpExtensionSeconds = .25f;
 
    playerDefs->DefaultLives = 3;
+   playerDefs->MaxHealth = 100;
    playerDefs->DefaultDirection = Direction::Right;
    playerDefs->DefaultMovementType = MovementType::Standing;
 

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -262,12 +262,30 @@ void PlayingStateConsoleRenderer::DrawEntity( const shared_ptr<ReadOnlyEntity> e
 void PlayingStateConsoleRenderer::DrawStatusBar()
 {
    auto player = _playerInfoProvider->GetPlayer();
+   auto playerEntity = _playerInfoProvider->GetPlayerEntity();
    auto left = _renderDefs->ArenaStatusBarLeftChars + 2;
    auto top = _renderDefs->ArenaStatusBarTopChars;
 
    _consoleBuffer->Draw( left, top, format( "Lives:  {}", player->GetLivesRemaining() ) );
-   _consoleBuffer->Draw( left, top + 1, "Health: ||||||||||||||||||||||||||" );
-   _consoleBuffer->Draw( left + 34, top + 1, "|||||", ConsoleColor::DarkGrey );
+
+   top++;
+   _consoleBuffer->Draw( left, top, "Health: " );
+   left += 8;
+
+   int totalHealthBars = 30;
+   int healthyBars = totalHealthBars * ( playerEntity->GetHealth() / (float)playerEntity->GetMaxHealth() );
+   int unHealthyBars = totalHealthBars - healthyBars;
+   
+   for ( int i = 0; i < healthyBars; i++ )
+   {
+      _consoleBuffer->Draw( left, top, '|', ConsoleColor::White );
+      left++;
+   }
+   for ( int i = 0; i < unHealthyBars; i++ )
+   {
+      _consoleBuffer->Draw( left, top, '|', ConsoleColor::DarkGrey );
+      left++;
+   }
 }
 
 void PlayingStateConsoleRenderer::DrawPauseOverlay()

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -49,7 +49,8 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<Conso
 {
    eventAggregator->RegisterEventHandler( GameEvent::StageStarted, std::bind( &PlayingStateConsoleRenderer::HandleStageStartedEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::Pitfall, std::bind( &PlayingStateConsoleRenderer::HandlePitfallEvent, this ) );
-   eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &PlayingStateConsoleRenderer::HandleTileDeathEvent, this ) );
+   eventAggregator->RegisterEventHandler( GameEvent::TileDeath, std::bind( &PlayingStateConsoleRenderer::HandleCollisionDeathEvent, this ) );
+   eventAggregator->RegisterEventHandler( GameEvent::CollisionDeath, std::bind( &PlayingStateConsoleRenderer::HandleCollisionDeathEvent, this ) );
 }
 
 void PlayingStateConsoleRenderer::Render()
@@ -114,7 +115,7 @@ void PlayingStateConsoleRenderer::HandlePitfallEvent()
    _pitfallAnimationElapsedSeconds = 0;
 }
 
-void PlayingStateConsoleRenderer::HandleTileDeathEvent()
+void PlayingStateConsoleRenderer::HandleCollisionDeathEvent()
 {
    const auto& hitBox = _playerInfoProvider->GetPlayerEntity()->GetHitBox();
    auto particleStartLeftChars = _playerViewportChars.Left + (short)( hitBox.Width / 2 / _renderDefs->ArenaCharWidth ) + _viewportOffsetChars.Left;

--- a/MegaManLofi/PlayingStateConsoleRenderer.cpp
+++ b/MegaManLofi/PlayingStateConsoleRenderer.cpp
@@ -273,7 +273,7 @@ void PlayingStateConsoleRenderer::DrawStatusBar()
    left += 8;
 
    int totalHealthBars = 30;
-   int healthyBars = totalHealthBars * ( playerEntity->GetHealth() / (float)playerEntity->GetMaxHealth() );
+   auto healthyBars = (int)( totalHealthBars * ( playerEntity->GetHealth() / (float)playerEntity->GetMaxHealth() ) );
    int unHealthyBars = totalHealthBars - healthyBars;
    
    for ( int i = 0; i < healthyBars; i++ )

--- a/MegaManLofi/PlayingStateConsoleRenderer.h
+++ b/MegaManLofi/PlayingStateConsoleRenderer.h
@@ -41,7 +41,7 @@ namespace MegaManLofi
    private:
       void HandleStageStartedEvent();
       void HandlePitfallEvent();
-      void HandleTileDeathEvent();
+      void HandleCollisionDeathEvent();
 
       void UpdateCaches();
 

--- a/MegaManLofi/ReadOnlyEntity.cpp
+++ b/MegaManLofi/ReadOnlyEntity.cpp
@@ -15,5 +15,7 @@ ReadOnlyEntity::ReadOnlyEntity() :
    _maxGravityVelocity( 0 ),
    _gravityAccelerationPerSecond( 0 ),
    _frictionDecelerationPerSecond( 0 )
+   _health( 0 ),
+   _maxHealth( 0 )
 {
 }

--- a/MegaManLofi/ReadOnlyEntity.cpp
+++ b/MegaManLofi/ReadOnlyEntity.cpp
@@ -14,7 +14,7 @@ ReadOnlyEntity::ReadOnlyEntity() :
    _movementType( (MovementType)0 ),
    _maxGravityVelocity( 0 ),
    _gravityAccelerationPerSecond( 0 ),
-   _frictionDecelerationPerSecond( 0 )
+   _frictionDecelerationPerSecond( 0 ),
    _health( 0 ),
    _maxHealth( 0 )
 {

--- a/MegaManLofi/ReadOnlyEntity.h
+++ b/MegaManLofi/ReadOnlyEntity.h
@@ -27,6 +27,8 @@ namespace MegaManLofi
       virtual float GetMaxGravityVelocity() const { return _maxGravityVelocity; }
       virtual float GetGravityAccelerationPerSecond() const { return _gravityAccelerationPerSecond; }
       virtual float GetFrictionDecelerationPerSecond() const { return _frictionDecelerationPerSecond; }
+      virtual unsigned int GetHealth() const { return _health; }
+      virtual unsigned int GetMaxHealth() const { return _maxHealth; }
 
    protected:
       int _uniqueId;
@@ -41,5 +43,7 @@ namespace MegaManLofi
       float _maxGravityVelocity;
       float _gravityAccelerationPerSecond;
       float _frictionDecelerationPerSecond;
+      unsigned int _health;
+      unsigned int _maxHealth;
    };
 }

--- a/MegaManLofi/RectangleUtilities.cpp
+++ b/MegaManLofi/RectangleUtilities.cpp
@@ -16,13 +16,7 @@ bool RectangleUtilities::RectanglesIntersectF( const Rectangle<float>& r1, float
    auto r2Right = r2Left + r2.Width;
    auto r2Bottom = r2Top + r2.Height;
 
-   bool leftInBounds = r1Left > r2Left && r1Right < r2Right;
-   bool rightInBounds = r1Right > r2Left && r1Right < r2Right;
-   bool topInBounds = r1Top > r2Top && r1Top < r2Bottom;
-   bool bottomInBounds = r1Bottom > r2Top && r1Bottom < r2Bottom;
-
-   return ( leftInBounds && topInBounds ) || ( rightInBounds && topInBounds ) ||
-          ( leftInBounds && bottomInBounds ) || ( rightInBounds && bottomInBounds );
+   return r1Left < r2Right && r1Right > r2Left && r1Top < r2Bottom && r1Bottom > r2Top;
 }
 
 bool RectangleUtilities::CoordinateInRectangleF( const Coordinate<float>& c, float cLeftOffset, float cTopOffset,

--- a/MegaManLofi/SpawnPoint.h
+++ b/MegaManLofi/SpawnPoint.h
@@ -11,8 +11,7 @@ namespace MegaManLofi
       Coordinate<float> ArenaPosition;
       Direction Direction;
       bool IsActive = false;
-      bool HasSpawned = false;
-      bool ReSpawns = false;
+      bool IsDecommissioned = false;
       bool ReSpawnsAtInterval = false;
       float ReSpawnIntervalSeconds = 0;
       float IntervalElapsedSeconds = 0;

--- a/MegaManLofi/SpawnPoint.h
+++ b/MegaManLofi/SpawnPoint.h
@@ -15,5 +15,7 @@ namespace MegaManLofi
       bool ReSpawnsAtInterval = false;
       float ReSpawnIntervalSeconds = 0;
       float IntervalElapsedSeconds = 0;
+      bool IsBoundToUniqueId = false;
+      int UniqueIdBinding = -1;
    };
 }

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -286,7 +286,6 @@ TEST_F( ArenaTests, CheckSpawnPoints_InactivePointIsNotDecommissioned_SpawnsEnti
    _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
    _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
    _arenaDefs->SpawnPoints[0].IsActive = false;
-   _arenaDefs->SpawnPoints[0].IsDecommissioned = false;
    _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
    _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
    BuildArena();
@@ -301,6 +300,28 @@ TEST_F( ArenaTests, CheckSpawnPoints_InactivePointIsNotDecommissioned_SpawnsEnti
 
    EXPECT_EQ( entityPosition.Left, 1 );
    EXPECT_EQ( entityPosition.Top, 1 );
+   EXPECT_EQ( _arena->GetEntityCount(), 2 );
+   EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
+}
+
+TEST_F( ArenaTests, CheckSpawnPoints_InactivePointIsBoundToUniqueId_BindsToUniqueId )
+{
+   _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
+   _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
+   _arenaDefs->SpawnPoints[0].IsActive = false;
+   _arenaDefs->SpawnPoints[0].IsBoundToUniqueId = true;
+   _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
+   _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
+   BuildArena();
+
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   EXPECT_CALL( *_entityFactoryMock, CreateEntity( 5, Direction::Down ) ).WillOnce( Return( entityMock ) );
+   EXPECT_CALL( *entityMock, GetUniqueId() ).WillOnce( Return( 6 ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) );
+
+   _arena->CheckSpawnPoints();
+
+   EXPECT_EQ( _arena->GetSpawnPoint( 0 )->UniqueIdBinding, 6 );
    EXPECT_EQ( _arena->GetEntityCount(), 2 );
    EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
 }
@@ -368,6 +389,31 @@ TEST_F( ArenaTests, CheckSpawnPoints_ActivePointReSpawnIntervalElapased_SpawnsEn
    _arena->CheckSpawnPoints();
    EXPECT_EQ( entityPosition.Left, 1 );
    EXPECT_EQ( entityPosition.Top, 1 );
+   EXPECT_EQ( _arena->GetEntityCount(), 2 );
+   EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
+}
+
+TEST_F( ArenaTests, CheckSpawnPoints_ActivePointIsBoundToUniqueId_BindsToUniqueId )
+{
+   _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
+   _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
+   _arenaDefs->SpawnPoints[0].IsActive = true;
+   _arenaDefs->SpawnPoints[0].IsBoundToUniqueId = true;
+   _arenaDefs->SpawnPoints[0].ReSpawnsAtInterval = true;
+   _arenaDefs->SpawnPoints[0].ReSpawnIntervalSeconds = 5;
+   _arenaDefs->SpawnPoints[0].IntervalElapsedSeconds = 4.1f;
+   _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
+   _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
+   BuildArena();
+
+   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
+   EXPECT_CALL( *_entityFactoryMock, CreateEntity( 5, Direction::Down ) ).WillOnce( Return( entityMock ) );
+   EXPECT_CALL( *entityMock, GetUniqueId() ).WillOnce( Return( 7 ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) );
+
+   _arena->CheckSpawnPoints();
+
+   EXPECT_EQ( _arena->GetSpawnPoint( 0 )->UniqueIdBinding, 7 );
    EXPECT_EQ( _arena->GetEntityCount(), 2 );
    EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
 }

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -281,12 +281,12 @@ TEST_F( ArenaTests, RemoveEntity_EntityIsInList_RaisesArenaEntityDeSpawnedEvent 
    _arena->RemoveEntity( entityMock2 );
 }
 
-TEST_F( ArenaTests, CheckSpawnPoints_InactivePointHasNotSpawned_SpawnsEntity )
+TEST_F( ArenaTests, CheckSpawnPoints_InactivePointIsNotDecommissioned_SpawnsEntity )
 {
    _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
    _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
    _arenaDefs->SpawnPoints[0].IsActive = false;
-   _arenaDefs->SpawnPoints[0].HasSpawned = false;
+   _arenaDefs->SpawnPoints[0].IsDecommissioned = false;
    _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
    _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
    BuildArena();
@@ -305,71 +305,18 @@ TEST_F( ArenaTests, CheckSpawnPoints_InactivePointHasNotSpawned_SpawnsEntity )
    EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
 }
 
-TEST_F( ArenaTests, CheckSpawnPoints_InactivePointHasSpawnedAndDoesNotReSpawn_DoesNotSpawnEntity )
+TEST_F( ArenaTests, CheckSpawnPoints_InactivePointIsDecommissioned_DoesNotSpawnEntity )
 {
    _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
    _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
    _arenaDefs->SpawnPoints[0].IsActive = false;
-   _arenaDefs->SpawnPoints[0].HasSpawned = true;
-   _arenaDefs->SpawnPoints[0].ReSpawns = false;
+   _arenaDefs->SpawnPoints[0].IsDecommissioned = true;
    _arenaDefs->SpawnPoints[0].ReSpawnsAtInterval = false;
    BuildArena();
 
    EXPECT_CALL( *_entityFactoryMock, CreateEntity( _, _ ) ).Times( 0 );
 
    _arena->CheckSpawnPoints();
-}
-
-TEST_F( ArenaTests, CheckSpawnPoints_InactivePointHasSpawnedAndReSpawns_SpawnsEntity )
-{
-   _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
-   _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
-   _arenaDefs->SpawnPoints[0].IsActive = false;
-   _arenaDefs->SpawnPoints[0].HasSpawned = true;
-   _arenaDefs->SpawnPoints[0].ReSpawns = true;
-   _arenaDefs->SpawnPoints[0].ReSpawnsAtInterval = false;
-   _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
-   _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
-   BuildArena();
-
-   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
-   EXPECT_CALL( *_entityFactoryMock, CreateEntity( 5, Direction::Down ) ).WillOnce( Return( entityMock ) );
-   Coordinate<float> entityPosition;
-   EXPECT_CALL( *entityMock, SetArenaPosition( _ ) ).WillOnce( SaveArg<0>( &entityPosition ) );
-   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) );
-
-   _arena->CheckSpawnPoints();
-
-   EXPECT_EQ( entityPosition.Left, 1 );
-   EXPECT_EQ( entityPosition.Top, 1 );
-   EXPECT_EQ( _arena->GetEntityCount(), 2 );
-   EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
-}
-
-TEST_F( ArenaTests, CheckSpawnPoints_InactivePointHasSpawnedAndReSpawnsAtInterval_SpawnsEntity )
-{
-   _arenaDefs->SpawnPoints.push_back( SpawnPoint() );
-   _arenaDefs->SpawnPoints[0].ArenaPosition = { 1, 1 };
-   _arenaDefs->SpawnPoints[0].IsActive = false;
-   _arenaDefs->SpawnPoints[0].HasSpawned = true;
-   _arenaDefs->SpawnPoints[0].ReSpawns = false;
-   _arenaDefs->SpawnPoints[0].ReSpawnsAtInterval = true;
-   _arenaDefs->SpawnPoints[0].EntityMetaId = 5;
-   _arenaDefs->SpawnPoints[0].Direction = Direction::Down;
-   BuildArena();
-
-   auto entityMock = shared_ptr<mock_Entity>( new NiceMock<mock_Entity> );
-   EXPECT_CALL( *_entityFactoryMock, CreateEntity( 5, Direction::Down ) ).WillOnce( Return( entityMock ) );
-   Coordinate<float> entityPosition;
-   EXPECT_CALL( *entityMock, SetArenaPosition( _ ) ).WillOnce( SaveArg<0>( &entityPosition ) );
-   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ArenaEntitySpawned ) );
-
-   _arena->CheckSpawnPoints();
-
-   EXPECT_EQ( entityPosition.Left, 1 );
-   EXPECT_EQ( entityPosition.Top, 1 );
-   EXPECT_EQ( _arena->GetEntityCount(), 2 );
-   EXPECT_EQ( _arena->GetEntity( 1 ), entityMock );
 }
 
 TEST_F( ArenaTests, CheckSpawnPoints_ActivePointDoesNotReSpawnAtInterval_DoesNotSpawnEntity )

--- a/MegaManLofiTests/EntityTests.cpp
+++ b/MegaManLofiTests/EntityTests.cpp
@@ -57,3 +57,10 @@ TEST_F( EntityTests, Setters_Always_SetsPropertyValues )
    EXPECT_EQ( entity->GetHitBox().Height, 9 );
    EXPECT_EQ( entity->GetMovementType(), MovementType::Airborne );
 }
+
+TEST_F( EntityTests, TakeCollisionPayload_Always_ReturnsFalse )
+{
+   auto entity = make_shared<Entity>();
+
+   EXPECT_FALSE( entity->TakeCollisionPayload( EntityCollisionPayload() ) );
+}

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -553,6 +553,7 @@ TEST_F( GameTests, Tick_GameStateIsPlayingAndNotPaused_DoesEntityAndArenaActions
 
    EXPECT_CALL( *_entityPhysicsMock, Tick() );
    EXPECT_CALL( *_arenaPhysicsMock, Tick() );
+   EXPECT_CALL( *_arenaMock, DetectEntityCollisions() );
    EXPECT_CALL( *_arenaMock, DeSpawnInactiveEntities() );
    EXPECT_CALL( *_arenaMock, CheckSpawnPoints() );
 

--- a/MegaManLofiTests/GameTests.cpp
+++ b/MegaManLofiTests/GameTests.cpp
@@ -121,6 +121,7 @@ TEST_F( GameTests, ExecuteCommand_StartStage_ResetsGameObjects )
    _game->ExecuteCommand( GameCommand::StartGame );
 
    EXPECT_CALL( *_playerMock, ResetPosition() );
+   EXPECT_CALL( *_playerMock, ResetHealth() );
    EXPECT_CALL( *_arenaMock, Reset() );
    EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );
@@ -519,6 +520,7 @@ TEST_F( GameTests, Tick_RestartingStageNextFrame_ResetsGameObjects )
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
 
    EXPECT_CALL( *_playerMock, ResetPosition() );
+   EXPECT_CALL( *_playerMock, ResetHealth() );
    EXPECT_CALL( *_arenaMock, Reset() );
    EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );
@@ -565,6 +567,7 @@ TEST_F( GameTests, EventHandling_PitfallEventRaisedWithLivesLeft_DecrementsPlaye
    auto eventAggregator = make_shared<GameEventAggregator>();
    _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _entityPhysicsMock, _arenaPhysicsMock, _entityFactoryMock, _entityDefs ) );
 
+   EXPECT_CALL( *_playerMock, SetHealth( 0 ) );
    EXPECT_CALL( *_playerMock, SetLivesRemaining( 4 ) );
 
    eventAggregator->RaiseEvent( GameEvent::Pitfall );
@@ -577,6 +580,8 @@ TEST_F( GameTests, EventHandling_PitfallEventRaisedWithNoLivesLeft_ChangesNextGa
    auto eventAggregator = make_shared<GameEventAggregator>();
    _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _entityPhysicsMock, _arenaPhysicsMock, _entityFactoryMock, _entityDefs ) );
 
+   EXPECT_CALL( *_playerMock, SetHealth( 0 ) );
+
    eventAggregator->RaiseEvent( GameEvent::Pitfall );
    _game->Tick();
 
@@ -588,6 +593,7 @@ TEST_F( GameTests, EventHandling_TileDeathEventRaisedWithLivesLeft_DecrementsPla
    auto eventAggregator = make_shared<GameEventAggregator>();
    _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _entityPhysicsMock, _arenaPhysicsMock, _entityFactoryMock, _entityDefs ) );
 
+   EXPECT_CALL( *_playerMock, SetHealth( 0 ) );
    EXPECT_CALL( *_playerMock, SetLivesRemaining( 4 ) );
 
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
@@ -599,6 +605,8 @@ TEST_F( GameTests, EventHandling_TileDeathEventRaisedWithNoLivesLeft_ChangesNext
    ON_CALL( *_playerMock, GetLivesRemaining() ).WillByDefault( Return( 0 ) );
    auto eventAggregator = make_shared<GameEventAggregator>();
    _game.reset( new Game( eventAggregator, _playerMock, _stageMock, _entityPhysicsMock, _arenaPhysicsMock, _entityFactoryMock, _entityDefs ) );
+
+   EXPECT_CALL( *_playerMock, SetHealth( 0 ) );
 
    eventAggregator->RaiseEvent( GameEvent::TileDeath );
    _game->Tick();
@@ -614,6 +622,7 @@ TEST_F( GameTests, EventHandling_CollisionDeathEventRaisedWithLivesLeft_Restarts
    eventAggregator->RaiseEvent( GameEvent::CollisionDeath );
 
    EXPECT_CALL( *_playerMock, ResetPosition() );
+   EXPECT_CALL( *_playerMock, ResetHealth() );
    EXPECT_CALL( *_arenaMock, Reset() );
    EXPECT_CALL( *_arenaMock, SetPlayerEntity( static_pointer_cast<Entity>( _playerMock ) ) );
    EXPECT_CALL( *_arenaPhysicsMock, Reset() );

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -143,6 +143,16 @@ TEST_F( PlayerTests, ResetPosition_Always_ResetsPositionPropertiesFromDefs )
    EXPECT_EQ( _player->GetMovementType(), MovementType::Airborne );
 }
 
+TEST_F( PlayerTests, ResetHealth_Always_ResetsHealthToMaximum )
+{
+   BuildPlayer();
+   _player->SetHealth( 3 );
+
+   _player->ResetHealth();
+
+   EXPECT_EQ( _player->GetHealth(), 100 );
+}
+
 TEST_F( PlayerTests, GetLivesRemaining_Always_ReturnsLivesRemaining )
 {
    BuildPlayer();

--- a/MegaManLofiTests/PlayerTests.cpp
+++ b/MegaManLofiTests/PlayerTests.cpp
@@ -35,6 +35,7 @@ public:
       _playerDefs->JumpAccelerationPerSecond = 1;
       _playerDefs->MaxJumpExtensionSeconds = 0.25f;
       _playerDefs->DefaultLives = 5;
+      _playerDefs->MaxHealth = 100;
       _playerDefs->DefaultDirection = Direction::Left;
       _playerDefs->DefaultHitBox = { 0, 0, 4, 4 };
       _playerDefs->DefaultMovementType = MovementType::Airborne;
@@ -62,6 +63,7 @@ TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromDefs )
    _playerDefs->DefaultVelocityX = 100;
    _playerDefs->DefaultVelocityY = 200;
    _playerDefs->DefaultLives = 10;
+   _playerDefs->MaxHealth = 40;
    _playerDefs->DefaultDirection = Direction::Right;
    _playerDefs->DefaultHitBox = { 1, 2, 3, 4 };
    BuildPlayer();
@@ -76,6 +78,8 @@ TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromDefs )
    EXPECT_EQ( _player->GetGravityAccelerationPerSecond(), 100 );
    EXPECT_EQ( _player->GetFrictionDecelerationPerSecond(), 200 );
    EXPECT_EQ( _player->GetLivesRemaining(), 10 );
+   EXPECT_EQ( _player->GetHealth(), 40 );
+   EXPECT_EQ( _player->GetMaxHealth(), 40 );
    EXPECT_EQ( _player->GetDirection(), Direction::Right );
    EXPECT_EQ( _player->GetHitBox().Left, 1 );
    EXPECT_EQ( _player->GetHitBox().Top, 2 );

--- a/MegaManLofiTests/RectangleUtilitiesTests.cpp
+++ b/MegaManLofiTests/RectangleUtilitiesTests.cpp
@@ -27,7 +27,7 @@ TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperRightNoOffsets_Ret
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightNoOffsets_ReturnsFalse )
 {
-   Rectangle<float> r1 { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 10, 20, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
@@ -35,7 +35,7 @@ TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightNoOffsets_Ret
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerLeftNoOffsets_ReturnsFalse )
 {
-   Rectangle<float> r1 { 0, 10, 10, 10 };
+   Rectangle<float> r1 { 0, 20, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 0, 0, r2, 0, 0 ) );
@@ -91,7 +91,7 @@ TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarUpperRightWithOffsets_R
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> r1 { 10, 10, 10, 10 };
+   Rectangle<float> r1 { 10, 20, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );
@@ -99,7 +99,7 @@ TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerRightWithOffsets_R
 
 TEST_F( RectangleUtilitiesTests, RectanglesIntersectF_FarLowerLeftWithOffsets_ReturnsFalse )
 {
-   Rectangle<float> r1 { 0, 10, 10, 10 };
+   Rectangle<float> r1 { 0, 20, 10, 10 };
    Rectangle<float> r2 { 10, 10, 10, 10 };
 
    EXPECT_FALSE( RectangleUtilities::RectanglesIntersectF( r1, 1000, 2000, r2, 1000, 2000 ) );

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -21,6 +21,8 @@ public:
    MOCK_METHOD( void, Reload, ( ), ( override ) );
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( const std::shared_ptr<MegaManLofi::Entity>, GetMutableEntity, ( int ), ( const, override ) );
+   MOCK_METHOD( int, GetSpawnPointCount, ( ), ( const, override ) );
+   MOCK_METHOD( const std::shared_ptr<MegaManLofi::SpawnPoint>, GetSpawnPoint, ( int ), ( const, override ) );
    MOCK_METHOD( void, SetPlayerEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
    MOCK_METHOD( void, SetActiveRegion, ( MegaManLofi::Rectangle<float> ), ( override ) );
    MOCK_METHOD( void, SetDeSpawnRegion, ( MegaManLofi::Rectangle<float> ), ( override ) );

--- a/MegaManLofiTests/mock_Arena.h
+++ b/MegaManLofiTests/mock_Arena.h
@@ -30,4 +30,5 @@ public:
    MOCK_METHOD( void, RemoveEntity, ( const std::shared_ptr<MegaManLofi::Entity> ), ( override ) );
    MOCK_METHOD( void, CheckSpawnPoints, ( ), ( override ) );
    MOCK_METHOD( void, DeSpawnInactiveEntities, ( ), ( override ) );
+   MOCK_METHOD( void, DetectEntityCollisions, ( ), ( override ) );
 };

--- a/MegaManLofiTests/mock_Entity.h
+++ b/MegaManLofiTests/mock_Entity.h
@@ -21,6 +21,8 @@ public:
    MOCK_METHOD( float, GetMaxGravityVelocity, ( ), ( const, override ) );
    MOCK_METHOD( float, GetGravityAccelerationPerSecond, ( ), ( const, override ) );
    MOCK_METHOD( float, GetFrictionDecelerationPerSecond, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetHealth, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetMaxHealth, ( ), ( const, override ) );
 
    MOCK_METHOD( void, SetUniqueId, ( int ), ( override ) );
    MOCK_METHOD( void, SetEntityType, ( MegaManLofi::EntityType ), ( override ) );

--- a/MegaManLofiTests/mock_Entity.h
+++ b/MegaManLofiTests/mock_Entity.h
@@ -36,6 +36,7 @@ public:
    MOCK_METHOD( void, SetMaxGravityVelocity, ( float ), ( override ) );
    MOCK_METHOD( void, SetGravityAccelerationPerSecond, ( float ), ( override ) );
    MOCK_METHOD( void, SetFrictionDecelerationPerSecond, ( float ), ( override ) );
+   MOCK_METHOD( void, SetHealth, ( unsigned int ), ( override ) );
    MOCK_METHOD( void, StopX, ( ), ( override ) );
    MOCK_METHOD( void, StopY, ( ), ( override ) );
    MOCK_METHOD( bool, TakeCollisionPayload, ( const MegaManLofi::EntityCollisionPayload& ), ( override ) );

--- a/MegaManLofiTests/mock_Entity.h
+++ b/MegaManLofiTests/mock_Entity.h
@@ -38,4 +38,5 @@ public:
    MOCK_METHOD( void, SetFrictionDecelerationPerSecond, ( float ), ( override ) );
    MOCK_METHOD( void, StopX, ( ), ( override ) );
    MOCK_METHOD( void, StopY, ( ), ( override ) );
+   MOCK_METHOD( bool, TakeCollisionPayload, ( const MegaManLofi::EntityCollisionPayload& ), ( override ) );
 };

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -32,6 +32,7 @@ public:
    MOCK_METHOD( void, SetMovementType, ( MegaManLofi::MovementType ), ( override ) );
    MOCK_METHOD( void, StopX, ( ), ( override ) );
    MOCK_METHOD( void, StopY, ( ), ( override ) );
+   MOCK_METHOD( bool, TakeCollisionPayload, ( const MegaManLofi::EntityCollisionPayload& ), ( override ) );
 
    MOCK_METHOD( unsigned int, GetLivesRemaining, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsJumping, ( ), ( const, override ) );

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -18,6 +18,8 @@ public:
    MOCK_METHOD( MegaManLofi::Direction, GetDirection, ( ), ( const, override ) );
    MOCK_METHOD( const MegaManLofi::Rectangle<float>&, GetHitBox, ( ), ( const, override ) );
    MOCK_METHOD( MegaManLofi::MovementType, GetMovementType, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetHealth, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetMaxHealth, ( ), ( const, override ) );
 
    MOCK_METHOD( void, SetUniqueId, ( int ), ( override ) );
    MOCK_METHOD( void, SetEntityType, ( MegaManLofi::EntityType ), ( override ) );

--- a/MegaManLofiTests/mock_Player.h
+++ b/MegaManLofiTests/mock_Player.h
@@ -30,6 +30,10 @@ public:
    MOCK_METHOD( void, SetDirection, ( MegaManLofi::Direction ), ( override ) );
    MOCK_METHOD( void, SetHitBox, ( MegaManLofi::Rectangle<float> ), ( override ) );
    MOCK_METHOD( void, SetMovementType, ( MegaManLofi::MovementType ), ( override ) );
+   MOCK_METHOD( void, SetMaxGravityVelocity, ( float ), ( override ) );
+   MOCK_METHOD( void, SetGravityAccelerationPerSecond, ( float ), ( override ) );
+   MOCK_METHOD( void, SetFrictionDecelerationPerSecond, ( float ), ( override ) );
+   MOCK_METHOD( void, SetHealth, ( unsigned int ), ( override ) );
    MOCK_METHOD( void, StopX, ( ), ( override ) );
    MOCK_METHOD( void, StopY, ( ), ( override ) );
    MOCK_METHOD( bool, TakeCollisionPayload, ( const MegaManLofi::EntityCollisionPayload& ), ( override ) );
@@ -39,6 +43,7 @@ public:
 
    MOCK_METHOD( void, Reset, ( ), ( override ) );
    MOCK_METHOD( void, ResetPosition, ( ), ( override ) );
+   MOCK_METHOD( void, ResetHealth, ( ), ( override ) );
    MOCK_METHOD( void, SetLivesRemaining, ( unsigned int ), ( override ) );
    MOCK_METHOD( void, PointTo, ( MegaManLofi::Direction ), ( override ) );
    MOCK_METHOD( void, PushTo, ( MegaManLofi::Direction ), ( override ) );

--- a/MegaManLofiTests/mock_ReadOnlyEntity.h
+++ b/MegaManLofiTests/mock_ReadOnlyEntity.h
@@ -21,4 +21,6 @@ public:
    MOCK_METHOD( float, GetMaxGravityVelocity, ( ), ( const, override ) );
    MOCK_METHOD( float, GetGravityAccelerationPerSecond, ( ), ( const, override ) );
    MOCK_METHOD( float, GetFrictionDecelerationPerSecond, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetHealth, ( ), ( const, override ) );
+   MOCK_METHOD( unsigned int, GetMaxHealth, ( ), ( const, override ) );
 };


### PR DESCRIPTION
Here it is, the beginning of things colliding with each other in the game world! Even though we don't have enemies yet, I still accounted for them. It should work like this:

- If a player and an item collide, the player receives the item's payload
- If a player and a projectile collide, the player receives the projectile's payload
- If a player and an enemy collide, the player receives the enemy's payload
- If an enemy and a projectile collide, the enemy receives the projectile's payload

This is a fancy way of saying players get hurt by bullets and enemies, enemies get hurt by bullets, and players can pick up items. Also, I added a way for spawn points to bind to items, so when the player picks up that specific item it will decommission the spawn point until the entire stage restarts.