### PR TITLE
Bugfix: Entities should not de-spawn on environment collision

### DIFF
--- a/MegaManLofi/ArenaPhysics.cpp
+++ b/MegaManLofi/ArenaPhysics.cpp
@@ -144,7 +144,7 @@ void ArenaPhysics::DetectEntityTileCollisionX( const shared_ptr<Entity> entity, 
             else
             {
                entity->StopX();
-               HandleEntityEnvironmentCollision( entity );
+               HandleEntityArenaEdgeCollision( entity );
                break;
             }
          }
@@ -178,7 +178,7 @@ void ArenaPhysics::DetectEntityTileCollisionX( const shared_ptr<Entity> entity, 
             else
             {
                entity->StopX();
-               HandleEntityEnvironmentCollision( entity );
+               HandleEntityArenaEdgeCollision( entity );
                break;
             }
          }
@@ -223,7 +223,7 @@ void ArenaPhysics::DetectEntityTileCollisionY( const shared_ptr<Entity> entity, 
             else
             {
                entity->StopY();
-               HandleEntityEnvironmentCollision( entity );
+               HandleEntityArenaEdgeCollision( entity );
                break;
             }
          }
@@ -260,7 +260,7 @@ void ArenaPhysics::DetectEntityTileCollisionY( const shared_ptr<Entity> entity, 
                {
                   _eventAggregator->RaiseEvent( GameEvent::Pitfall );
                }
-               HandleEntityEnvironmentCollision( entity );
+               HandleEntityArenaEdgeCollision( entity );
                break;
             }
          }
@@ -332,6 +332,15 @@ bool ArenaPhysics::DetectPlayerCrossedPortal( Direction direction, const shared_
 }
 
 void ArenaPhysics::HandleEntityEnvironmentCollision( const shared_ptr<Entity> entity )
+{
+   if ( entity->GetEntityType() == EntityType::Projectile )
+   {
+      _entityTileIndicesCache.erase( entity );
+      _stage->GetMutableActiveArena()->RemoveEntity( entity );
+   }
+}
+
+void ArenaPhysics::HandleEntityArenaEdgeCollision( const shared_ptr<Entity> entity )
 {
    if ( entity->GetEntityType() != EntityType::Player )
    {

--- a/MegaManLofi/ArenaPhysics.h
+++ b/MegaManLofi/ArenaPhysics.h
@@ -37,6 +37,7 @@ namespace MegaManLofi
       void DetectEntityTileCollisionY( const std::shared_ptr<Entity> entity, float& newPositionTop, bool& crossedPortal );
       bool DetectPlayerCrossedPortal( Direction direction, const std::shared_ptr<Entity> entity );
       void HandleEntityEnvironmentCollision( const std::shared_ptr<Entity> entity );
+      void HandleEntityArenaEdgeCollision( const std::shared_ptr<Entity> entity );
       void DetectEntityMovementType( const std::shared_ptr<Entity> entity ) const;
 
       void UpdateRegions();


### PR DESCRIPTION
I made a mistake with my last commit, and as a result any non-player entity would automatically de-spawn when colliding with the environment. That included touching any floor or wall, so most of the enemies were mysteriously disappearing.

This makes sure non-player and non-projectile entities will only de-spawn if they touch the edge of an arena.