### PR TITLE
Implemented friendly fire

### DIFF
--- a/MegaManLofi/Arena.cpp
+++ b/MegaManLofi/Arena.cpp
@@ -234,6 +234,26 @@ void Arena::PlayerPickUpItem( const shared_ptr<Entity> player, const shared_ptr<
 
 void Arena::EntityTakeHealthPayload( const shared_ptr<Entity> taker, const shared_ptr<Entity> giver )
 {
+   if ( giver->GetEntityType() == EntityType::Projectile )
+   {
+      auto isFriendly = _entityDefs->ProjectileInfoMap[giver->GetEntityMetaId()].IsFriendly;
+
+      if ( taker->GetEntityType() == EntityType::Player ) // friendly projectiles only hurt enemies
+      {
+         if ( isFriendly )
+         {
+            return;
+         }
+      }
+      else // un-friendly projectiles only hurt the player
+      {
+         if ( !isFriendly )
+         {
+            return;
+         }
+      }
+   }
+
    const auto& payload = _entityDefs->CollisionPayloadMap[giver->GetEntityMetaId()];
    taker->TakeCollisionPayload( payload );
 

--- a/MegaManLofi/ArenaDefsGenerator.cpp
+++ b/MegaManLofi/ArenaDefsGenerator.cpp
@@ -40,9 +40,9 @@ map<int, shared_ptr<ArenaDefs>> ArenaDefsGenerator::GenerateArenaDefsMap( const 
    arenaDefsMap[1]->Tiles = ArenaTileGenerator::GenerateArenaTiles( 1 );
    arenaDefsMap[1]->PlayerStartPosition = { worldDefs->TileWidth * 2, worldDefs->TileHeight * 19 };
 
-   // large health drop at 112, 24
+   // extra life at 112, 24
    arenaDefsMap[1]->SpawnPoints.push_back( SpawnPoint() );
-   arenaDefsMap[1]->SpawnPoints[0].EntityMetaId = 3;
+   arenaDefsMap[1]->SpawnPoints[0].EntityMetaId = 4;
    arenaDefsMap[1]->SpawnPoints[0].ArenaPosition = { worldDefs->TileWidth * 112, worldDefs->TileHeight * 24 };
    arenaDefsMap[1]->SpawnPoints[0].IsBoundToUniqueId = true;
 

--- a/MegaManLofi/ConsoleSpriteDefsGenerator.cpp
+++ b/MegaManLofi/ConsoleSpriteDefsGenerator.cpp
@@ -216,6 +216,27 @@ shared_ptr<ConsoleSprite> ConsoleSpriteDefsGenerator::GenerateLargeHealthDropSpr
    return sprite;
 }
 
+shared_ptr<ConsoleSprite> ConsoleSpriteDefsGenerator::GenerateExtraLifeSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
+{
+   auto sprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, 0.25f ) );
+
+   ConsoleImage image0;
+   ConsoleImage image1;
+
+   image0.Width = 1;
+   image0.Height = 1;
+   image0.Pixels.push_back( { '@', true, ConsoleColor::Blue, ConsoleColor::Black } );
+
+   image1.Width = 1;
+   image1.Height = 1;
+   image1.Pixels.push_back( { '@', true, ConsoleColor::DarkBlue, ConsoleColor::Black } );
+
+   sprite->AddImage( image0 );
+   sprite->AddImage( image1 );
+
+   return sprite;
+}
+
 shared_ptr<ConsoleSprite> ConsoleSpriteDefsGenerator::GeneratePlayerThwipSprite( const shared_ptr<IFrameRateProvider> frameRateProvider )
 {
    auto thwipSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite( frameRateProvider, .05f ) );
@@ -396,6 +417,18 @@ map<int, shared_ptr<EntityConsoleSprite>> ConsoleSpriteDefsGenerator::GenerateEn
       }
    }
    entitySpriteMap[3] = largeHealthDropEntitySprite;
+
+   // extra life
+   auto extraLifeSprite = GenerateExtraLifeSprite( frameRateProvider );
+   auto extraLifeEntitySprite = make_shared<EntityConsoleSprite>();
+   for ( int i = 0; i < (int)MovementType::MovementTypeCount; i++ )
+   {
+      for ( int j = 0; j < (int)Direction::DirectionCount; j++ )
+      {
+         extraLifeEntitySprite->AddSprite( (MovementType)i, (Direction)j, extraLifeSprite );
+      }
+   }
+   entitySpriteMap[4] = extraLifeEntitySprite;
 
    return entitySpriteMap;
 }

--- a/MegaManLofi/ConsoleSpriteDefsGenerator.h
+++ b/MegaManLofi/ConsoleSpriteDefsGenerator.h
@@ -25,6 +25,7 @@ namespace MegaManLofi
       static std::shared_ptr<ConsoleSprite> GenerateBulletSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
       static std::shared_ptr<ConsoleSprite> GenerateSmallHealthDropSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
       static std::shared_ptr<ConsoleSprite> GenerateLargeHealthDropSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
+      static std::shared_ptr<ConsoleSprite> GenerateExtraLifeSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
 
       static std::shared_ptr<ConsoleSprite> GeneratePlayerThwipSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );
       static std::shared_ptr<ConsoleSprite> GeneratePlayerThwipInTransitionSprite( const std::shared_ptr<IFrameRateProvider> frameRateProvider );

--- a/MegaManLofi/EntityDefsGenerator.cpp
+++ b/MegaManLofi/EntityDefsGenerator.cpp
@@ -14,6 +14,7 @@ shared_ptr<EntityDefs> EntityDefsGenerator::GenerateEntityDefs()
    entityDefs->EntityTypeMap[1] = EntityType::Projectile;   // bullet
    entityDefs->EntityTypeMap[2] = EntityType::Item;         // small health drop
    entityDefs->EntityTypeMap[3] = EntityType::Item;         // large health drop
+   entityDefs->EntityTypeMap[4] = EntityType::Item;         // extra life
 
    // bullet
    entityDefs->ProjectileInfoMap[1].HitBox = { 0, 0, 10, 10 }; // player is 152 x 234
@@ -32,6 +33,12 @@ shared_ptr<EntityDefs> EntityDefsGenerator::GenerateEntityDefs()
    entityDefs->ItemInfoMap[3].MaxGravityVelocity = 4'000;
    entityDefs->ItemInfoMap[3].GravityAccelerationPerSecond = 10'000;
    entityDefs->CollisionPayloadMap[3].Health = 25;
+
+   // extra life
+   entityDefs->ItemInfoMap[4].HitBox = { 0, 0, 38, 78 }; // one full tile
+   entityDefs->ItemInfoMap[4].MaxGravityVelocity = 4'000;
+   entityDefs->ItemInfoMap[4].GravityAccelerationPerSecond = 10'000;
+   entityDefs->CollisionPayloadMap[4].Lives = 1;
 
    return entityDefs;
 }

--- a/MegaManLofi/EntityDefsGenerator.cpp
+++ b/MegaManLofi/EntityDefsGenerator.cpp
@@ -18,6 +18,7 @@ shared_ptr<EntityDefs> EntityDefsGenerator::GenerateEntityDefs()
    // bullet
    entityDefs->ProjectileInfoMap[1].HitBox = { 0, 0, 10, 10 }; // player is 152 x 234
    entityDefs->ProjectileInfoMap[1].Velocity = 2'500;
+   entityDefs->ProjectileInfoMap[1].IsFriendly = true;
    entityDefs->CollisionPayloadMap[1].Health = -10;
 
    // small health drop

--- a/MegaManLofi/Game.cpp
+++ b/MegaManLofi/Game.cpp
@@ -163,6 +163,7 @@ void Game::StartStage()
    _eventAggregator->RaiseEvent( GameEvent::StageStarted );
 }
 
+// TODO: move this into the Player class
 void Game::Shoot()
 {
    if ( _nextState != GameState::Playing )

--- a/MegaManLofi/ProjectileInfo.h
+++ b/MegaManLofi/ProjectileInfo.h
@@ -7,6 +7,7 @@ namespace MegaManLofi
    struct ProjectileInfo
    {
       Rectangle<float> HitBox;
-      float Velocity;
+      float Velocity = 0;
+      bool IsFriendly = false;
    };
 }

--- a/MegaManLofiTests/ArenaTests.cpp
+++ b/MegaManLofiTests/ArenaTests.cpp
@@ -542,8 +542,22 @@ TEST_F( ArenaTests, DetectEntityCollisions_PlayerCollidesWithEnemy_PlayerTakesHe
    EXPECT_EQ( payload.Health, -5 );
 }
 
-TEST_F( ArenaTests, DetectEntityCollisions_PlayerCollidesWithProjectile_PlayerTakesHealthPayload )
+TEST_F( ArenaTests, DetectEntityCollisions_PlayerCollidesWithFriendlyProjectile_PlayerDoesNotTakeHealthPayload )
 {
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = true;
+   _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
+   _arena->AddEntity( _playerMock );
+   _arena->AddEntity( _projectileEntityMock );
+
+   EXPECT_CALL( *_playerMock, TakeCollisionPayload( _ ) ).Times( 0 );
+
+   _arena->DetectEntityCollisions();
+   auto test = true;
+}
+
+TEST_F( ArenaTests, DetectEntityCollisions_PlayerCollidesWithUnfriendlyProjectile_PlayerTakesHealthPayload )
+{
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = false;
    _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
    _arena->AddEntity( _playerMock );
    _arena->AddEntity( _projectileEntityMock );
@@ -586,8 +600,21 @@ TEST_F( ArenaTests, DetectEntityCollisions_ItemBoundToSpawnPointCollidesWithPlay
    EXPECT_TRUE( _arena->GetSpawnPoint( 0 )->IsDecommissioned );
 }
 
-TEST_F( ArenaTests, DetectEntityCollisions_ProjectileCollidesWithPlayer_PlayerTakesHealthPayload )
+TEST_F( ArenaTests, DetectEntityCollisions_FriendlyProjectileCollidesWithPlayer_PlayerDoesNotTakeHealthPayload )
 {
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = true;
+   _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
+   _arena->AddEntity( _projectileEntityMock );
+   _arena->AddEntity( _playerMock );
+
+   EXPECT_CALL( *_playerMock, TakeCollisionPayload( _ ) ).Times( 0 );
+
+   _arena->DetectEntityCollisions();
+}
+
+TEST_F( ArenaTests, DetectEntityCollisions_UnfriendlyProjectileCollidesWithPlayer_PlayerTakesHealthPayload )
+{
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = false;
    _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
    _arena->AddEntity( _projectileEntityMock );
    _arena->AddEntity( _playerMock );
@@ -600,8 +627,21 @@ TEST_F( ArenaTests, DetectEntityCollisions_ProjectileCollidesWithPlayer_PlayerTa
    EXPECT_EQ( payload.Health, -10 );
 }
 
-TEST_F( ArenaTests, DetectEntityCollisions_ProjectileCollidesWithEnemy_EnemyTakesHealthPayload )
+TEST_F( ArenaTests, DetectEntityCollisions_UnfriendlyProjectileCollidesWithEnemy_EnemyDoesNotTakeHealthPayload )
 {
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = false;
+   _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
+   _arena->AddEntity( _projectileEntityMock );
+   _arena->AddEntity( _enemyEntityMock );
+
+   EXPECT_CALL( *_enemyEntityMock, TakeCollisionPayload( _ ) ).Times( 0 );
+
+   _arena->DetectEntityCollisions();
+}
+
+TEST_F( ArenaTests, DetectEntityCollisions_FriendlyProjectileCollidesWithEnemy_EnemyTakesHealthPayload )
+{
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = true;
    _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
    _arena->AddEntity( _projectileEntityMock );
    _arena->AddEntity( _enemyEntityMock );
@@ -628,8 +668,21 @@ TEST_F( ArenaTests, DetectEntityCollisions_EnemyCollidesWithPlayer_PlayerTakesHe
    EXPECT_EQ( payload.Health, -5 );
 }
 
-TEST_F( ArenaTests, DetectEntityCollisions_EnemyCollidesWithProjectile_EnemyTakesHealthPayload )
+TEST_F( ArenaTests, DetectEntityCollisions_EnemyCollidesWithUnfriendlyProjectile_EnemyDoesNotTakeHealthPayload )
 {
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = false;
+   _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
+   _arena->AddEntity( _enemyEntityMock );
+   _arena->AddEntity( _projectileEntityMock );
+
+   EXPECT_CALL( *_enemyEntityMock, TakeCollisionPayload( _ ) ).Times( 0 );
+
+   _arena->DetectEntityCollisions();
+}
+
+TEST_F( ArenaTests, DetectEntityCollisions_EnemyCollidesWithFriendlyProjectile_EnemyTakesHealthPayload )
+{
+   _entityDefs->ProjectileInfoMap[4].IsFriendly = true;
    _arena.reset( new Arena( _arenaDefs, _worldDefs, _entityDefs, _eventAggregatorMock, _frameRateProviderMock, _entityFactoryMock ) );
    _arena->AddEntity( _enemyEntityMock );
    _arena->AddEntity( _projectileEntityMock );


### PR DESCRIPTION
After setting up projectile collision detection, I ran into a bug where you take damage from your own bullets, particularly when shooting downward during a fall or shooting leftward (that might be a separate issue, I'm not sure I'm spawning bullets in the correct place when shooting leftward). This PR adds an `IsFriendly` flag to `ProjectileInfo`. If a projectile is friendly, it will only hurt an enemy. Likewise, if a projectile is not friendly, it will only hurt the player.

BONUS: I added an extra life item and put one in the stage, all the way to the right.